### PR TITLE
Improved logging for store copy / Updated store info to handle multi-arch images

### DIFF
--- a/cmd/hauler/cli/store/copy.go
+++ b/cmd/hauler/cli/store/copy.go
@@ -63,7 +63,7 @@ func CopyCmd(ctx context.Context, o *CopyOpts, s *store.Layout, targetRef string
 			}
 		}
 
-		err := cosign.LoadImage(ctx, s, components[1], ropts)
+		err := cosign.LoadImages(ctx, s, components[1], ropts)
 		if err != nil {
 			return err
 		}
@@ -72,6 +72,6 @@ func CopyCmd(ctx context.Context, o *CopyOpts, s *store.Layout, targetRef string
 		return fmt.Errorf("detecting protocol from [%s]", targetRef)
 	}
 
-	l.Infof("Copied artifacts to [%s]", components[1])
+	l.Infof("copied artifacts to [%s]", components[1])
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc5
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.9.4 h1:xR7vG4IXt5RWx6FfIjyAtsoMAtnc3C/rFXBBd2AjZwE=
 github.com/onsi/ginkgo/v2 v2.9.4/go.mod h1:gCQYp2Q+kSoIj7ykSVb9nskRSsR6PUj4AiLywzIhbKM=
 github.com/onsi/gomega v1.27.6 h1:ENqfyGeS5AX/rlXDd/ETokDz93u0YufY1Pgxuy/PvWE=

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -4,6 +4,7 @@ const (
 	OCIManifestSchema1        = "application/vnd.oci.image.manifest.v1+json"
 	DockerManifestSchema2     = "application/vnd.docker.distribution.manifest.v2+json"
 	DockerManifestListSchema2 = "application/vnd.docker.distribution.manifest.list.v2+json"
+	OCIImageIndexSchema       = "application/vnd.oci.image.index.v1+json"
 
 	DockerConfigJSON        = "application/vnd.docker.container.image.v1+json"
 	DockerLayer             = "application/vnd.docker.image.rootfs.diff.tar.gzip"

--- a/pkg/content/oci.go
+++ b/pkg/content/oci.go
@@ -161,6 +161,14 @@ func (o *OCI) Fetch(ctx context.Context, desc ocispec.Descriptor) (io.ReadCloser
 	return readerAt, nil
 }
 
+func (o *OCI) FetchManifest(ctx context.Context, manifest ocispec.Manifest) (io.ReadCloser, error) {
+	readerAt, err := o.manifestBlobReaderAt(manifest)
+	if err != nil {
+		return nil, err
+	}
+	return readerAt, nil
+}
+
 // Pusher returns a new pusher for the provided reference
 // The returned Pusher should satisfy content.Ingester and concurrent attempts
 // to push the same blob using the Ingester API should result in ErrUnavailable.
@@ -202,6 +210,14 @@ func (o *OCI) Walk(fn func(reference string, desc ocispec.Descriptor) error) err
 
 func (o *OCI) blobReaderAt(desc ocispec.Descriptor) (*os.File, error) {
 	blobPath, err := o.ensureBlob(desc.Digest.Algorithm().String(), desc.Digest.Hex())
+	if err != nil {
+		return nil, err
+	}
+	return os.Open(blobPath)
+}
+
+func (o *OCI) manifestBlobReaderAt(manifest ocispec.Manifest) (*os.File, error) {
+	blobPath, err := o.ensureBlob(string(manifest.Config.Digest.Algorithm().String()), manifest.Config.Digest.Hex())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

**What kind of change does this PR introduce?**
* Improved logging for store copy 
* Updated store info to handle multi-arch images

**What is the current behavior?**
* `hauler store copy` provides no incremental feedback.
* `hauler store info` is missing data for the majority of images.

**What is the new behavior (if this is a feature change)?**
* `hauler store copy` provides better logging.
```
❯ ./bin/hauler store copy registry://your.registry.com                                                                                                                                                                                                              
11:31AM INF carbide/k3s-docs:0.1.2
11:31AM INF rancher/mirrored-library-traefik:2.9.1
11:31AM INF hauler/sha256sum-amd64.txt:latest
11:31AM INF carbide/heimdall2:0.1.1
11:31AM INF carbide/carbide-whitelabel:0.1.1
11:31AM INF rancher/hardened-calico:v3.26.1-build20230802
11:31AM INF carbide/stigatron-hook:0.2.0
11:31AM INF copied artifacts to [your.registry.com]
```

* `hauler store info` now handles multi-arch images.

![image](https://github.com/rancherfederal/hauler/assets/42001113/ef69dcfa-b32e-4d07-ac61-01cf30a49af1)


**Does this PR introduce a breaking change?**
* No

**Other information**:
* <!-- Any additional information -->