### PR TITLE
add login command

### DIFF
--- a/cmd/hauler/cli/cli.go
+++ b/cmd/hauler/cli/cli.go
@@ -32,6 +32,7 @@ func New() *cobra.Command {
 
 	// Add subcommands
 	addDownload(cmd)
+	addLogin(cmd)
 	addStore(cmd)
 	addServe(cmd)
 	addVersion(cmd)

--- a/cmd/hauler/cli/login.go
+++ b/cmd/hauler/cli/login.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"os"
+	"io"
+	"fmt"
+	"github.com/spf13/cobra"
+
+	"oras.land/oras-go/pkg/content"
+
+	"github.com/rancherfederal/hauler/pkg/cosign"
+)
+
+type Opts struct {
+	Username  string
+	Password  string
+	PasswordStdin bool
+}
+
+func (o *Opts) AddArgs(cmd *cobra.Command) {
+	f := cmd.Flags()
+	f.StringVarP(&o.Username, "username", "u", "", "Username")
+	f.StringVarP(&o.Password, "password", "p", "", "Password")
+	f.BoolVarP(&o.PasswordStdin, "password-stdin", "", false, "Take the password from stdin")
+}
+
+func addLogin(parent *cobra.Command) {
+	o := &Opts{}
+
+	cmd := &cobra.Command{
+		Use:   "login",
+		Short: "Log in to a registry",
+		Example: `
+# Log in to reg.example.com
+hauler login reg.example.com -u bob -p haulin`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, arg []string) error {
+			ctx := cmd.Context()
+
+			if o.PasswordStdin {
+				contents, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return err
+				}
+				o.Password = strings.TrimSuffix(string(contents), "\n")
+				o.Password = strings.TrimSuffix(o.Password, "\r")
+			}
+			
+			if o.Username == "" && o.Password == "" {
+				return fmt.Errorf("username and password required")
+			}
+
+			return login(ctx, o, arg[0])
+		},
+	}
+	o.AddArgs(cmd)
+
+	parent.AddCommand(cmd)
+}
+
+func login(ctx context.Context, o *Opts, registry string) error {
+	ropts := content.RegistryOptions{
+		Username:  o.Username,
+		Password:  o.Password,
+	}
+
+	err := cosign.RegistryLogin(ctx, nil, registry, ropts)
+	if err != nil {
+		return err
+	}
+	
+	return nil
+}

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -140,17 +140,18 @@ func LoadImages(ctx context.Context, s *store.Layout, registry string, ropts con
 
 // RegistryLogin - performs cosign login
 func RegistryLogin(ctx context.Context, s *store.Layout, registry string, ropts content.RegistryOptions) error {
+	log := log.FromContext(ctx)
 	cosignBinaryPath, err := getCosignPath(ctx)
 	if err != nil {
 		return err
 	}
 
 	cmd := exec.Command(cosignBinaryPath, "login", registry, "-u", ropts.Username, "-p", ropts.Password)
-
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("error logging into registry: %v, output: %s", err, output)
 	}
+	log.Infof(strings.Trim(string(output), "\n"))
 
 	return nil
 }


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
* adds login command.

**What is the current behavior?**
* Currently, before dealing with authenticated registries via `hauler store add/sync` you need to do a `docker/cosign login` prior to issuing those commands. 

**What is the new behavior (if this is a feature change)?**
* `hauler login` has been added meaning you still have to run a login command, but now it's just part of the hauler toolset.
```
❯ hauler login harbor.amartin.cloud -u <user> -p <password>                                                                                                                                                                                                                                                    
4:03PM INF logged in via /Users/amartin/.docker/config.json
```

![image](https://github.com/rancherfederal/hauler/assets/42001113/977468ea-abf5-4897-b348-1a966547f9b8)

**Does this PR introduce a breaking change?**
* Shouldn't.

**Other information**:
* <!-- Any additional information -->