### PR TITLE
pre 0.3 general bug fixes

### DIFF
--- a/cmd/hauler/cli/download.go
+++ b/cmd/hauler/cli/download.go
@@ -21,13 +21,13 @@ Note that the content type determines it's format on disk.  Hauler's built in co
 	- Chart: as a .tar.gz named after the chart (ex: loki:2.0.2 --> loki-2.0.2.tar.gz)`,
 		Example: `
 # Download a file
-hauler dl my-file.yaml:latest
+hauler dl localhost:5000/my-file.yaml:latest
 
 # Download an image
-hauler dl rancher/k3s:v1.22.2-k3s2
+hauler dl localhost:5000/rancher/k3s:v1.22.2-k3s2
 
 # Download a chart
-hauler dl longhorn:1.2.0`,
+hauler dl localhost:5000/hauler/longhorn:1.2.0`,
 		Aliases: []string{"dl"},
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, arg []string) error {

--- a/cmd/hauler/cli/download/download.go
+++ b/cmd/hauler/cli/download/download.go
@@ -40,12 +40,13 @@ func (o *Opts) AddArgs(cmd *cobra.Command) {
 func Cmd(ctx context.Context, o *Opts, ref string) error {
 	l := log.FromContext(ctx)
 
-	rs, err := content.NewRegistry(content.RegistryOptions{
+	ropts := content.RegistryOptions{
 		Username:  o.Username,
 		Password:  o.Password,
 		Insecure:  o.Insecure,
 		PlainHTTP: o.PlainHTTP,
-	})
+	}
+	rs, err := content.NewRegistry(ropts)
 	if err != nil {
 		return err
 	}

--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/rancherfederal/ocil/pkg/artifacts/file/getter"
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/action"
 
@@ -39,7 +40,11 @@ func AddFileCmd(ctx context.Context, o *AddFileOpts, s *store.Layout, reference 
 func storeFile(ctx context.Context, s *store.Layout, fi v1alpha1.File) error {
 	l := log.FromContext(ctx)
 
-	f := file.NewFile(fi.Path)
+	copts := getter.ClientOptions{
+		NameOverride: fi.Name,
+	}
+
+	f := file.NewFile(fi.Path, file.WithClient(getter.NewClient(copts)))
 	ref, err := reference.NewTagged(f.Name(fi.Path), reference.DefaultTag)
 	if err != nil {
 		return err

--- a/cmd/hauler/cli/store/copy.go
+++ b/cmd/hauler/cli/store/copy.go
@@ -18,7 +18,6 @@ import (
 type CopyOpts struct {
 	*RootOpts
 
-	Target    string
 	Username  string
 	Password  string
 	Insecure  bool
@@ -53,12 +52,13 @@ func CopyCmd(ctx context.Context, o *CopyOpts, s *store.Layout, targetRef string
 
 	case "registry":
 		l.Debugf("identified registry target reference")
-		r, err := content.NewRegistry(content.RegistryOptions{
+		ropts := content.RegistryOptions{
 			Username:  o.Username,
 			Password:  o.Password,
 			Insecure:  o.Insecure,
 			PlainHTTP: o.PlainHTTP,
-		})
+		}
+		r, err := content.NewRegistry(ropts)
 		if err != nil {
 			return err
 		}

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -2,8 +2,11 @@ package store
 
 import (
 	"context"
+	"os"
 
 	"github.com/mholt/archiver/v3"
+	"github.com/rancherfederal/ocil/pkg/content"
+	"github.com/rancherfederal/ocil/pkg/store"
 	"github.com/spf13/cobra"
 
 	"github.com/rancherfederal/hauler/pkg/log"
@@ -23,17 +26,39 @@ func (o *LoadOpts) AddFlags(cmd *cobra.Command) {
 func LoadCmd(ctx context.Context, o *LoadOpts, archiveRefs ...string) error {
 	l := log.FromContext(ctx)
 
-	// TODO: Support more formats?
-	a := archiver.NewTarZstd()
-	a.OverwriteExisting = true
-
 	for _, archiveRef := range archiveRefs {
 		l.Infof("loading content from [%s] to [%s]", archiveRef, o.StoreDir)
-		err := a.Unarchive(archiveRef, o.StoreDir)
+		err := unarchiveLayoutTo(ctx, archiveRef, o.StoreDir)
 		if err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// unarchiveLayoutTo accepts an archived oci layout and extracts the contents to an existing oci layout, preserving the index
+func unarchiveLayoutTo(ctx context.Context, archivePath string, dest string) error {
+	tmpdir, err := os.MkdirTemp("", "hauler")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpdir)
+
+	if err := archiver.Unarchive(archivePath, tmpdir); err != nil {
+		return err
+	}
+
+	s, err := store.NewLayout(tmpdir)
+	if err != nil {
+		return err
+	}
+
+	ts, err := content.NewOCI(dest)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.CopyAll(ctx, ts, nil)
+	return err
 }

--- a/cmd/hauler/cli/store/sync.go
+++ b/cmd/hauler/cli/store/sync.go
@@ -136,7 +136,10 @@ func SyncCmd(ctx context.Context, o *SyncOpts, s *store.Layout) error {
 				}
 
 				for _, cfg := range cfg.Spec.Charts {
-					tc, err := tchart.NewThickChart(cfg, &action.ChartPathOptions{})
+					tc, err := tchart.NewThickChart(cfg, &action.ChartPathOptions{
+						RepoURL: cfg.RepoURL,
+						Version: cfg.Version,
+					})
 					if err != nil {
 						return err
 					}

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/pkg/errors v0.9.1
-	github.com/rancherfederal/ocil v0.1.8
+	github.com/rancherfederal/ocil v0.1.9
 	github.com/rs/zerolog v1.26.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -961,8 +961,8 @@ github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/rancherfederal/ocil v0.1.8 h1:jVYD/AY7ipXgKepdZDDG1mxMOxCk/KIDdZw2qsseR+c=
-github.com/rancherfederal/ocil v0.1.8/go.mod h1:l4d1cHHfdXDGtio32AYDjG6n1i1JxQK+kAom0cVf0SY=
+github.com/rancherfederal/ocil v0.1.9 h1:pmiUQCh2HTIMDD9tDj/UqBAAxq4yloLFgd2WnrZnQgc=
+github.com/rancherfederal/ocil v0.1.9/go.mod h1:l4d1cHHfdXDGtio32AYDjG6n1i1JxQK+kAom0cVf0SY=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/pkg/apis/hauler.cattle.io/v1alpha1/file.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha1/file.go
@@ -21,8 +21,7 @@ type File struct {
 	// Path is the path to the file contents, can be a local or remote path
 	Path string `json:"path"`
 
-	// Reference is an optionally defined reference to the contents within the store
-	// 	If not specified, this will be generated as follows:
-	// 		hauler/<path base>:latest
-	Reference string `json:"reference,omitempty"`
+	// Name is an optional field specifying the name of the file when specified,
+	// 	it will override any dynamic name discovery from Path
+	Name string `json:"name,omitempty"`
 }

--- a/pkg/collection/chart/chart.go
+++ b/pkg/collection/chart/chart.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rancherfederal/hauler/pkg/apis/hauler.cattle.io/v1alpha1"
 	"github.com/rancherfederal/hauler/pkg/content/chart"
+	"github.com/rancherfederal/hauler/pkg/reference"
 )
 
 var _ artifacts.OCICollection = (*tchart)(nil)
@@ -60,7 +61,16 @@ func (c *tchart) compute() error {
 }
 
 func (c *tchart) chartContents() error {
-	c.contents[c.config.Name] = c.chart
+	ch, err := c.chart.Load()
+	if err != nil {
+		return err
+	}
+
+	ref, err := reference.NewTagged(ch.Name(), ch.Metadata.Version)
+	if err != nil {
+		return err
+	}
+	c.contents[ref.Name()] = c.chart
 	return nil
 }
 

--- a/pkg/collection/k3s/k3s.go
+++ b/pkg/collection/k3s/k3s.go
@@ -106,8 +106,8 @@ func (k *k3s) executable() error {
 }
 
 func (k *k3s) bootstrap() error {
-	namedBootstrapUrl := fmt.Sprintf("%s?filename=%s", bootstrapUrl, "k3s-init.sh")
-	f := file.NewFile(namedBootstrapUrl)
+	c := getter.NewClient(getter.ClientOptions{NameOverride: "k3s-init.sh"})
+	f := file.NewFile(bootstrapUrl, file.WithClient(c))
 
 	ref := fmt.Sprintf("%s/k3s-init.sh:%s", reference.DefaultNamespace, reference.DefaultTag)
 	k.contents[ref] = f

--- a/pkg/content/chart/chart.go
+++ b/pkg/content/chart/chart.go
@@ -56,16 +56,6 @@ func NewChart(name string, opts *action.ChartPathOptions) (*Chart, error) {
 		return nil, err
 	}
 
-	// c, err := loader.Loader(chartPath)
-	// if err != nil {
-	// 	return nil, err
-	// }
-	//
-	// ch, err := c.Load()
-	// if err != nil {
-	// 	return nil, err
-	// }
-	//
 	return &Chart{
 		path: chartPath,
 	}, err

--- a/testdata/contents.yaml
+++ b/testdata/contents.yaml
@@ -7,15 +7,16 @@ spec:
     # hauler can save/redistribute files on disk (be careful! paths are relative)
     - path: testdata/contents.yaml
 
-    # TODO: when directories are specified, they will be archived and stored as a file
-#    - path: testdata/
+    # when directories are specified, the directory contents will be archived and stored
+    - path: testdata/
 
     # hauler can also fetch remote content, and will "smartly" identify filenames _when possible_
     #   filename below = "k3s-images.txt"
     - path: "https://github.com/k3s-io/k3s/releases/download/v1.22.2%2Bk3s2/k3s-images.txt"
 
-    # when filenames are not appropriate, a name should be specified
+    # when discovered filenames are not desired, a file name can be specified
     - path: https://get.k3s.io
+      name: k3s-init.sh
 
 ---
 apiVersion: content.hauler.cattle.io/v1alpha1


### PR DESCRIPTION
- ensure thick charts and k3s reference follows proper naming convnetion
- change `store load` to properly update layout stores (by copying oci layouts instead of just unarchiving things)
- add option for file names to be overridden