### PR TITLE
updated archive default name

### DIFF
--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -19,7 +19,7 @@ type SaveOpts struct {
 func (o *SaveOpts) AddArgs(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	f.StringVarP(&o.FileName, "filename", "f", "pkg.tar.zst", "Name of archive")
+	f.StringVarP(&o.FileName, "filename", "f", "haul.tar.zst", "Name of archive")
 }
 
 // SaveCmd


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
* Updated the archive default name from `pkg.tar.zst` to `haul.tar.zst` to match the messaging and branding of Hauler... https://rancherfederal.github.io/hauler-docs/docs/core-concepts

**What is the current behavior?**
* Default name of the archive is `pkg.tar.zst`

**What is the new behavior (if this is a feature change)?**
* Default name of the archive is `haul.tar.zst`

**Does this PR introduce a breaking change?**
* No

**Other information**:
* No