### PR TITLE
fix for dup digest smashing in cosign

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,7 @@ release:
 
 env:
   - vpkg=github.com/rancherfederal/hauler/internal/version
-  - cosign_version=v2.2.3+carbide.1
+  - cosign_version=v2.2.3+carbide.2
 
 builds:
   - main: cmd/hauler/main.go

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL:=/bin/bash
 GO_FILES=$(shell go list ./... | grep -v /vendor/)
 
-COSIGN_VERSION=v2.2.3+carbide.1
+COSIGN_VERSION=v2.2.3+carbide.2
 
 .SILENT:
 


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [ ] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix.  Shared digests are getting smashed in the `index.json` due to a change made in our cosign fork for the last release.  I've reverted that change in a new tag `v2.2.3+carbide.2`.

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Reverted change in our cosign fork that was put into place to keep duplicates out of the `index.json` if you ran the `image add` command twice but that didn't jive well when 2 different images shared layers.  Sticking with the lesser of the 2 evils.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- Tested with the longhorn and mirrored-longhorn images.  (Thanks Brian Durden)

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- specific cosign change - https://github.com/rancher-government-carbide/cosign/commit/49542360ffb5de63f9d2f5856b658651d5538e40
