### PR TITLE
fix for validating foreign blobs

### DIFF
--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -95,6 +95,10 @@ func (o *ServeOpts) defaultConfig() *configuration.Configuration {
 			// "maintenance": configuration.Parameters{"readonly.enabled": false},
 		},
 	}
+
+	// Add validation configuration
+	cfg.Validation.Manifests.URLs.Allow = []string{".+"}
+
 	cfg.Log.Level = "info"
 	cfg.HTTP.Addr = fmt.Sprintf(":%d", o.Port)
 	cfg.HTTP.Headers = http.Header{

--- a/internal/server/registry.go
+++ b/internal/server/registry.go
@@ -45,6 +45,9 @@ func NewTempRegistry(ctx context.Context, root string) *tmpRegistryServer {
 			"filesystem": configuration.Parameters{"rootdirectory": root},
 		},
 	}
+	// Add validation configuration
+	cfg.Validation.Manifests.URLs.Allow = []string{".+"}
+	
 	cfg.Log.Level = "error"
 	cfg.HTTP.Headers = http.Header{
 		"X-Content-Type-Options": []string{"nosniff"},


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [ ] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
Added additional configuration to `hauler store serve` to allow certain layers when starting the registry. 

**What is the current behavior?**
* If you have images in your hauler store with a layer of type `application/vnd.docker.image.rootfs.foreign.diff.tar.gzip` (usually with windows arch images), the registry fails to start.

```
multiple errors returned: UNKNOWN: unknown error; UNKNOWN: unknown error; map[]; MANIFEST_BLOB_UNKNOWN: blob unknown to registry;
```

**What is the new behavior (if this is a feature change)?**
* registry validates the layer and starts up normally.

**Does this PR introduce a breaking change?**
* <!-- What changes might users need to make in their application due to this PR? -->

**Other information**:
* <!-- Any additional information -->