### PR TITLE
split hauler login into registry and helm-repo

### DIFF
--- a/cmd/hauler/cli/login.go
+++ b/cmd/hauler/cli/login.go
@@ -1,40 +1,48 @@
 package cli
 
 import (
-	"context"
 	"strings"
 	"os"
 	"io"
 	"fmt"
 	"github.com/spf13/cobra"
 
-	"oras.land/oras-go/pkg/content"
-
-	"github.com/rancherfederal/hauler/pkg/cosign"
+	"github.com/rancherfederal/hauler/cmd/hauler/cli/login"
 )
 
-type Opts struct {
-	Username  string
-	Password  string
-	PasswordStdin bool
-}
-
-func (o *Opts) AddArgs(cmd *cobra.Command) {
-	f := cmd.Flags()
-	f.StringVarP(&o.Username, "username", "u", "", "Username")
-	f.StringVarP(&o.Password, "password", "p", "", "Password")
-	f.BoolVarP(&o.PasswordStdin, "password-stdin", "", false, "Take the password from stdin")
-}
-
 func addLogin(parent *cobra.Command) {
-	o := &Opts{}
-
 	cmd := &cobra.Command{
 		Use:   "login",
-		Short: "Log in to a registry",
+		Short: "Log in to a registry or helm repo",
+		Aliases: []string{"l"},
 		Example: `
-# Log in to reg.example.com
-hauler login reg.example.com -u bob -p haulin`,
+# authenticate to registry reg.example.com
+hauler login registry reg.example.com -u bob -p haulin
+
+# authenticate to a helm repo
+hauler login helm <chart-name> https://chart.repo.com -u bob -p haulin`,
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, arg []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(
+		addLoginRegistry(),
+		addLoginHelm(),
+	)
+
+	parent.AddCommand(cmd)
+}
+
+func addLoginRegistry() *cobra.Command {
+	o := &login.RegistryOpts{}
+
+	cmd := &cobra.Command{
+		Use:     "registry",
+		Short:   "Log into an authenticated registry",
+		Aliases: []string{"r"},
+		Example: `hauler login registry reg.example.com -u bob -p haulin`,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, arg []string) error {
 			ctx := cmd.Context()
@@ -52,24 +60,53 @@ hauler login reg.example.com -u bob -p haulin`,
 				return fmt.Errorf("username and password required")
 			}
 
-			return login(ctx, o, arg[0])
+			return login.RegistryLoginCmd(ctx, o, arg[0])
 		},
 	}
 	o.AddArgs(cmd)
 
-	parent.AddCommand(cmd)
+	return cmd
 }
 
-func login(ctx context.Context, o *Opts, registry string) error {
-	ropts := content.RegistryOptions{
-		Username:  o.Username,
-		Password:  o.Password,
-	}
+func addLoginHelm() *cobra.Command {
+	o := &login.HelmOpts{}
 
-	err := cosign.RegistryLogin(ctx, nil, registry, ropts)
-	if err != nil {
-		return err
+	cmd := &cobra.Command{
+		Use:     "helm-repo [name] [url]",
+		Short:   "Authentication info for a helm repo",
+		Aliases: []string{"h"},
+		Example: `hauler login helm-repo my-helm-repo https://chart.repo.com -u bob -p haulin`,
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, arg []string) error {
+			ctx := cmd.Context()
+
+			name := arg[0]
+			url := arg[1]
+
+			if o.PasswordStdin {
+				contents, err := io.ReadAll(os.Stdin)
+				if err != nil {
+					return err
+				}
+				o.Password = strings.TrimSuffix(string(contents), "\n")
+				o.Password = strings.TrimSuffix(o.Password, "\r")
+			}
+			
+			if o.Username == "" || o.Password == "" {
+				return fmt.Errorf("both username and password are required")
+			}
+
+			// Check if the repo name is legal
+			if strings.Contains(name, "/") {
+				return fmt.Errorf("repository name (%s) contains '/', please specify a different name without '/'", name)
+			}
+
+			return login.HelmLoginCmd(ctx, o, name, url)
+		},
 	}
-	
-	return nil
+	o.AddArgs(cmd)
+
+	return cmd
 }
+
+

--- a/cmd/hauler/cli/login/helm.go
+++ b/cmd/hauler/cli/login/helm.go
@@ -1,0 +1,94 @@
+package login
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/rancherfederal/hauler/pkg/log"
+	"helm.sh/helm/v3/pkg/cli"
+	"helm.sh/helm/v3/pkg/getter"
+	"helm.sh/helm/v3/pkg/repo"
+)
+
+type HelmOpts struct {
+	Username string
+	Password string
+	PasswordStdin bool
+	CertFile string
+	KeyFile string
+	CAFile string
+	InsecureSkipTLSverify bool
+	PassCredentialsAll bool
+}
+
+func (o *HelmOpts) AddArgs(cmd *cobra.Command) {
+	f := cmd.Flags()
+
+	f.StringVarP(&o.Username, "username", "u", "", "chart repository username where to locate the requested chart")
+	f.StringVarP(&o.Password, "password", "p", "", "chart repository password where to locate the requested chart")
+	f.BoolVar(&o.PasswordStdin, "password-stdin", false, "Take the password from stdin")
+	f.StringVar(&o.CertFile, "cert-file", "", "identify HTTPS client using this SSL certificate file")
+	f.StringVar(&o.KeyFile, "key-file", "", "identify HTTPS client using this SSL key file")
+	f.StringVar(&o.CAFile, "ca-file", "", "verify certificates of HTTPS-enabled servers using this CA bundle")
+	f.BoolVar(&o.InsecureSkipTLSverify, "insecure-skip-tls-verify", false, "skip tls certificate checks for the chart download")
+	f.BoolVar(&o.PassCredentialsAll, "pass-credentials", false, "pass credentials to all domains")
+}
+
+func HelmLoginCmd(ctx context.Context, o *HelmOpts, repoName string, repoUrl string) error {
+	l := log.FromContext(ctx)
+
+	// Create a new Entry for the repository
+	entry := repo.Entry{
+		Name:     repoName,
+		URL:      repoUrl,
+		Username: o.Username,
+		Password: o.Password,
+		CertFile: o.CertFile,
+		KeyFile: o.KeyFile,
+		CAFile: o.CAFile,
+		InsecureSkipTLSverify: o.InsecureSkipTLSverify,
+		PassCredentialsAll: o.PassCredentialsAll,
+	}
+
+	// Get the settings from the environment
+	settings := cli.New()
+
+	// Create a new RepoFile if it does not exist
+	repoFile := settings.RepositoryConfig
+	l.Debugf(repoFile)
+	if _, err := os.Stat(repoFile); os.IsNotExist(err) {
+		_, err := os.Create(repoFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Load the RepoFile
+	repositories, err := repo.LoadFile(repoFile)
+	if err != nil {
+		return err
+	}
+
+	// validate that the repo is a valid and can be reached with the information provided
+	r, err := repo.NewChartRepository(&entry, getter.All(settings))
+	if err != nil {
+		return err
+	}
+	if _, err := r.DownloadIndexFile(); err != nil {
+		return fmt.Errorf("looks like %s is not a valid chart repository or cannot be reached: %s", repoUrl, err)
+	}
+
+	// Add the new Entry to the RepoFile
+	repositories.Update(&entry)
+
+	// Write the changes to the file
+	err = repositories.WriteFile(repoFile, 0644)
+	if err != nil {
+		return err
+	}
+
+	l.Infof("%s has been added to your repositories", repoName)
+	return nil
+}

--- a/cmd/hauler/cli/login/registry.go
+++ b/cmd/hauler/cli/login/registry.go
@@ -1,0 +1,36 @@
+package login
+
+import (
+	"context"
+	"github.com/spf13/cobra"
+	"oras.land/oras-go/pkg/content"
+
+	"github.com/rancherfederal/hauler/pkg/cosign"
+)
+
+type RegistryOpts struct {
+	Username  string
+	Password  string
+	PasswordStdin bool
+}
+
+func (o *RegistryOpts) AddArgs(cmd *cobra.Command) {
+	f := cmd.Flags()
+	f.StringVarP(&o.Username, "username", "u", "", "Username")
+	f.StringVarP(&o.Password, "password", "p", "", "Password")
+	f.BoolVar(&o.PasswordStdin, "password-stdin", false, "Take the password from stdin")
+}
+
+func RegistryLoginCmd(ctx context.Context, o *RegistryOpts, registry string) error {
+	ropts := content.RegistryOptions{
+		Username:  o.Username,
+		Password:  o.Password,
+	}
+
+	err := cosign.RegistryLogin(ctx, nil, registry, ropts)
+	if err != nil {
+		return err
+	}
+	
+	return nil
+}


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

* In support of issue: https://github.com/rancherfederal/hauler/issues/190

**Types of Changes:**

* feature and breaking change

**Proposed Changes:**

- Hauler login was just for registries but we needed to add support for authenticated helm repos so this PR splits the `hauler login` command into `hauler login registry` and `hauler login helm-repo`.

**Verification/Testing of Changes:**

- crossed two fingers and said some nice words.
- repo info added to helm repositories file that's used by the helm client libraries.

**Additional Context:**

- If you have an existing scripts using `hauler login` they will need to be adjusted accordingly.

```
❯ hauler login registry --help                                                                                                                                                                                                                                                                          
Log into an authenticated registry

Usage:
  hauler login registry [flags]

Aliases:
  registry, r

Examples:
hauler login registry reg.example.com -u bob -p haulin

Flags:
  -h, --help              help for registry
  -p, --password string   Password
      --password-stdin    Take the password from stdin
  -u, --username string   Username

Global Flags:
  -l, --log-level string    (default "info")
```

```
❯ hauler login helm-repo --help                                                                                                                                                                                                                                                                          
Authentication info for a helm repo

Usage:
  hauler login helm-repo [name] [url] [flags]

Aliases:
  helm-repo, h

Examples:
hauler login helm-repo my-helm-repo https://chart.repo.com -u bob -p haulin

Flags:
      --ca-file string             verify certificates of HTTPS-enabled servers using this CA bundle
      --cert-file string           identify HTTPS client using this SSL certificate file
  -h, --help                       help for helm-repo
      --insecure-skip-tls-verify   skip tls certificate checks for the chart download
      --key-file string            identify HTTPS client using this SSL key file
      --pass-credentials           pass credentials to all domains
  -p, --password string            chart repository password where to locate the requested chart
      --password-stdin             Take the password from stdin
  -u, --username string            chart repository username where to locate the requested chart

Global Flags:
  -l, --log-level string    (default "info")
```