### PR TITLE
Make content types pubic, expose configuration fields

### DIFF
--- a/pkg/content/chart/chart.go
+++ b/pkg/content/chart/chart.go
@@ -24,6 +24,10 @@ import (
 var _ artifact.OCI = (*Chart)(nil)
 
 type Chart struct {
+	Repo    string
+	Name    string
+	Version string
+
 	path string
 
 	annotations map[string]string
@@ -41,7 +45,10 @@ func NewChart(name, repo, version string) (*Chart, error) {
 	}
 
 	return &Chart{
-		path: cp,
+		Repo:    repo,
+		Name:    name,
+		Version: version,
+		path:    cp,
 	}, nil
 }
 

--- a/pkg/content/file/file.go
+++ b/pkg/content/file/file.go
@@ -13,9 +13,9 @@ import (
 )
 
 // interface guard
-var _ artifact.OCI = (*file)(nil)
+var _ artifact.OCI = (*File)(nil)
 
-type file struct {
+type File struct {
 	ref    string
 	client *getter.Client
 
@@ -26,10 +26,10 @@ type file struct {
 	annotations map[string]string
 }
 
-func NewFile(ref string, opts ...Option) *file {
+func NewFile(ref string, opts ...Option) *File {
 	client := getter.NewClient(getter.ClientOptions{})
 
-	f := &file{
+	f := &File{
 		client: client,
 		ref:    ref,
 	}
@@ -40,22 +40,22 @@ func NewFile(ref string, opts ...Option) *file {
 	return f
 }
 
-func (f *file) Name(ref string) string {
+func (f *File) Name(ref string) string {
 	return f.client.Name(ref)
 }
 
-func (f *file) MediaType() string {
+func (f *File) MediaType() string {
 	return consts.OCIManifestSchema1
 }
 
-func (f *file) RawConfig() ([]byte, error) {
+func (f *File) RawConfig() ([]byte, error) {
 	if err := f.compute(); err != nil {
 		return nil, err
 	}
 	return f.config.Raw()
 }
 
-func (f *file) Layers() ([]gv1.Layer, error) {
+func (f *File) Layers() ([]gv1.Layer, error) {
 	if err := f.compute(); err != nil {
 		return nil, err
 	}
@@ -64,14 +64,14 @@ func (f *file) Layers() ([]gv1.Layer, error) {
 	return layers, nil
 }
 
-func (f *file) Manifest() (*gv1.Manifest, error) {
+func (f *File) Manifest() (*gv1.Manifest, error) {
 	if err := f.compute(); err != nil {
 		return nil, err
 	}
 	return f.manifest, nil
 }
 
-func (f *file) compute() error {
+func (f *File) compute() error {
 	if f.computed {
 		return nil
 	}

--- a/pkg/content/file/file.go
+++ b/pkg/content/file/file.go
@@ -16,7 +16,8 @@ import (
 var _ artifact.OCI = (*File)(nil)
 
 type File struct {
-	ref    string
+	Ref string
+
 	client *getter.Client
 
 	computed    bool
@@ -31,7 +32,7 @@ func NewFile(ref string, opts ...Option) *File {
 
 	f := &File{
 		client: client,
-		ref:    ref,
+		Ref:    ref,
 	}
 
 	for _, opt := range opts {
@@ -77,7 +78,7 @@ func (f *File) compute() error {
 	}
 
 	ctx := context.Background()
-	blob, err := f.client.LayerFrom(ctx, f.ref)
+	blob, err := f.client.LayerFrom(ctx, f.Ref)
 	if err != nil {
 		return err
 	}
@@ -87,9 +88,9 @@ func (f *File) compute() error {
 		return err
 	}
 
-	cfg := f.client.Config(f.ref)
+	cfg := f.client.Config(f.Ref)
 	if cfg == nil {
-		cfg = f.client.Config(f.ref)
+		cfg = f.client.Config(f.Ref)
 	}
 
 	cfgDesc, err := partial.Descriptor(cfg)

--- a/pkg/content/file/file_test.go
+++ b/pkg/content/file/file_test.go
@@ -68,7 +68,7 @@ func Test_file_Config(t *testing.T) {
 
 			got := string(m.Config.MediaType)
 			if got != tt.want {
-				t.Errorf("Expected mediatype %s | got %s", got, tt.want)
+				t.Errorf("unxpected mediatype; got %s, want %s", got, tt.want)
 			}
 		})
 	}
@@ -96,27 +96,26 @@ func Test_file_Layers(t *testing.T) {
 		// TODO: Add directory test
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(it *testing.T) {
 			f := file.NewFile(tt.ref, file.WithClient(mc))
 
 			layers, err := f.Layers()
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Layers() error = %v, wantErr %v", err, tt.wantErr)
-				return
+				it.Fatalf("unexpected Layers() error: got %v, want %v", err, tt.wantErr)
 			}
 
 			rc, err := layers[0].Compressed()
 			if err != nil {
-				t.Fatal(err)
+				it.Fatal(err)
 			}
 
 			got, err := io.ReadAll(rc)
 			if err != nil {
-				t.Fatal(err)
+				it.Fatal(err)
 			}
 
 			if !bytes.Equal(got, tt.want) {
-				t.Errorf("Layers() got = %v, want %v", layers, tt.want)
+				it.Fatalf("unexpected Layers(): got %v, want %v", layers, tt.want)
 			}
 		})
 	}

--- a/pkg/content/file/options.go
+++ b/pkg/content/file/options.go
@@ -5,22 +5,22 @@ import (
 	"github.com/rancherfederal/hauler/pkg/artifact"
 )
 
-type Option func(*file)
+type Option func(*File)
 
 func WithClient(c *getter.Client) Option {
-	return func(f *file) {
+	return func(f *File) {
 		f.client = c
 	}
 }
 
 func WithConfig(obj interface{}, mediaType string) Option {
-	return func(f *file) {
+	return func(f *File) {
 		f.config = artifact.ToConfig(obj, artifact.WithConfigMediaType(mediaType))
 	}
 }
 
 func WithAnnotations(m map[string]string) Option {
-	return func(f *file) {
+	return func(f *File) {
 		f.annotations = m
 	}
 }

--- a/pkg/content/image/image.go
+++ b/pkg/content/image/image.go
@@ -9,9 +9,9 @@ import (
 	"github.com/rancherfederal/hauler/pkg/artifact"
 )
 
-var _ artifact.OCI = (*image)(nil)
+var _ artifact.OCI = (*Image)(nil)
 
-func (i *image) MediaType() string {
+func (i *Image) MediaType() string {
 	mt, err := i.Image.MediaType()
 	if err != nil {
 		return ""
@@ -19,15 +19,15 @@ func (i *image) MediaType() string {
 	return string(mt)
 }
 
-func (i *image) RawConfig() ([]byte, error) {
+func (i *Image) RawConfig() ([]byte, error) {
 	return i.RawConfigFile()
 }
 
-type image struct {
+type Image struct {
 	gv1.Image
 }
 
-func NewImage(ref string, opts ...remote.Option) (*image, error) {
+func NewImage(ref string, opts ...remote.Option) (*Image, error) {
 	r, err := name.ParseReference(ref)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func NewImage(ref string, opts ...remote.Option) (*image, error) {
 		return nil, err
 	}
 
-	return &image{
+	return &Image{
 		Image: img,
 	}, nil
 }

--- a/pkg/content/image/image.go
+++ b/pkg/content/image/image.go
@@ -24,6 +24,7 @@ func (i *Image) RawConfig() ([]byte, error) {
 }
 
 type Image struct {
+	Ref string
 	gv1.Image
 }
 
@@ -44,6 +45,7 @@ func NewImage(ref string, opts ...remote.Option) (*Image, error) {
 	}
 
 	return &Image{
+		Ref:   ref,
 		Image: img,
 	}, nil
 }


### PR DESCRIPTION
Allow content to be used publicly outside of the hauler package. Add fields reflecting the creation parameters to more clearly inherit functionality confirmed by unit tests.

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature / refactor



* **What is the current behavior?** (You can also link to an open issue here)
Types that implement the `OCI` interface for `Content` objects are private and hard to use in unit test contexts.


* **What is the new behavior (if this is a feature change)?**
Publicly exposes types that implement the `OCI` interface for `Content` API objects, and adds fields these types to more easily inherit unit test guarantees.