### PR TITLE
add simple type filter to store info

### DIFF
--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/action"
+	"fmt"
 
 	"github.com/rancherfederal/hauler/cmd/hauler/cli/store"
 )
@@ -155,6 +156,8 @@ func addStoreSave() *cobra.Command {
 func addStoreInfo() *cobra.Command {
 	o := &store.InfoOpts{RootOpts: rootStoreOpts}
 
+	var allowedValues = []string{"image", "chart", "file", "all"}
+
 	cmd := &cobra.Command{
 		Use:     "info",
 		Short:   "Print out information about the store",
@@ -167,8 +170,13 @@ func addStoreInfo() *cobra.Command {
 			if err != nil {
 				return err
 			}
-
-			return store.InfoCmd(ctx, o, s)
+			
+			for _, allowed := range allowedValues {
+				if o.TypeFilter == allowed {
+					return store.InfoCmd(ctx, o, s)
+				}
+			}
+			return fmt.Errorf("type must be one of %v", allowedValues)
 		},
 	}
 	o.AddFlags(cmd)


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
* adjustment made for issue https://github.com/rancherfederal/hauler/issues/137

**What is the current behavior?**
* `hauler store info` returns everything in the store/haul.

**What is the new behavior (if this is a feature change)?**
* `hauler store info` allows for `-t / --type` flag that accepts `image`, `chart`, or `file`

**Does this PR introduce a breaking change?**
* <!-- What changes might users need to make in their application due to this PR? -->

**Other information**:
* <!-- Any additional information -->