### PR TITLE
deprecation notices for `dl` and the non-store version of `serve`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ For a guided example of all of `haulers` capabilities, check out the [guided exa
 * [go-containerregistry](https://github.com/google/go-containerregistry)
 * [oras](https://github.com/oras-project/oras)
 * [cosign](https://github.com/sigstore/cosign)
+
+## Notices
+
+*** WARNING: Deprecated Command *** 
+
+The `hauler download (dl)` and `hauler serve (not the store version)` commands are deprecated and will be removed in a future release of Hauler.

--- a/cmd/hauler/cli/download.go
+++ b/cmd/hauler/cli/download.go
@@ -12,7 +12,10 @@ func addDownload(parent *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "download",
 		Short: "Download OCI content from a registry and populate it on disk",
-		Long: `Locate OCI content based on it's reference in a compatible registry and download the contents to disk.
+		Long: `*** WARNING: Deprecated Command *** 
+The 'download (dl)' command is deprecated and will be removed in a future release of Hauler.
+
+Locate OCI content based on it's reference in a compatible registry and download the contents to disk.
 
 Note that the content type determines it's format on disk.  Hauler's built in content types act as follows:
 

--- a/cmd/hauler/cli/serve.go
+++ b/cmd/hauler/cli/serve.go
@@ -10,6 +10,8 @@ func addServe(parent *cobra.Command) {
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Run one or more of hauler's embedded servers types",
+		Long: `*** WARNING: Deprecated Command *** 
+The 'serve' command is deprecated and will be removed in a future release of Hauler.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return cmd.Help()
 		},


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Adds notification messages for hauler download and hauler serve (not the store version).

* **What is the current behavior?** (You can also link to an open issue here)

No deprecation messages.

* **What is the new behavior (if this is a feature change)?**

Adds notification messages for hauler download and hauler serve (not the store version).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**: