### PR TITLE
release process checks tag to determine pre-release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,6 +5,9 @@ before:
     - go mod download
     - rm -rf cmd/hauler/binaries
 
+release:
+  prerelease: auto
+
 env:
   - vpkg=github.com/rancherfederal/hauler/internal/version
   - cosign_version=v2.2.2+carbide.2


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
* Add the ability to check the tag to determine pre-prelease.

**What is the current behavior?**
* Release behavior is full release by default which deploys our RCs to our homebrew tap.  (which we don't want)

**What is the new behavior (if this is a feature change)?**
* goreleaser config validates tag semver to determine pre-release or full release.

**Does this PR introduce a breaking change?**
* Nope

**Other information**:
* <!-- Any additional information -->