### PR TITLE
fix logging for files

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -41,8 +41,7 @@ func AddFileCmd(ctx context.Context, o *AddFileOpts, s *store.Layout, reference 
 
 func storeFile(ctx context.Context, s *store.Layout, fi v1alpha1.File) error {
 	l := log.FromContext(ctx)
-	l.Infof("adding 'file' [%s] to the store", fi.Name)
-	
+
 	copts := getter.ClientOptions{
 		NameOverride: fi.Name,
 	}
@@ -53,6 +52,7 @@ func storeFile(ctx context.Context, s *store.Layout, fi v1alpha1.File) error {
 		return err
 	}
 
+	l.Infof("adding 'file' [%s] to the store as [%s]", fi.Path, ref.Name())
 	_, err = s.AddOCI(ctx, f, ref.Name())
 	if err != nil {
 		return err


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [ ] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- The logging for `sync`ing or `add`ing a file to the store depended on supplying a name used for overriding which is obviously optional.  So you would get something like below if you didn't pass the `--name` flag.
```
❯ hauler store add file https://raw.githubusercontent.com/zackbradys/code-templates/main/k8s/yamls/rancher-banner-tssci.yaml  
2024-04-01 12:10:46 INF adding 'file' [] to the store
2024-04-01 12:10:46 INF successfully added 'file' [hauler/rancher-banner-tssci.yaml:latest]
```

With this PR, you get 
```
❯ hauler store add file https://raw.githubusercontent.com/zackbradys/code-templates/main/k8s/yamls/rancher-banner-tssci.yam
2024-04-01 12:17:30 INF adding 'file' [https://raw.githubusercontent.com/zackbradys/code-templates/main/k8s/yamls/rancher-banner-tssci.yaml] to the store
2024-04-01 12:17:30 INF successfully added 'file' [hauler/rancher-banner-tssci.yaml:latest]
```

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- tested via `hauler store add file` and `hauler store sync`

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
