### PR TITLE
Add `--platform` flag to image processes and RGS flavored cosign setup improvement.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           distribution: goreleaser
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist -p 1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -27,6 +27,7 @@ jobs:
           go-version: 1.21.x
       - name: Run Unit Tests
         run: |
+          mkdir -p cmd/hauler/binaries
           touch cmd/hauler/binaries/dummy.txt
           go test -race -covermode=atomic -coverprofile=coverage.out ./pkg/... ./internal/... ./cmd/...
       - name: On Failure, Launch Debug Session

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -27,6 +27,7 @@ jobs:
           go-version: 1.21.x
       - name: Run Unit Tests
         run: |
+          touch cmd/hauler/binaries/dummy.txt
           go test -race -covermode=atomic -coverprofile=coverage.out ./pkg/... ./internal/... ./cmd/...
       - name: On Failure, Launch Debug Session
         if: ${{ failure() }}

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ tmp/
 bin/
 /store/
 /registry/
+cmd/hauler/binaries

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,9 +3,11 @@ before:
   hooks:
     - go mod tidy
     - go mod download
+    - rm -rf cmd/hauler/binaries
 
 env:
   - vpkg=github.com/rancherfederal/hauler/internal/version
+  - cosign_version=v2.2.2+carbide.1
 
 builds:
   - main: cmd/hauler/main.go
@@ -18,6 +20,12 @@ builds:
       - arm64
     ldflags:
       - -s -w -X {{ .Env.vpkg }}.gitVersion={{ .Version }} -X {{ .Env.vpkg }}.gitCommit={{ .ShortCommit }} -X {{ .Env.vpkg }}.gitTreeState={{if .IsGitDirty}}dirty{{else}}clean{{end}} -X {{ .Env.vpkg }}.buildDate={{ .Date }}
+    hooks:
+      pre:
+        - mkdir -p cmd/hauler/binaries
+        - wget -P cmd/hauler/binaries/ https://github.com/rancher-government-carbide/cosign/releases/download/{{ .Env.cosign_version }}/cosign-{{ .Os }}-{{ .Arch }}{{ if eq .Os "windows" }}.exe{{ end }}
+      post:
+        - rm -rf cmd/hauler/binaries
     env:
       - CGO_ENABLED=0
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
 
 env:
   - vpkg=github.com/rancherfederal/hauler/internal/version
-  - cosign_version=v2.2.2+carbide.1
+  - cosign_version=v2.2.2+carbide.2
 
 builds:
   - main: cmd/hauler/main.go

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ BUILD_OS=darwin
 BUILD_ARCH=arm64 
 GO_FILES=$(shell go list ./... | grep -v /vendor/)
 
-COSIGN_VERSION=v2.2.2+carbide.1
+COSIGN_VERSION=v2.2.2+carbide.2
 
 BUILD_VERSION=$(shell cat VERSION)
 BUILD_TAG=$(BUILD_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,7 @@
 SHELL:=/bin/bash
-BUILD_OS=darwin
-BUILD_ARCH=arm64 
 GO_FILES=$(shell go list ./... | grep -v /vendor/)
 
 COSIGN_VERSION=v2.2.2+carbide.2
-
-BUILD_VERSION=$(shell cat VERSION)
-BUILD_TAG=$(BUILD_VERSION)
 
 .SILENT:
 
@@ -15,9 +10,9 @@ all: fmt vet install test
 build:
 	rm -rf cmd/hauler/binaries;\
 	mkdir -p cmd/hauler/binaries;\
-    wget -P cmd/hauler/binaries/ https://github.com/rancher-government-carbide/cosign/releases/download/$(COSIGN_VERSION)/cosign-$(BUILD_OS)-$(BUILD_ARCH);\
+    wget -P cmd/hauler/binaries/ https://github.com/rancher-government-carbide/cosign/releases/download/$(COSIGN_VERSION)/cosign-$(shell go env GOOS)-$(shell go env GOARCH);\
 	mkdir bin;\
-	GOENV=GOARCH=$(BUILD_ARCH) CGO_ENABLED=0 go build -o bin ./cmd/...;\
+	CGO_ENABLED=0 go build -o bin ./cmd/...;\
 
 build-all: fmt vet
 	goreleaser build --rm-dist --snapshot
@@ -25,8 +20,8 @@ build-all: fmt vet
 install:
 	rm -rf cmd/hauler/binaries;\
 	mkdir -p cmd/hauler/binaries;\
-    wget -P cmd/hauler/binaries/ https://github.com/rancher-government-carbide/cosign/releases/download/$(COSIGN_VERSION)/cosign-$(BUILD_OS)-$(BUILD_ARCH);\
-	GOENV=GOARCH=$(BUILD_ARCH) CGO_ENABLED=0 go install ./cmd/...;\
+	wget -P cmd/hauler/binaries/ https://github.com/rancher-government-carbide/cosign/releases/download/$(COSIGN_VERSION)/cosign-$(shell go env GOOS)-$(shell go env GOARCH);\
+	CGO_ENABLED=0 go install ./cmd/...;\
 
 vet:
 	go vet $(GO_FILES)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 SHELL:=/bin/bash
-GO_BUILD_ENV=GOOS=linux GOARCH=amd64 
+BUILD_OS=darwin
+BUILD_ARCH=arm64 
 GO_FILES=$(shell go list ./... | grep -v /vendor/)
+
+COSIGN_VERSION=v2.2.2+carbide.1
 
 BUILD_VERSION=$(shell cat VERSION)
 BUILD_TAG=$(BUILD_VERSION)
@@ -10,14 +13,20 @@ BUILD_TAG=$(BUILD_VERSION)
 all: fmt vet install test
 
 build:
+	rm -rf cmd/hauler/binaries;\
+	mkdir -p cmd/hauler/binaries;\
+    wget -P cmd/hauler/binaries/ https://github.com/rancher-government-carbide/cosign/releases/download/$(COSIGN_VERSION)/cosign-$(BUILD_OS)-$(BUILD_ARCH);\
 	mkdir bin;\
-	GOENV=GOARCH=$(uname -m) CGO_ENABLED=0 go build -o bin ./cmd/...;\
+	GOENV=GOARCH=$(BUILD_ARCH) CGO_ENABLED=0 go build -o bin ./cmd/...;\
 
 build-all: fmt vet
 	goreleaser build --rm-dist --snapshot
 	
 install:
-	GOENV=GOARCH=$(uname -m) CGO_ENABLED=0 go install ./cmd/...;\
+	rm -rf cmd/hauler/binaries;\
+	mkdir -p cmd/hauler/binaries;\
+    wget -P cmd/hauler/binaries/ https://github.com/rancher-government-carbide/cosign/releases/download/$(COSIGN_VERSION)/cosign-$(BUILD_OS)-$(BUILD_ARCH);\
+	GOENV=GOARCH=$(BUILD_ARCH) CGO_ENABLED=0 go install ./cmd/...;\
 
 vet:
 	go vet $(GO_FILES)

--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -61,13 +61,15 @@ func storeFile(ctx context.Context, s *store.Layout, fi v1alpha1.File) error {
 
 type AddImageOpts struct {
 	*RootOpts
-	Name string
-	Key  string
+	Name     string
+	Key      string
+	Platform string
 }
 
 func (o *AddImageOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 	f.StringVarP(&o.Key, "key", "k", "", "(Optional) Path to the key for digital signature verification")
+	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specific platform to save. i.e. linux/amd64. Defaults to all if flag is omitted.")
 }
 
 func AddImageCmd(ctx context.Context, o *AddImageOpts, s *store.Layout, reference string) error {
@@ -86,10 +88,10 @@ func AddImageCmd(ctx context.Context, o *AddImageOpts, s *store.Layout, referenc
 		l.Infof("signature verified for image [%s]", cfg.Name)
 	}
 
-	return storeImage(ctx, s, cfg)
+	return storeImage(ctx, s, cfg, o.Platform)
 }
 
-func storeImage(ctx context.Context, s *store.Layout, i v1alpha1.Image) error {
+func storeImage(ctx context.Context, s *store.Layout, i v1alpha1.Image, platform string) error {
 	l := log.FromContext(ctx)
 
 	r, err := name.ParseReference(i.Name)
@@ -97,7 +99,7 @@ func storeImage(ctx context.Context, s *store.Layout, i v1alpha1.Image) error {
 		return err
 	}
 
-	err = cosign.SaveImage(ctx, s, r.Name())
+	err = cosign.SaveImage(ctx, s, r.Name(), platform)
 	if err != nil {
 		return err
 	}

--- a/cmd/hauler/main.go
+++ b/cmd/hauler/main.go
@@ -3,10 +3,15 @@ package main
 import (
 	"context"
 	"os"
+	"embed"
 
 	"github.com/rancherfederal/hauler/cmd/hauler/cli"
+	"github.com/rancherfederal/hauler/pkg/cosign"
 	"github.com/rancherfederal/hauler/pkg/log"
 )
+
+//go:embed binaries/*
+var binaries embed.FS
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -15,6 +20,11 @@ func main() {
 	logger := log.NewLogger(os.Stdout)
 	ctx = logger.WithContext(ctx)
 
+	// ensure cosign binary is available
+	if err := cosign.EnsureBinaryExists(ctx, binaries); err != nil {
+		logger.Errorf("%v", err)
+	}
+	
 	if err := cli.New().ExecuteContext(ctx); err != nil {
 		logger.Errorf("%v", err)
 	}

--- a/pkg/apis/hauler.cattle.io/v1alpha1/image.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha1/image.go
@@ -24,4 +24,8 @@ type Image struct {
 	// Path is the path to the cosign public key used for verifying image signatures
 	//Key string `json:"key,omitempty"`
 	Key string `json:"key"`
+
+	// Platform of the image to be pulled.  If not specified, all platforms will be pulled.
+	//Platform string `json:"key,omitempty"`
+	Platform string `json:"platform"`
 }

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -211,8 +211,6 @@ func EnsureBinaryExists(ctx context.Context, bin embed.FS) (error) {
 
 // getCosignPath returns the binary path
 func getCosignPath(ctx context.Context) (string, error) {
-	l := log.FromContext(ctx)
-
 	// Get the current user's information
 	currentUser, err := user.Current()
 	if err != nil {
@@ -231,7 +229,6 @@ func getCosignPath(ctx context.Context) (string, error) {
         if err := os.MkdirAll(haulerDir, 0755); err != nil {
             return "", fmt.Errorf("Error creating .hauler directory: %v\n", err)
         }
-        l.Debugf("Created .hauler directory at: %s", haulerDir)
     }
 
 	// Determine the binary name.


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
* Allows hauler to pull and store specific image platforms/architectures.
* Improves setup of the RGS forked cosign binary.

**What is the current behavior?**
* Currently the default behavior of Hauler pulling images is inherited from cosign, and that's to pull everything when it writes to local disk.
* The process of setting up cosign in the background is clunky.

**What is the new behavior (if this is a feature change)?**
* Added a `--platform` flag to ...
   * `hauler store image add <image> --platform linux/amd64` 
   * `hauler store sync <stuff.yaml> --platform linux/amd64`.
* Hauler manifest have the ability to specify/override the platform for individual images with the sync flag being able to apply a blanket platform.
```
apiVersion: content.hauler.cattle.io/v1alpha1
kind: Images
metadata:
  name: rancher-airgap-images-rancher-minimal
spec:
  images:
    - name: rancher/mirrored-nginx-ingress-controller-defaultbackend:1.5-rancher1
      platform: linux/amd64
    - name: rancher/mirrored-calico-cni:v3.26.1
      platform: linux/amd64
```

* Example `hauler store info` after using the platform flag.

![image](https://github.com/rancherfederal/hauler/assets/42001113/4f903fcb-d546-417d-b352-edbe574b79cc)

* The cosign binary has an improved workflow for being deployed into `<user home>/.hauler` that flows better when dealing with an air-gap situation.

**Does this PR introduce a breaking change?**
* The default behavior without the flag remains the same.
* `hauler store info` has renamed `Arch` to `Platform`

**Other information**:
* <!-- Any additional information -->