### PR TITLE
allow embedded registry to be run as a service

### DIFF
--- a/cmd/hauler/cli/serve/registry.go
+++ b/cmd/hauler/cli/serve/registry.go
@@ -11,13 +11,18 @@ import (
 	"github.com/distribution/distribution/v3/version"
 	"github.com/spf13/cobra"
 
+	"github.com/kardianos/service"
+
 	"github.com/rancherfederal/hauler/internal/server"
+	"github.com/rancherfederal/hauler/pkg/log"
 )
 
 type RegistryOpts struct {
 	Root       string
 	Port       int
 	ConfigFile string
+
+	Service bool
 }
 
 func (o *RegistryOpts) AddFlags(cmd *cobra.Command) {
@@ -25,9 +30,26 @@ func (o *RegistryOpts) AddFlags(cmd *cobra.Command) {
 	f.StringVarP(&o.Root, "root", "r", ".", "Path to root of the directory to serve")
 	f.IntVarP(&o.Port, "port", "p", 5000, "Port to listen on")
 	f.StringVarP(&o.ConfigFile, "config", "c", "", "Path to a config file, will override all other configs")
+	f.BoolVar(&o.Service, "service", false, "Initialize hauler's registry as a service, this must be configured with a config file (-c).  Note: this requires root privileges.")
 }
 
 func RegistryCmd(ctx context.Context, o *RegistryOpts) error {
+	l := log.FromContext(ctx)
+
+	if o.Service {
+		args := []string{"serve", "registry"}
+		if o.ConfigFile == "" {
+			l.Warnf("no config file set, defaults will be used in the service file")
+		} else {
+			args = append(args, []string{"-c", o.ConfigFile}...)
+		}
+		if err := ensureService(args); err != nil {
+			return err
+		}
+
+		l.Infof("successfully created service file [%s], enable and start it", "hauler-registry")
+		return nil
+	}
 	ctx = dcontext.WithVersion(ctx, version.Version)
 
 	cfg := o.defaultConfig()
@@ -78,3 +100,78 @@ func (o *RegistryOpts) defaultConfig() *configuration.Configuration {
 
 	return cfg
 }
+
+func ensureService(args []string) error {
+	prg := prog{}
+
+	cfg := &service.Config{
+		Name:        "hauler-registry",
+		DisplayName: "Hauler Registry",
+		Description: "Hauler's embedded registry",
+	}
+	s, err := service.New(prg, cfg)
+	if err != nil {
+		return err
+	}
+
+	var (
+		deps []string
+	)
+
+	switch s.Platform() {
+	case "linux-openrc":
+		deps = []string{"need net", "use dns", "after firewall"}
+
+	case "linux-systemd":
+		deps = []string{"After=network-online.target", "Wants=network-online.target"}
+		cfg.Option = map[string]interface{}{
+			"SystemdScript": systemdUnit,
+		}
+	}
+
+	cfg.Arguments = args
+	cfg.Dependencies = deps
+	return s.Install()
+}
+
+type prog struct{}
+
+func (p prog) Start(s service.Service) error {
+	return nil
+}
+
+func (p prog) Stop(s service.Service) error {
+	return nil
+}
+
+const systemdUnit = `[Unit]
+Description={{.Description}}
+Documentation=https://hauler.dev
+ConditionFileIsExecutable={{.Path|cmdEscape}}
+{{range $i, $dep := .Dependencies}}
+{{$dep}} {{end}}
+[Service]
+StartLimitInterval=5
+StartLimitBurst=10
+ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmdEscape}}{{end}}
+RestartSec=120
+Delegate=yes
+KillMode=process
+LimitCORE=infinity
+TasksMax=infinity
+TimeoutStartSec=0
+{{- if .ChRoot}}RootDirectory={{.ChRoot|cmd}}{{- end}}
+{{- if .WorkingDirectory}}WorkingDirectory={{.WorkingDirectory|cmdEscape}}{{- end}}
+{{- if .UserName}}User={{.UserName}}{{end}}
+{{- if .ReloadSignal}}ExecReload=/bin/kill -{{.ReloadSignal}} "$MAINPID"{{- end}}
+{{- if .PIDFile}}PIDFile={{.PIDFile|cmd}}{{- end}}
+{{- if and .LogOutput .HasOutputFileSupport -}}
+StandardOutput=file:/var/log/{{.Name}}.out
+StandardError=file:/var/log/{{.Name}}.err
+{{- end}}
+{{- if .SuccessExitStatus}}SuccessExitStatus={{.SuccessExitStatus}}{{- end}}
+{{ if gt .LimitNOFILE -1 }}LimitNOFILE={{.LimitNOFILE}}{{- end}}
+{{ if .Restart}}Restart={{.Restart}}{{- end}}
+[Install]
+WantedBy=multi-user.target
+`

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/go-containerregistry v0.7.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
+	github.com/kardianos/service v1.2.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2

--- a/go.sum
+++ b/go.sum
@@ -628,6 +628,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
+github.com/kardianos/service v1.2.0 h1:bGuZ/epo3vrt8IPC7mnKQolqFeYJb7Cs8Rk4PSOBB/g=
+github.com/kardianos/service v1.2.0/go.mod h1:CIMRFEJVL+0DS1a3Nx06NaMn4Dz63Ng6O7dl0qH0zVM=
 github.com/karrick/godirwalk v1.15.8 h1:7+rWAZPn9zuRxaIqqT8Ohs2Q2Ac0msBqwRdxNCr2VVs=
 github.com/karrick/godirwalk v1.15.8/go.mod h1:j4mkqPuvaLI8mp1DroR3P6ad7cyYd4c1qeJ3RV7ULlk=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -1254,6 +1256,7 @@ golang.org/x/sys v0.0.0-20200916030750-2334cc1a136f/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200922070232-aee5d888a860/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200923182605-d9f96fdee20d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201015000850-e3ed0017c211/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201112073958-5cba982894dd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201117170446-d9b008d0a637/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
adds an optional (off by default) command to `hauler serve registry` that installs the registry as a `service`.

This _should_ work on any `openrc` or `systemd` enabled host.

Note: it is still up to the user to enable/start the service.