### PR TITLE
Exit with status code 1 if cosign is not configured

### DIFF
--- a/cmd/hauler/main.go
+++ b/cmd/hauler/main.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"os"
 	"embed"
+	"os"
 
 	"github.com/rancherfederal/hauler/cmd/hauler/cli"
 	"github.com/rancherfederal/hauler/pkg/cosign"
@@ -23,8 +23,9 @@ func main() {
 	// ensure cosign binary is available
 	if err := cosign.EnsureBinaryExists(ctx, binaries); err != nil {
 		logger.Errorf("%v", err)
+		os.Exit(1)
 	}
-	
+
 	if err := cli.New().ExecuteContext(ctx); err != nil {
 		logger.Errorf("%v", err)
 		cancel()


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] The commit message follows the guidelines.
- [ ] Tests for the changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).


**What kind of change does this PR introduce?**
* Fails early if cosign is not available. For reference: https://github.com/rancherfederal/hauler/issues/185

**What is the current behavior?**
* If cosign is not properly configured, Hauler will proceed the execution and fail at a later stage:

```
8:16AM ERR Error: open binaries/cosign-linux-amd64: file does not exist

8:16AM INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Images] to store
8:16AM ERR Error (attempt 1/3): error adding image to store: fork/exec /root/.hauler/cosign: no such file or directory, output:
8:16AM ERR Error (attempt 2/3): error adding image to store: fork/exec /root/.hauler/cosign: no such file or directory, output:
8:16AM ERR Error (attempt 3/3): error adding image to store: fork/exec /root/.hauler/cosign: no such file or directory, output:
Error: operation failed after 3 attempts
Usage:
  hauler store sync [flags]
```

**What is the new behavior (if this is a feature change)?**
* Hauler will abort execution if cosign is not found / stored at the necessary path.

**Does this PR introduce a breaking change?**
* No.