### PR TITLE
Bump API version to v1alpha2; handle multiple API versions

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/rancherfederal/ocil/pkg/store"
 
-	"github.com/rancherfederal/hauler/pkg/apis/hauler.cattle.io/v1alpha1"
+	"github.com/rancherfederal/hauler/pkg/apis/hauler.cattle.io/v1alpha2"
 	"github.com/rancherfederal/hauler/pkg/content/chart"
 	"github.com/rancherfederal/hauler/pkg/log"
 	"github.com/rancherfederal/hauler/pkg/reference"
@@ -30,14 +30,14 @@ func (o *AddFileOpts) AddFlags(cmd *cobra.Command) {
 }
 
 func AddFileCmd(ctx context.Context, o *AddFileOpts, s *store.Layout, reference string) error {
-	cfg := v1alpha1.File{
+	cfg := v1alpha2.File{
 		Path: reference,
 	}
 
 	return storeFile(ctx, s, cfg)
 }
 
-func storeFile(ctx context.Context, s *store.Layout, fi v1alpha1.File) error {
+func storeFile(ctx context.Context, s *store.Layout, fi v1alpha2.File) error {
 	l := log.FromContext(ctx)
 
 	copts := getter.ClientOptions{
@@ -70,14 +70,14 @@ func (o *AddImageOpts) AddFlags(cmd *cobra.Command) {
 }
 
 func AddImageCmd(ctx context.Context, o *AddImageOpts, s *store.Layout, reference string) error {
-	cfg := v1alpha1.Image{
+	cfg := v1alpha2.Image{
 		Name: reference,
 	}
 
 	return storeImage(ctx, s, cfg)
 }
 
-func storeImage(ctx context.Context, s *store.Layout, i v1alpha1.Image) error {
+func storeImage(ctx context.Context, s *store.Layout, i v1alpha2.Image) error {
 	l := log.FromContext(ctx)
 
 	img, err := image.NewImage(i.Name)
@@ -121,7 +121,7 @@ func (o *AddChartOpts) AddFlags(cmd *cobra.Command) {
 
 func AddChartCmd(ctx context.Context, o *AddChartOpts, s *store.Layout, chartName string) error {
 	// TODO: Reduce duplicates between api chart and upstream helm opts
-	cfg := v1alpha1.Chart{
+	cfg := v1alpha2.Chart{
 		Name:    chartName,
 		RepoURL: o.ChartOpts.RepoURL,
 		Version: o.ChartOpts.Version,
@@ -130,7 +130,7 @@ func AddChartCmd(ctx context.Context, o *AddChartOpts, s *store.Layout, chartNam
 	return storeChart(ctx, s, cfg, o.ChartOpts)
 }
 
-func storeChart(ctx context.Context, s *store.Layout, cfg v1alpha1.Chart, opts *action.ChartPathOptions) error {
+func storeChart(ctx context.Context, s *store.Layout, cfg v1alpha2.Chart, opts *action.ChartPathOptions) error {
 	l := log.FromContext(ctx)
 
 	// TODO: This shouldn't be necessary

--- a/cmd/hauler/cli/store/sync.go
+++ b/cmd/hauler/cli/store/sync.go
@@ -12,8 +12,10 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/rancherfederal/ocil/pkg/store"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/rancherfederal/hauler/pkg/apis/hauler.cattle.io/v1alpha1"
+	"github.com/rancherfederal/hauler/pkg/apis/hauler.cattle.io/v1alpha2"
 	tchart "github.com/rancherfederal/hauler/pkg/collection/chart"
 	"github.com/rancherfederal/hauler/pkg/collection/imagetxt"
 	"github.com/rancherfederal/hauler/pkg/collection/k3s"
@@ -72,105 +74,129 @@ func SyncCmd(ctx context.Context, o *SyncOpts, s *store.Layout) error {
 
 			l.Infof("syncing [%s] to store", obj.GroupVersionKind().String())
 
-			// TODO: Should type switch instead...
-			switch obj.GroupVersionKind().Kind {
-			case v1alpha1.FilesContentKind:
-				var cfg v1alpha1.Files
-				if err := yaml.Unmarshal(doc, &cfg); err != nil {
-					return err
-				}
-
-				for _, f := range cfg.Spec.Files {
-					err := storeFile(ctx, s, f)
-					if err != nil {
-						return err
-					}
-				}
-
-			case v1alpha1.ImagesContentKind:
-				var cfg v1alpha1.Images
-				if err := yaml.Unmarshal(doc, &cfg); err != nil {
-					return err
-				}
-
-				for _, i := range cfg.Spec.Images {
-					err := storeImage(ctx, s, i)
-					if err != nil {
-						return err
-					}
-				}
-
-			case v1alpha1.ChartsContentKind:
-				var cfg v1alpha1.Charts
-				if err := yaml.Unmarshal(doc, &cfg); err != nil {
-					return err
-				}
-
-				for _, ch := range cfg.Spec.Charts {
-					// TODO: Provide a way to configure syncs
-					err := storeChart(ctx, s, ch, &action.ChartPathOptions{})
-					if err != nil {
-						return err
-					}
-				}
-
-			case v1alpha1.K3sCollectionKind:
-				var cfg v1alpha1.K3s
-				if err := yaml.Unmarshal(doc, &cfg); err != nil {
-					return err
-				}
-
-				k, err := k3s.NewK3s(cfg.Spec.Version)
-				if err != nil {
-					return err
-				}
-
-				if _, err := s.AddOCICollection(ctx, k); err != nil {
-					return err
-				}
-
-			case v1alpha1.ChartsCollectionKind:
-				var cfg v1alpha1.ThickCharts
-				if err := yaml.Unmarshal(doc, &cfg); err != nil {
-					return err
-				}
-
-				for _, cfg := range cfg.Spec.Charts {
-					tc, err := tchart.NewThickChart(cfg, &action.ChartPathOptions{
-						RepoURL: cfg.RepoURL,
-						Version: cfg.Version,
-					})
-					if err != nil {
-						return err
-					}
-
-					if _, err := s.AddOCICollection(ctx, tc); err != nil {
-						return err
-					}
-				}
-
-			case v1alpha1.ImageTxtsContentKind:
-				var cfg v1alpha1.ImageTxts
-				if err := yaml.Unmarshal(doc, &cfg); err != nil {
-					return err
-				}
-
-				for _, cfgIt := range cfg.Spec.ImageTxts {
-					it, err := imagetxt.New(cfgIt.Ref,
-						imagetxt.WithIncludeSources(cfgIt.Sources.Include...),
-						imagetxt.WithExcludeSources(cfgIt.Sources.Exclude...),
+			gvk := obj.GroupVersionKind()
+			switch {
+			// content.hauler.cattle.io/v1alpha1
+			// collection.hauler.cattle.io/v1alpha1
+			case gvk.Version == v1alpha1.Version:
+				if gvk.GroupVersion() == v1alpha1.ContentGroupVersion || gvk.GroupVersion() == v1alpha1.CollectionGroupVersion {
+					return fmt.Errorf(
+						"%s is deprecated and unsupported; use %s instead",
+						gvk.GroupVersion().String(),
+						schema.GroupVersion{Group: gvk.Group, Version: v1alpha2.Version}.String(),
 					)
-					if err != nil {
-						return fmt.Errorf("convert ImageTxt %s: %v", cfg.Name, err)
+				}
+				return fmt.Errorf("unrecognized API object type: %s", gvk.String())
+			// content.hauler.cattle.io/v1alpha2
+			case gvk.GroupVersion() == v1alpha2.ContentGroupVersion:
+				switch gvk.Kind {
+				// content.hauler.cattle.io/v1alpha2 Files
+				case v1alpha2.FilesContentKind:
+					var cfg v1alpha2.Files
+					if err := yaml.Unmarshal(doc, &cfg); err != nil {
+						return err
+					}
+					for _, f := range cfg.Spec.Files {
+						err := storeFile(ctx, s, f)
+						if err != nil {
+							return err
+						}
 					}
 
-					if _, err := s.AddOCICollection(ctx, it); err != nil {
-						return fmt.Errorf("add ImageTxt %s to store: %v", cfg.Name, err)
+				// content.hauler.cattle.io/v1alpha2 Images
+				case v1alpha2.ImagesContentKind:
+					var cfg v1alpha2.Images
+					if err := yaml.Unmarshal(doc, &cfg); err != nil {
+						return err
 					}
+					for _, i := range cfg.Spec.Images {
+						err := storeImage(ctx, s, i)
+						if err != nil {
+							return err
+						}
+					}
+
+				// content.hauler.cattle.io/v1alpha2 Charts
+				case v1alpha2.ChartsContentKind:
+					var cfg v1alpha2.Charts
+					if err := yaml.Unmarshal(doc, &cfg); err != nil {
+						return err
+					}
+					for _, ch := range cfg.Spec.Charts {
+						// TODO: Provide a way to configure syncs
+						err := storeChart(ctx, s, ch, &action.ChartPathOptions{})
+						if err != nil {
+							return err
+						}
+					}
+
+				// content.hauler.cattle.io/v1alpha2 unknown Kind
+				default:
+					return fmt.Errorf("unrecognized content kind: %s", gvk.Kind)
 				}
 
+			// collection.hauler.cattle.io/v1alpha2
+			case gvk.GroupVersion() == v1alpha2.CollectionGroupVersion:
+				switch gvk.Kind {
+				// collection.hauler.cattle.io/v1alpha2 K3s
+				case v1alpha2.K3sCollectionKind:
+					var cfg v1alpha2.K3s
+					if err := yaml.Unmarshal(doc, &cfg); err != nil {
+						return err
+					}
+					k, err := k3s.NewK3s(cfg.Spec.Version)
+					if err != nil {
+						return err
+					}
+					if _, err := s.AddOCICollection(ctx, k); err != nil {
+						return err
+					}
+
+				// collection.hauler.cattle.io/v1alpha2 ThickCharts
+				case v1alpha2.ChartsCollectionKind:
+					var cfg v1alpha2.ThickCharts
+					if err := yaml.Unmarshal(doc, &cfg); err != nil {
+						return err
+					}
+					for _, cfg := range cfg.Spec.Charts {
+						tc, err := tchart.NewThickChart(cfg, &action.ChartPathOptions{
+							RepoURL: cfg.RepoURL,
+							Version: cfg.Version,
+						})
+						if err != nil {
+							return err
+						}
+						if _, err := s.AddOCICollection(ctx, tc); err != nil {
+							return err
+						}
+					}
+
+				// collection.hauler.cattle.io/v1alpha2 ImageTxts
+				case v1alpha2.ImageTxtsContentKind:
+					var cfg v1alpha2.ImageTxts
+					if err := yaml.Unmarshal(doc, &cfg); err != nil {
+						return err
+					}
+					for _, cfgIt := range cfg.Spec.ImageTxts {
+						it, err := imagetxt.New(cfgIt.Path,
+							imagetxt.WithIncludeSources(cfgIt.Sources.Include...),
+							imagetxt.WithExcludeSources(cfgIt.Sources.Exclude...),
+						)
+						if err != nil {
+							return fmt.Errorf("convert ImageTxt %s: %v", cfg.Name, err)
+						}
+						if _, err := s.AddOCICollection(ctx, it); err != nil {
+							return fmt.Errorf("add ImageTxt %s to store: %v", cfg.Name, err)
+						}
+					}
+
+				// collection.hauler.cattle.io/v1alpha2 unknown Kind
+				default:
+					return fmt.Errorf("unrecognized collection kind: %s", gvk.Kind)
+				}
+			// unknown API group + version
 			default:
-				return fmt.Errorf("unrecognized content/collection type: %s", obj.GroupVersionKind().String())
+				return fmt.Errorf("unrecognized API object type: %s", gvk)
 			}
 		}
 	}

--- a/pkg/apis/hauler.cattle.io/v1alpha2/chart.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha2/chart.go
@@ -1,4 +1,4 @@
-package v1alpha1
+package v1alpha2
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/hauler.cattle.io/v1alpha2/driver.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha2/driver.go
@@ -1,4 +1,4 @@
-package v1alpha1
+package v1alpha2
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/hauler.cattle.io/v1alpha2/file.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha2/file.go
@@ -1,4 +1,4 @@
-package v1alpha1
+package v1alpha2
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,7 +21,7 @@ type File struct {
 	// Path is the path to the file contents, can be a local or remote path
 	Path string `json:"path"`
 
-	// Name is an optional field specifying the name of the file when specified,
-	// 	it will override any dynamic name discovery from Path
+	// Name is an optional field specifying the name of the file. When specified, it
+	// will override any dynamic name discovery from Path
 	Name string `json:"name,omitempty"`
 }

--- a/pkg/apis/hauler.cattle.io/v1alpha2/groupversion_info.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha2/groupversion_info.go
@@ -1,0 +1,18 @@
+package v1alpha2
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+const (
+	Version         = "v1alpha2"
+	ContentGroup    = "content.hauler.cattle.io"
+	CollectionGroup = "collection.hauler.cattle.io"
+)
+
+var (
+	ContentGroupVersion = schema.GroupVersion{Group: ContentGroup, Version: Version}
+	// SchemeBuilder       = &scheme.Builder{GroupVersion: ContentGroupVersion}
+
+	CollectionGroupVersion = schema.GroupVersion{Group: CollectionGroup, Version: Version}
+)

--- a/pkg/apis/hauler.cattle.io/v1alpha2/image.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha2/image.go
@@ -1,4 +1,4 @@
-package v1alpha1
+package v1alpha2
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/hauler.cattle.io/v1alpha2/imagetxt.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha2/imagetxt.go
@@ -1,4 +1,4 @@
-package v1alpha1
+package v1alpha2
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,7 +20,7 @@ type ImageTxtsSpec struct {
 }
 
 type ImageTxt struct {
-	Ref     string          `json:"ref,omitempty"`
+	Path    string          `json:"path,omitempty"`
 	Sources ImageTxtSources `json:"sources,omitempty"`
 }
 

--- a/pkg/apis/hauler.cattle.io/v1alpha2/k3s.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha2/k3s.go
@@ -1,4 +1,4 @@
-package v1alpha1
+package v1alpha2
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/collection/chart/chart.go
+++ b/pkg/collection/chart/chart.go
@@ -5,7 +5,7 @@ import (
 	"github.com/rancherfederal/ocil/pkg/artifacts/image"
 	"helm.sh/helm/v3/pkg/action"
 
-	"github.com/rancherfederal/hauler/pkg/apis/hauler.cattle.io/v1alpha1"
+	"github.com/rancherfederal/hauler/pkg/apis/hauler.cattle.io/v1alpha2"
 	"github.com/rancherfederal/hauler/pkg/content/chart"
 	"github.com/rancherfederal/hauler/pkg/reference"
 )
@@ -15,13 +15,13 @@ var _ artifacts.OCICollection = (*tchart)(nil)
 // tchart is a thick chart that includes all the dependent images as well as the chart itself
 type tchart struct {
 	chart  *chart.Chart
-	config v1alpha1.ThickChart
+	config v1alpha2.ThickChart
 
 	computed bool
 	contents map[string]artifacts.OCI
 }
 
-func NewThickChart(cfg v1alpha1.ThickChart, opts *action.ChartPathOptions) (artifacts.OCICollection, error) {
+func NewThickChart(cfg v1alpha2.ThickChart, opts *action.ChartPathOptions) (artifacts.OCICollection, error) {
 	o, err := chart.NewChart(cfg.Chart.Name, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/collection/chart/dependents.go
+++ b/pkg/collection/chart/dependents.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/util/jsonpath"
 
-	"github.com/rancherfederal/hauler/pkg/apis/hauler.cattle.io/v1alpha1"
+	"github.com/rancherfederal/hauler/pkg/apis/hauler.cattle.io/v1alpha2"
 )
 
 var defaultKnownImagePaths = []string{
@@ -29,13 +29,13 @@ var defaultKnownImagePaths = []string{
 }
 
 // ImagesInChart will render a chart and identify all dependent images from it
-func ImagesInChart(c *helmchart.Chart) (v1alpha1.Images, error) {
+func ImagesInChart(c *helmchart.Chart) (v1alpha2.Images, error) {
 	docs, err := template(c)
 	if err != nil {
-		return v1alpha1.Images{}, err
+		return v1alpha2.Images{}, err
 	}
 
-	var images []v1alpha1.Image
+	var images []v1alpha2.Image
 	reader := yaml.NewYAMLReader(bufio.NewReader(strings.NewReader(docs)))
 	for {
 		raw, err := reader.Read()
@@ -43,17 +43,17 @@ func ImagesInChart(c *helmchart.Chart) (v1alpha1.Images, error) {
 			break
 		}
 		if err != nil {
-			return v1alpha1.Images{}, err
+			return v1alpha2.Images{}, err
 		}
 
 		found := find(raw, defaultKnownImagePaths...)
 		for _, f := range found {
-			images = append(images, v1alpha1.Image{Name: f})
+			images = append(images, v1alpha2.Image{Name: f})
 		}
 	}
 
-	ims := v1alpha1.Images{
-		Spec: v1alpha1.ImageSpec{
+	ims := v1alpha2.Images{
+		Spec: v1alpha2.ImageSpec{
 			Images: images,
 		},
 	}

--- a/pkg/collection/imagetxt/imagetxt.go
+++ b/pkg/collection/imagetxt/imagetxt.go
@@ -66,9 +66,9 @@ func WithExcludeSources(exclude ...string) Option {
 	return withExcludeSources(exclude)
 }
 
-func New(ref string, opts ...Option) (*ImageTxt, error) {
+func New(path string, opts ...Option) (*ImageTxt, error) {
 	it := &ImageTxt{
-		Ref: ref,
+		Ref: path,
 
 		client: getter.NewClient(getter.ClientOptions{}),
 		lock:   &sync.Mutex{},


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
APi version bump


* **What is the current behavior?** (You can also link to an open issue here)
Linked issue https://github.com/rancherfederal/hauler/issues/120


* **What is the new behavior (if this is a feature change)?**
Breaking changes in API indicated by new API version.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes: bumps API object version to reflect breaking changes, `sync` subcommand handles multiple API versions.
