### PR TITLE
Add color and systemctl install for using hauler to serve images/files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,7 @@ esac
 
 if [ "$platform" == linux ]; then
 # create hauler dir
-mkdir /opt/hauler
+if [ ! -d /opt/hauler ]; then mkdir /opt/hauler ; fi
 
 # add systemd file
 cat << EOF > /etc/systemd/system/hauler@.service
@@ -185,9 +185,10 @@ info "Successfully Installed at /usr/local/bin/hauler"
 verbose "- Hauler v${version} is now available for use!"
 
 # display systemd message
-verbose "- $BLUE'systemctl start hauler@regsitry'$NO_COLOR or $BLUE'systemctl start hauler@fileserver'$NO_COLOR is available"
-verbose "    cd to /opt/hauler/ and create a store here with the name $BLUE'store'$NO_COLOR"
-
+verbose "- Systemd servies are available"
+verbose "  cd to /opt/hauler/ and use the default store named $BLUE'store'$NO_COLOR."
+verbose "- Start registry service - $BLUE'systemctl start hauler@regsitry'$NO_COLOR."
+verbose "- Start fileserver service - $BLUE'systemctl start hauler@fileserver'$NO_COLOR."
 
 # display hauler docs message
 info "Documentation:$BLUE https://hauler.dev $NO_COLOR" && echo


### PR DESCRIPTION
Add color and systemctl install for using hauler to serve images/files

**Please check below, if the PR fulfills these requirements:**
- [X] The commit message follows the guidelines.
- [X] Tests for the changes have been added (for bug fixes / features).
- [X] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
Adding systemd logic

**What is the current behavior?**
N/A

**What is the new behavior (if this is a feature change)?**
adds systemd file for starting hauler as a daemon
- Start registry service - 'systemctl start hauler@regsitry'.
- Start fileserver service - 'systemctl start hauler@fileserver'.
- 

**Does this PR introduce a breaking change?**
Nope

**Other information**:
cute animal picture.
![360_F_643119209_iLHJkoQExXcgYYQw0zYKurptxQXAAjlr](https://github.com/rancherfederal/hauler/assets/3177276/3c426205-2633-4154-9968-1e44161242fb)
