### PR TITLE
add support for specifying an image's platform

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -65,7 +65,7 @@ type AddImageOpts struct {
 func (o *AddImageOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	f.StringVarP(&o.Platform, "platform", "p", "all", "Image's platform, specified as OS/ARCH[/VARIANT].  Defaults to images default.")
+	f.StringVarP(&o.Platform, "platform", "p", "", "Image's platform, specified as OS/ARCH[/VARIANT].")
 }
 
 func AddImageCmd(ctx context.Context, o *AddImageOpts, s *store.Store, reference string) error {

--- a/pkg/apis/hauler.cattle.io/v1alpha1/image.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha1/image.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -20,4 +21,6 @@ type ImageSpec struct {
 type Image struct {
 	// Name is the full location for the image, can be referenced by tags or digests
 	Name string `json:"name"`
+
+	Platform ocispec.Platform `json:"platform,omitempty"`
 }

--- a/pkg/store/stager.go
+++ b/pkg/store/stager.go
@@ -121,10 +121,12 @@ func (l *layout) add(ctx context.Context, oci artifact.OCI, ref name.Reference) 
 	if err != nil {
 		return err
 	}
+
 	mdata, err := json.Marshal(m)
 	if err != nil {
 		return err
 	}
+
 	mdigest := digest.FromBytes(mdata)
 	l.blobs[mdigest] = static.NewLayer(mdata, m.MediaType)
 

--- a/testdata/contents.yaml
+++ b/testdata/contents.yaml
@@ -33,8 +33,11 @@ spec:
     # or by their digest:
     - name: registry@sha256:42043edfae481178f07aa077fa872fcc242e276d302f4ac2026d9d2eb65b955f
 
-    # or fully qualified from any OCI compliant registry registry
+    # or fully qualified from any OCI compliant registry for other platforms
     - name: ghcr.io/fluxcd/flux-cli:v0.22.0
+      platform:
+        os: linux
+        architecture: arm64
 
 ---
 apiVersion: content.hauler.cattle.io/v1alpha1


### PR DESCRIPTION
closes #76 

allow an image's platform to be specified either in the cli or in the api

```bash
hauler store add image alpine:latest --platform linux/arm64
```

```yaml
apiVersion: content.hauler.cattle.io/v1alpha1
kind: Images
metadata:
  name: myimage
spec:
  images:
    # or fully qualified from any OCI compliant registry for other platforms
    - name: ghcr.io/fluxcd/flux-cli:v0.22.0
      platform:
        os: linux
        architecture: arm64
```

Note this does _not_ add support for __multi__ platform images, that is being tracked in #104 