### PR TITLE
Store fileserver

### DIFF
--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -112,7 +112,7 @@ func addStoreServe() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "serve",
-		Short: "Expose the content of a local store through an OCI compliant server",
+		Short: "Expose the content of a local store through an OCI compliant registry or file server",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -108,12 +108,28 @@ func addStoreLoad() *cobra.Command {
 }
 
 func addStoreServe() *cobra.Command {
-	o := &store.ServeOpts{RootOpts: rootStoreOpts}
-
 	cmd := &cobra.Command{
 		Use:   "serve",
 		Short: "Expose the content of a local store through an OCI compliant registry or file server",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.AddCommand(
+		addStoreServeRegistry(),
+		addStoreServeFiles(),
+	)
+
+	return cmd
+}
+
+// RegistryCmd serves the embedded registry
+func addStoreServeRegistry() *cobra.Command {
+    o := &store.ServeRegistryOpts{RootOpts: rootStoreOpts}
+	cmd := &cobra.Command{
+        Use:   "registry",
+        Short: "Serve the embedded registry",
+        RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
 			s, err := o.Store(ctx)
@@ -121,12 +137,36 @@ func addStoreServe() *cobra.Command {
 				return err
 			}
 
-			return store.ServeCmd(ctx, o, s)
-		},
-	}
-	o.AddFlags(cmd)
+			return store.ServeRegistryCmd(ctx, o, s)
+        },
+    }
 
-	return cmd
+    o.AddFlags(cmd)
+
+    return cmd
+}
+
+// FileServerCmd serves the file server
+func addStoreServeFiles() *cobra.Command {
+    o := &store.ServeFilesOpts{RootOpts: rootStoreOpts}
+	cmd := &cobra.Command{
+        Use:   "fileserver",
+        Short: "Serve the file server",
+        RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			s, err := o.Store(ctx)
+			if err != nil {
+				return err
+			}
+
+			return store.ServeFilesCmd(ctx, o, s)
+        },
+    }
+
+    o.AddFlags(cmd)
+
+    return cmd
 }
 
 func addStoreSave() *cobra.Command {

--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rancherfederal/hauler/pkg/store"
 
 	"github.com/rancherfederal/hauler/internal/server"
+	"github.com/rancherfederal/hauler/pkg/log"
 )
 
 type ServeOpts struct {
@@ -25,7 +26,8 @@ type ServeOpts struct {
 	Port       int
 	RootDir    string
 	ConfigFile string
-	Daemon     bool
+
+	Files      bool
 
 	storedir string
 }
@@ -33,45 +35,96 @@ type ServeOpts struct {
 func (o *ServeOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	f.IntVarP(&o.Port, "port", "p", 5000, "Port to listen on")
-	f.StringVar(&o.RootDir, "directory", "registry", "Directory to use for registry backend (defaults to '$PWD/registry')")
+	f.BoolVarP(&o.Files, "files", "f", false, "Toggle file server instead of registry")
+	f.IntVarP(&o.Port, "port", "p", 0, "Port to listen on.  Defaults to 5000 for registry and 8080 for file server.")
+	f.StringVar(&o.RootDir, "directory", "", "Directory to use for backend.  Defaults to $PWD/registry for registry and $PWD/store-files for file server.")
 	f.StringVarP(&o.ConfigFile, "config", "c", "", "Path to a config file, will override all other configs")
-	f.BoolVarP(&o.Daemon, "daemon", "d", false, "Toggle serving as a daemon")
+
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if o.Port == 0 {
+			o.Port = getDefaultPort(o.Files)
+		}
+		if o.RootDir == "" {
+			o.RootDir = getDefaultDirectory(o.Files)
+		}
+		return nil
+	}
+}
+
+func getDefaultPort(files bool) int {
+	if files {
+		return 8080
+	}
+	return 5000
+}
+
+func getDefaultDirectory(files bool) string {
+	if files {
+		return "store-files"
+	}
+	return "registry"
 }
 
 // ServeCmd serves the embedded registry almost identically to how distribution/v3 does it
 func ServeCmd(ctx context.Context, o *ServeOpts, s *store.Layout) error {
+	l := log.FromContext(ctx)
 	ctx = dcontext.WithVersion(ctx, version.Version)
 
-	tr := server.NewTempRegistry(ctx, o.RootDir)
-	if err := tr.Start(); err != nil {
-		return err
-	}
-
-	opts := &CopyOpts{}
-	if err := CopyCmd(ctx, opts, s, "registry://"+tr.Registry()); err != nil {
-		return err
-	}
-
-	tr.Close()
-
-	cfg := o.defaultConfig()
-	if o.ConfigFile != "" {
-		ucfg, err := loadConfig(o.ConfigFile)
+	if o.Files {
+		opts := &CopyOpts{}
+		if err := CopyCmd(ctx, opts, s, "dir://"+o.RootDir); err != nil {
+			return err
+		}
+		
+		cfg := server.FileConfig{
+			Root: o.RootDir,
+			Port: o.Port,
+		}
+	
+		f, err := server.NewFile(ctx, cfg)
 		if err != nil {
 			return err
 		}
-		cfg = ucfg
+		
+		l.Infof("starting file server on port [%d]", o.Port)
+		if err := f.ListenAndServe(); err != nil {
+			return err
+		}
+
+	} else { // start registry
+
+		tr := server.NewTempRegistry(ctx, o.RootDir)
+		if err := tr.Start(); err != nil {
+			return err
+		}
+
+		opts := &CopyOpts{}
+		if err := CopyCmd(ctx, opts, s, "registry://"+tr.Registry()); err != nil {
+			return err
+		}
+
+		tr.Close()
+
+		cfg := o.defaultConfig()
+		if o.ConfigFile != "" {
+			ucfg, err := loadConfig(o.ConfigFile)
+			if err != nil {
+				return err
+			}
+			cfg = ucfg
+		}
+
+		l.Infof("starting registry on port [%d]", o.Port)
+		r, err := server.NewRegistry(ctx, cfg)
+		if err != nil {
+			return err
+		}
+		
+		if err = r.ListenAndServe(); err != nil {
+			return err
+		}
 	}
 
-	r, err := server.NewRegistry(ctx, cfg)
-	if err != nil {
-		return err
-	}
-
-	if err = r.ListenAndServe(); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/internal/server/file.go
+++ b/internal/server/file.go
@@ -21,8 +21,7 @@ type FileConfig struct {
 // TODO: Better configs
 func NewFile(ctx context.Context, cfg FileConfig) (Server, error) {
 	r := mux.NewRouter()
-	r.Handle("/", handlers.LoggingHandler(os.Stdout, http.FileServer(http.Dir(cfg.Root))))
-
+	r.PathPrefix("/").Handler(handlers.LoggingHandler(os.Stdout, http.StripPrefix("/", http.FileServer(http.Dir(cfg.Root)))))
 	if cfg.Root == "" {
 		cfg.Root = "."
 	}


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
* Currently, `hauler store serve` only supports serving an OCI compatible registry.  This change implements an additional option to serve a traditional file server for files and charts that have been added to the local haul/store.

**What is the current behavior?**
* the `hauler store serve` command is only for serving a registry.
```
❯ hauler store serve -h   
Expose the content of a local store through an OCI compliant server

Usage:
  hauler store serve [flags]

Flags:
  -c, --config string      Path to a config file, will override all other configs
  -d, --daemon             Toggle serving as a daemon
      --directory string   Directory to use for registry backend (defaults to '$PWD/registry') (default "registry")
  -h, --help               help for serve
  -p, --port int           Port to listen on (default 5000)

Global Flags:
      --cache string       Location of where to store cache data (defaults to $XDG_CACHE_DIR/hauler)
  -l, --log-level string    (default "info")
  -s, --store string       Location to create store at (default "store") 
```

**What is the new behavior (if this is a feature change)?**
* added new subcommands for differentiating a registry or a file server.
```
❯ hauler store serve registry -h
Serve the embedded registry

Usage:
  hauler store serve registry [flags]

Flags:
  -c, --config string      Path to a config file, will override all other configs
      --directory string   Directory to use for backend.  Defaults to $PWD/registry (default "registry")
  -h, --help               help for registry
  -p, --port int           Port to listen on. (default 5000)

Global Flags:
      --cache string       Location of where to store cache data (defaults to $XDG_CACHE_DIR/hauler)
  -l, --log-level string    (default "info")
  -s, --store string       Location to create store at (default "store")
```
and

```
❯ hauler store serve fileserver -h 
Serve the file server

Usage:
  hauler store serve fileserver [flags]

Flags:
      --directory string   Directory to use for backend.  Defaults to $PWD/store-files (default "store-files")
  -h, --help               help for fileserver
  -p, --port int           Port to listen on. (default 8080)

Global Flags:
      --cache string       Location of where to store cache data (defaults to $XDG_CACHE_DIR/hauler)
  -l, --log-level string    (default "info")
  -s, --store string       Location to create store at (default "store")
```

**Does this PR introduce a breaking change?**
* `hauler store serve` no longer starts a registry without the added `registry` subcommand.

**Other information**:
* <!-- Any additional information -->