### PR TITLE
update to add size totals and cosign artifacts to the `info` command

### DIFF
--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -196,7 +196,7 @@ func addStoreSave() *cobra.Command {
 func addStoreInfo() *cobra.Command {
 	o := &store.InfoOpts{RootOpts: rootStoreOpts}
 
-	var allowedValues = []string{"image", "chart", "file", "all"}
+	var allowedValues = []string{"image", "chart", "file", "sigs", "atts", "sbom", "all"}
 
 	cmd := &cobra.Command{
 		Use:     "info",


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
* Adds a size total to the bottom on the `hauler store info` table.
* Adds any cosign bits (aka sigs, atts, and sbom) to the table / json that may make up that total if they exist.

**What is the current behavior?**
* No size total or visibility into the cosign bits.

**What is the new behavior (if this is a feature change)?**
* `hauler store info` now includes cosign bits and a size total.

![image](https://github.com/rancherfederal/hauler/assets/42001113/3fb1f6f3-e491-4dd1-8bd0-8cc1e2e84385)

**Does this PR introduce a breaking change?**
* N/A unless you are doing stuff with the json output and weren't expecting the extra cosign artifacts.

**Other information**:
* <!-- Any additional information -->