### PR TITLE
fix hauler version display

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,7 +5,7 @@ before:
     - go mod download
 
 env:
-  - vpkg=github.com/rancherfederal/hauler/pkg/version
+  - vpkg=github.com/rancherfederal/hauler/internal/version
 
 builds:
   - main: cmd/hauler/main.go
@@ -17,7 +17,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X {{ .Env.vpkg }}.GitVersion={{ .Version }} -X {{ .Env.vpkg }}.commit={{ .ShortCommit }} -X {{ .Env.vpkg }}.buildDate={{ .Date }}
+      - -s -w -X {{ .Env.vpkg }}.gitVersion={{ .Version }} -X {{ .Env.vpkg }}.gitCommit={{ .ShortCommit }} -X {{ .Env.vpkg }}.gitTreeState={{if .IsGitDirty}}dirty{{else}}clean{{end}} -X {{ .Env.vpkg }}.buildDate={{ .Date }}
     env:
       - CGO_ENABLED=0
 


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [ ] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
* the `goreleaser` parameters to feed the build info to the version command was broken after the v0.4.0 release.

**What is the current behavior?**
```
❯ hauler version                                                                                                                                                                                                                                                                                                         
GitVersion:    devel
GitCommit:     unknown
GitTreeState:  unknown
BuildDate:     unknown
GoVersion:     go1.21.3
Compiler:      gc
Platform:      darwin/arm64
```

**What is the new behavior (if this is a feature change)?**
```
❯ hauler version                                                                                                                                                                                                                                                                               
GitVersion:    {correct version}
GitCommit:     756c017
GitTreeState:  clean
BuildDate:     2023-11-30T18:37:01Z
GoVersion:     go1.21.4
Compiler:      gc
Platform:      darwin/arm64
```

**Does this PR introduce a breaking change?**
Nothing

**Other information**:
* <!-- Any additional information -->