### PR TITLE
deprecate misleading cache flag from store

### DIFF
--- a/cmd/hauler/cli/store/flags.go
+++ b/cmd/hauler/cli/store/flags.go
@@ -18,11 +18,13 @@ const (
 
 type RootOpts struct {
 	StoreDir string
+	CacheDir string
 }
 
 func (o *RootOpts) AddArgs(cmd *cobra.Command) {
 	pf := cmd.PersistentFlags()
 	pf.StringVarP(&o.StoreDir, "store", "s", DefaultStoreName, "Location to create store at")
+	pf.StringVar(&o.CacheDir, "cache", "", "(deprecated flag and currently not used)")
 }
 
 func (o *RootOpts) Store(ctx context.Context) (*store.Layout, error) {

--- a/cmd/hauler/cli/store/flags.go
+++ b/cmd/hauler/cli/store/flags.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/rancherfederal/hauler/pkg/layer"
 	"github.com/rancherfederal/hauler/pkg/store"
 	"github.com/spf13/cobra"
 
@@ -15,17 +14,14 @@ import (
 
 const (
 	DefaultStoreName = "store"
-	DefaultCacheDir  = "hauler"
 )
 
 type RootOpts struct {
 	StoreDir string
-	CacheDir string
 }
 
 func (o *RootOpts) AddArgs(cmd *cobra.Command) {
 	pf := cmd.PersistentFlags()
-	pf.StringVar(&o.CacheDir, "cache", "", "Location of where to store cache data (defaults to $XDG_CACHE_DIR/hauler)")
 	pf.StringVarP(&o.StoreDir, "store", "s", DefaultStoreName, "Location to create store at")
 }
 
@@ -48,37 +44,9 @@ func (o *RootOpts) Store(ctx context.Context) (*store.Layout, error) {
 		return nil, err
 	}
 
-	// TODO: Do we want this to be configurable?
-	c, err := o.Cache(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	s, err := store.NewLayout(abs, store.WithCache(c))
+	s, err := store.NewLayout(abs)
 	if err != nil {
 		return nil, err
 	}
 	return s, nil
-}
-
-func (o *RootOpts) Cache(ctx context.Context) (layer.Cache, error) {
-	dir := o.CacheDir
-
-	if dir == "" {
-		// Default to $XDG_CACHE_HOME
-		cachedir, err := os.UserCacheDir()
-		if err != nil {
-			return nil, err
-		}
-
-		abs, _ := filepath.Abs(filepath.Join(cachedir, DefaultCacheDir))
-		if err := os.MkdirAll(abs, os.ModePerm); err != nil {
-			return nil, err
-		}
-
-		dir = abs
-	}
-
-	c := layer.NewFilesystemCache(dir)
-	return c, nil
 }


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- N/A

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bug Fix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- The `--cache` flag under `hauler store` was misleadingly left behind from a much earlier release before introducing cosign for image handling.

- Deprecating to stop confusion as it does absolutely nothing in the current versions of Hauler.  Will remove completely at a later time.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- Flag deprecated...
```
❯ hauler store --help 
Interact with hauler's embedded content store

Usage:
  hauler store [flags]
  hauler store [command]

Aliases:
  store, s

Available Commands:
  add         Add content to store
  copy        Copy all store contents to another OCI registry
  extract     Extract content from the store to disk
  info        Print out information about the store
  load        Load a content store from a store archive
  save        Save a content store to a store archive
  serve       Expose the content of a local store through an OCI compliant registry or file server
  sync        Sync content to the embedded content store

Flags:
      --cache string   (deprecated and currently not used)
  -h, --help           help for store
  -s, --store string   Location to create store at (default "store")

Global Flags:
  -l, --log-level string    (default "info")
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
