### PR TITLE
Adding example of imperative generation of declarative config file to doc

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -140,7 +140,7 @@ rancher/nginx-ingress-controller:nginx-1.0.2-hardened4
 
 * The generated list of images can then be used to easily generate a hauler config file by using the following logic:
 ```bash
-temp=$(echo "$IMAGE_LIST" | sed 's/^/  - /')
+temp=$(echo "$IMAGE_LIST" | sed 's/^/  - name: /')
 # sed intents each entry in the list by 2 spaces, then
 # appends -, to make add an entry to the yaml list
 cat << EOF | tee contents.yaml
@@ -164,16 +164,16 @@ metadata:
   name: myimage
 spec:
   images:
-  - index.docker.io/rancher/hardened-etcd:v3.5.1-k3s1-build20220112
-  - index.docker.io/rancher/hardened-kubernetes:v1.23.5-rke2r1-build20220316
-  - index.docker.io/rancher/rke2-cloud-provider:v0.0.3-build20211118
-  - rancher/hardened-calico:v3.21.4-build20220228
-  - rancher/hardened-cluster-autoscaler:v1.8.5-build20211119
-  - rancher/hardened-coredns:v1.9.1-build20220318
-  - rancher/hardened-flannel:v0.17.0-build20220317
-  - rancher/hardened-k8s-metrics-server:v0.5.0-build20211119
-  - rancher/klipper-helm:v0.7.0-build20220315
-  - rancher/nginx-ingress-controller:nginx-1.0.2-hardened4
+  - name: index.docker.io/rancher/hardened-etcd:v3.5.1-k3s1-build20220112
+  - name: index.docker.io/rancher/hardened-kubernetes:v1.23.5-rke2r1-build20220316
+  - name: index.docker.io/rancher/rke2-cloud-provider:v0.0.3-build20211118
+  - name: rancher/hardened-calico:v3.21.4-build20220228
+  - name: rancher/hardened-cluster-autoscaler:v1.8.5-build20211119
+  - name: rancher/hardened-coredns:v1.9.1-build20220318
+  - name: rancher/hardened-flannel:v0.17.0-build20220317
+  - name: rancher/hardened-k8s-metrics-server:v0.5.0-build20211119
+  - name: rancher/klipper-helm:v0.7.0-build20220315
+  - name: rancher/nginx-ingress-controller:nginx-1.0.2-hardened4
 ```
 
 ### Collections

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -141,8 +141,8 @@ rancher/nginx-ingress-controller:nginx-1.0.2-hardened4
 * The generated list of images can then be used to easily generate a hauler config file by using the following logic:
 ```bash
 temp=$(echo "$IMAGE_LIST" | sed 's/^/  - name: /')
-# sed intents each entry in the list by 2 spaces, then
-# appends -, to make add an entry to the yaml list
+# sed, stream editor, appends 2 spaces of indentation denotes 
+# an entry in a list, then adds name: to match expected syntax
 cat << EOF | tee contents.yaml
 apiVersion: content.hauler.cattle.io/v1alpha1
 kind: Images

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -117,6 +117,63 @@ hauler store sync -f testdata/contents.yaml
 
 The API for each type of built-in `content` allows you to easily and declaratively define all the `content` that exist within a `haul`, and ensures a more gitops compatible workflow for managing the lifecycle of your `hauls`.
 
+It's also easy to imperatively generate a declarative contents.yaml
+* This will generate a list of all images running in your cluster, store it in an environment variable, then echo the environment variable to show the list.
+```bash
+export IMAGE_LIST=$(kubectl get pods --all-namespaces -o jsonpath="{.items[*].spec.containers[*].image}" |tr -s '[[:space:]]' '\n' |sort |uniq -c | cut -c 9-)
+echo "$IMAGE_LIST"
+```
+
+* Example Output
+```console
+index.docker.io/rancher/hardened-etcd:v3.5.1-k3s1-build20220112
+index.docker.io/rancher/hardened-kubernetes:v1.23.5-rke2r1-build20220316
+index.docker.io/rancher/rke2-cloud-provider:v0.0.3-build20211118
+rancher/hardened-calico:v3.21.4-build20220228
+rancher/hardened-cluster-autoscaler:v1.8.5-build20211119
+rancher/hardened-coredns:v1.9.1-build20220318
+rancher/hardened-flannel:v0.17.0-build20220317
+rancher/hardened-k8s-metrics-server:v0.5.0-build20211119
+rancher/klipper-helm:v0.7.0-build20220315
+rancher/nginx-ingress-controller:nginx-1.0.2-hardened4
+```
+
+* The generated list of images can then be used to easily generate a hauler config file by using the following logic:
+```bash
+temp=$(echo "$IMAGE_LIST" | sed 's/^/  - /')
+# sed intents each entry in the list by 2 spaces, then
+# appends -, to make add an entry to the yaml list
+cat << EOF | tee contents.yaml
+apiVersion: content.hauler.cattle.io/v1alpha1
+kind: Images
+metadata:
+  name: myimage
+spec:
+  images:
+$temp
+EOF
+```
+
+* The result would look like this
+```console
+apiVersion: content.hauler.cattle.io/v1alpha1
+kind: Images
+metadata:
+  name: myimage
+spec:
+  images:
+  - index.docker.io/rancher/hardened-etcd:v3.5.1-k3s1-build20220112
+  - index.docker.io/rancher/hardened-kubernetes:v1.23.5-rke2r1-build20220316
+  - index.docker.io/rancher/rke2-cloud-provider:v0.0.3-build20211118
+  - rancher/hardened-calico:v3.21.4-build20220228
+  - rancher/hardened-cluster-autoscaler:v1.8.5-build20211119
+  - rancher/hardened-coredns:v1.9.1-build20220318
+  - rancher/hardened-flannel:v0.17.0-build20220317
+  - rancher/hardened-k8s-metrics-server:v0.5.0-build20211119
+  - rancher/klipper-helm:v0.7.0-build20220315
+  - rancher/nginx-ingress-controller:nginx-1.0.2-hardened4
+```
+
 ### Collections
 
 Earlier we referred to `content` as "primitives".  While the quotes justify the loose definition of that term, we call it that because they can be used to build groups of `content`, which we call `collections`.

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -152,6 +152,8 @@ spec:
   images:
 $temp
 EOF
+
+cat contents.yaml
 ```
 
 * The result would look like this


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines  
(unsure where guidelines are)
- [ ] Tests for the changes have been added  
(not a bug fix / feature, but I manually tested the doc update against a live cluster)
- [ ] Docs have been added / updated  
(This is a doc update to a pre-existing feature)

* **What kind of change does this PR introduce?**
docs update

* **What is the new behavior (if this is a feature change)?**
UX improvement to docs by showing how to easily imperatively generate a declarative contents.yaml file for air gap deployments.

  The newly added doc section can be previewed here:  
  https://github.com/neoakris/hauler/blob/content_doc_example/docs/walkthrough.md#content-api

* **Does this PR introduce a breaking change?**
No
