### PR TITLE
temp dir override for `hauler store load`

### DIFF
--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -20,11 +20,11 @@ type LoadOpts struct {
 func (o *LoadOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	// On Unix systems, TempDir returns $TMPDIR if non-empty, else /tmp.
-	// On Windows, TempDir uses GetTempPath, returning the first non-empty
+	// On Unix systems, the default is $TMPDIR if non-empty, else /tmp.
+	// On Windows, the default is GetTempPath, returning the first non-empty
 	// value from %TMP%, %TEMP%, %USERPROFILE%, or the Windows directory.
-	// On Plan 9, TempDir returns /tmp.
-	f.StringVarP(&o.TempOverride, "temp", "t", "", "overrides the default directory for temporary files, as returned by your OS.")
+	// On Plan 9, the default is /tmp.
+	f.StringVarP(&o.TempOverride, "tempdir", "t", "", "overrides the default directory for temporary files, as returned by your OS.")
 }
 
 // LoadCmd


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- By default `hauler store load` temporarily copies the contents of its haul to the OS's default TEMP directory in order to maintain an existing store's contents should it exist.
  -  On Unix systems, the default is $TMPDIR if non-empty, else /tmp.
  -  On Windows, the default is GetTempPath, returning the first non-empty
      value from %TMP%, %TEMP%, %USERPROFILE%, or the Windows directory.
  -  On Plan 9, the default is /tmp.

- Added a new flag to `hauler store load` called `--tempdir or -t` that allows the user to override that value if they do not have the ability to modify the ENV that normally controls that.

```
❯  hauler store load --help                                                                                                                                                                                                                                                                               ─╯
Load a content store from a store archive

Usage:
  hauler store load [flags]

Flags:
  -h, --help             help for load
  -t, --tempdir string   overrides the default directory for temporary files, as returned by your OS.

Global Flags:
      --cache string       (deprecated flag and currently not used)
  -l, --log-level string    (default "info")
  -s, --store string       Location to create store at (default "store")
```

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- When overrode via the new flag, the supplied directory is used for temp.
- When omitting the flag, the normal OS temp dir is used just like today.

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
