### PR TITLE
Update Vagrantfile for (hacky) air-gapped local environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 artifacts
+local-artifacts
 airgap-scp.sh
 .vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,8 +8,12 @@ Vagrant.configure("2") do |config|
   config.vm.box = "centos/7"
   config.vm.hostname = "airgap"
   config.vm.network "private_network", type: "dhcp"
+  config.vm.provision "shell",
+    run: "always",
+    inline: "ip route delete default"
+
   config.vm.synced_folder ".", "/opt/k3ama"
-  
+
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"
     vb.cpus = "2"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,9 @@ Vagrant.configure("2") do |config|
   config.vm.network "private_network", type: "dhcp"
   config.vm.provision "shell",
     run: "always",
-    inline: "ip route delete default"
+    inline: "ip route delete default && \
+      gw_ip=$(ip -f inet a show eth1 | awk 'match($0, /inet ([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})/, arr) { print arr[1] }')
+      ip r add default via $gw_ip dev eth1 proto dhcp metric 100"
 
   config.vm.synced_folder ".", "/opt/k3ama"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,16 +8,15 @@ Vagrant.configure("2") do |config|
   config.vm.box = "centos/7"
   config.vm.hostname = "airgap"
   config.vm.network "private_network", type: "dhcp"
-  config.vm.provision "shell",
-    run: "always",
-    inline: "ip route delete default && \
-      gw_ip=$(ip -f inet a show eth1 | awk 'match($0, /inet ([0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3})/, arr) { print arr[1] }')
-      ip r add default via $gw_ip dev eth1 proto dhcp metric 100"
 
   config.vm.synced_folder ".", "/opt/k3ama"
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "1024"
     vb.cpus = "2"
+  
+  config.vm.provision "shell",
+    run: "always",
+    inline: "/opt/k3ama/k3ama-vagrant-airgap.sh airgap"
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,19 +1,17 @@
 ##################################
+# The vagrant-vbguest plugin is required for CentOS 7.
+# Run the following command to install/update this plugin:
 # vagrant plugin install vagrant-vbguest
 ##################################
-
 
 Vagrant.configure("2") do |config|
   config.vm.box = "centos/7"
   config.vm.hostname = "airgap"
   config.vm.network "private_network", type: "dhcp"
-#    name: "vboxnet3"
-#  config.vm.network "private_network", ip: "10.0.2.1",
-#    auto_config: false
-  config.vm.synced_folder ".","/opt/k3ama"
+  config.vm.synced_folder ".", "/opt/k3ama"
   
   config.vm.provider "virtualbox" do |vb|
-   vb.memory = "1024"
-   vb.cpus = "2"
+    vb.memory = "1024"
+    vb.cpus = "2"
   end
 end

--- a/k3ama-vagrant-airgap.sh
+++ b/k3ama-vagrant-airgap.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -x
+
+if [ "$#" -ne 1 ] || ( [ "$1" != "internet" ] && [ "$1" != "airgap" ] ); then
+  echo \
+"Enable or disable internet access in k3ama's CentOS Vagrant machine.
+
+Usage: $0 internet
+       $0 airgap" >&2
+  exit 1
+fi
+
+if [ "$1" = "internet" ]; then
+  # internet: set default gateway to NAT network interface
+  default_iface="eth0"
+  gw_ip="10.0.2.2"
+else
+  # airgap: set default gateway to private network interface
+  default_iface="eth1"
+  gw_ip=$(ip -f inet a show "${default_iface}" | awk 'match($0, /inet ([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})/, arr) { print arr[1] }')
+fi
+
+
+ip r delete default
+ip r add default via ${gw_ip} dev ${default_iface} proto dhcp metric 100

--- a/k3ama-vagrant-install.sh
+++ b/k3ama-vagrant-install.sh
@@ -1,0 +1,33 @@
+
+if [ -f "/usr/local/bin/k3s-uninstall.sh" ]; then
+  /usr/local/bin/k3s-uninstall.sh
+else
+  echo "k3s is not installed"
+fi
+
+if pgrep -x "firewalld" >/dev/null
+then
+    echo "[FATAL] disable firewalld first"
+fi
+
+SELINUXSTATUS=$(getenforce)
+  if [ "$SELINUXSTATUS" == "Permissive" ]; then
+      echo "[FATAL] disable selinux"
+      exit 1
+  else
+      echo "SELINUX disabled. continuing"
+  fi
+
+LOCAL_IMAGES_FILEPATH=/var/lib/rancher/k3s/agent/images
+
+mkdir -p ${LOCAL_IMAGES_FILEPATH}
+cp /opt/k3ama/local-artifacts/images/k3s-airgap-images-amd64.tar ${LOCAL_IMAGES_FILEPATH}
+
+cp /opt/k3ama/local-artifacts/bin/k3s /usr/local/bin/k3s
+chmod +x /usr/local/bin/k3s
+
+yum install -y /opt/k3ama/local-artifacts/rpm/*
+
+INSTALL_K3S_SKIP_DOWNLOAD=true /opt/k3ama/local-artifacts/bin/k3s-install.sh
+
+chmod +r /etc/rancher/k3s/k3s.yaml

--- a/k3ama-vagrant-prep.sh
+++ b/k3ama-vagrant-prep.sh
@@ -1,0 +1,33 @@
+
+K3S_VERSION='v1.18.8%2Bk3s1'
+
+ADDL_IMAGES=./local-artifacts/images
+LOCAL_BIN=./local-artifacts/bin
+LOCAL_RPM=./local-artifacts/rpm
+
+mkdir -p ${ADDL_IMAGES}
+mkdir -p ${LOCAL_BIN}
+
+pushd ${ADDL_IMAGES}
+
+curl -LO https://github.com/rancher/k3s/releases/download/${K3S_VERSION}/k3s-airgap-images-amd64.tar
+
+popd
+
+pushd ${LOCAL_BIN}
+
+curl -LO https://github.com/rancher/k3s/releases/download/${K3S_VERSION}/k3s
+chmod +x k3s
+curl -L https://raw.githubusercontent.com/rancher/k3s/${K3S_VERSION}/install.sh -o k3s-install.sh
+chmod +x k3s-install.sh
+
+popd
+
+pushd ${LOCAL_RPM}
+curl -LO https://rpm.rancher.io/k3s-selinux-0.1.1-rc1.el7.noarch.rpm
+
+# on machine with yum installed and internet access:
+# yum install -y yum-utils
+# yumdownloader --destdir=. --resolve container-selinux selinux-policy-base
+
+popd


### PR DESCRIPTION
Clarified perquisites in Vagrantfile, modified default gateway, and validated configuration with a manual install of k3s. Added local copies of all artifacts required for k3s v1.18.8+k3s1 installation into the vagrant VM, and added vagrant-specific prep and install scripts.