### PR TITLE
image spec manifest annotations - key/platform/registry

### DIFF
--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -51,4 +51,6 @@ const (
 	KindAnnotation     = "dev.cosignproject.cosign/image"
 
 	CarbideRegistry = "rgcrprod.azurecr.us"
+	ImageAnnotationKey = "hauler.dev/key"
+	ImageAnnotationPlatform = "hauler.dev/platform"
 )

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -53,4 +53,5 @@ const (
 	CarbideRegistry = "rgcrprod.azurecr.us"
 	ImageAnnotationKey = "hauler.dev/key"
 	ImageAnnotationPlatform = "hauler.dev/platform"
+	ImageAnnotationRegistry = "hauler.dev/registry"
 )

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -60,7 +60,7 @@ func SaveImage(ctx context.Context, s *store.Layout, ref string, platform string
 		if err != nil {
 			if strings.Contains(string(output), "specified reference is not a multiarch image") {
 				l.Infof(fmt.Sprintf("specified image [%s] is not a multiarch image.  (choosing default)", ref))
-			    // Rerun the command without the platform flag
+				// Rerun the command without the platform flag
 				cmd = exec.Command(cosignBinaryPath, "save", ref, "--dir", s.Root)
 				output, err = cmd.CombinedOutput()
 				if err != nil {

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -43,6 +43,7 @@ func VerifySignature(ctx context.Context, s *store.Layout, keyPath string, ref s
 
 // SaveImage saves image and any signatures/attestations to the store.
 func SaveImage(ctx context.Context, s *store.Layout, ref string, platform string) error {
+	l := log.FromContext(ctx)
 	operation := func() error {
 		cosignBinaryPath, err := getCosignPath(ctx)
 		if err != nil {
@@ -58,7 +59,8 @@ func SaveImage(ctx context.Context, s *store.Layout, ref string, platform string
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			if strings.Contains(string(output), "specified reference is not a multiarch image") {
-				// Rerun the command without the platform flag
+				l.Infof(fmt.Sprintf("specified image [%s] is not a multiarch image.  (choosing default)", ref))
+			    // Rerun the command without the platform flag
 				cmd = exec.Command(cosignBinaryPath, "save", ref, "--dir", s.Root)
 				output, err = cmd.CombinedOutput()
 				if err != nil {

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -59,7 +59,7 @@ func SaveImage(ctx context.Context, s *store.Layout, ref string, platform string
 		output, err := cmd.CombinedOutput()
 		if err != nil {
 			if strings.Contains(string(output), "specified reference is not a multiarch image") {
-				l.Infof(fmt.Sprintf("specified image [%s] is not a multiarch image.  (choosing default)", ref))
+				l.Debugf(fmt.Sprintf("specified image [%s] is not a multiarch image.  (choosing default)", ref))
 				// Rerun the command without the platform flag
 				cmd = exec.Command(cosignBinaryPath, "save", ref, "--dir", s.Root)
 				output, err = cmd.CombinedOutput()


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [ ] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
* Allows for the use of key/platform/registry annotations for the image spec of a Hauler manifest.  This gives users the ability to provide global overrides without the use of specifying flags via the CLI. 
```
apiVersion: content.hauler.cattle.io/v1alpha1
kind: Images
metadata:
  name: <name>
  annotations:
    hauler.dev/key: <cosign public key>
    hauler.dev/platform:<platform>
    hauler.dev/registry: <registry>
```

Currently, the flags from the CLI have a global effect on any image UNLESS it has a (key/platform) specified on the individual image. Individual image key/platform takes precedence.

Moving forward, if I have `hauler.dev/key` and/or `hauler.dev/platform` at the annotation level, it would work just like the CLI flag and globally apply for everything except individual images specifying otherwise.  Just like above.

If you just so happen to provide both an annotation AND the CLI flag for the same thing, the CLI flag wins.

As for the `hauler.dev/registry` annotation, it will apply globally unless the provided image reference already has a registry specified in its name.

**What is the current behavior?**
* The only way to specify a global overrides to Hauler manifest is via the CLI flags.

**What is the new behavior (if this is a feature change)?**
* Allows for the same functionality but via a declarative approach.


**Does this PR introduce a breaking change?**
* No

**Other information**:
* <!-- Any additional information -->