### PR TITLE
Added some documentation text to sync command

### DIFF
--- a/cmd/hauler/cli/store/sync.go
+++ b/cmd/hauler/cli/store/sync.go
@@ -27,18 +27,18 @@ import (
 
 type SyncOpts struct {
 	*RootOpts
-	ContentFiles []string
-	Key          string
-	Products	 []string
-	Platform	 string
-	Registry	 string
+	ContentFiles    []string
+	Key             string
+	Products        []string
+	Platform        string
+	Registry        string
 	ProductRegistry string
 }
 
 func (o *SyncOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	f.StringSliceVarP(&o.ContentFiles, "files", "f", []string{}, "Path to content files")
+	f.StringSliceVarP(&o.ContentFiles, "files", "f", []string{}, "Path(s) to local content files (Manifests). i.e. '--files ./rke2-files.yml")
 	f.StringVarP(&o.Key, "key", "k", "", "(Optional) Path to the key for signature verification")
 	f.StringSliceVar(&o.Products, "products", []string{}, "Used for RGS Carbide customers to supply a product and version and Hauler will retrieve the images. i.e. '--product rancher=v2.7.6'")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specific platform to save. i.e. linux/amd64. Defaults to all if flag is omitted.")
@@ -70,7 +70,7 @@ func SyncCmd(ctx context.Context, o *SyncOpts, s *store.Layout) error {
 		if err != nil {
 			return err
 		}
-		err = ExtractCmd(ctx, &ExtractOpts{RootOpts: o.RootOpts}, s, fmt.Sprintf("hauler/%s-manifest.yaml:%s", parts[0],tag))
+		err = ExtractCmd(ctx, &ExtractOpts{RootOpts: o.RootOpts}, s, fmt.Sprintf("hauler/%s-manifest.yaml:%s", parts[0], tag))
 		if err != nil {
 			return err
 		}
@@ -151,19 +151,19 @@ func processContent(ctx context.Context, fi *os.File, o *SyncOpts, s *store.Layo
 			}
 			a := cfg.GetAnnotations()
 			for _, i := range cfg.Spec.Images {
-	
+
 				// Check if the user provided a registry.  If a registry is provided in the annotation, use it for the images that don't have a registry in their ref name.
-				if a[consts.ImageAnnotationRegistry] != "" || o.Registry != ""{
-					newRef,_ := reference.Parse(i.Name)
-					
+				if a[consts.ImageAnnotationRegistry] != "" || o.Registry != "" {
+					newRef, _ := reference.Parse(i.Name)
+
 					newReg := o.Registry // cli flag
 					// if no cli flag but there was an annotation, use the annotation.
 					if o.Registry == "" && a[consts.ImageAnnotationRegistry] != "" {
 						newReg = a[consts.ImageAnnotationRegistry]
 					}
-					
+
 					if newRef.Context().RegistryStr() == "" {
-						newRef,err = reference.Relocate(i.Name, newReg)
+						newRef, err = reference.Relocate(i.Name, newReg)
 						if err != nil {
 							return err
 						}
@@ -189,7 +189,7 @@ func processContent(ctx context.Context, fi *os.File, o *SyncOpts, s *store.Layo
 						}
 					}
 					l.Debugf("key for image [%s]", key)
-					
+
 					// verify signature using the provided key.
 					err := cosign.VerifySignature(ctx, s, key, i.Name)
 					if err != nil {
@@ -209,7 +209,7 @@ func processContent(ctx context.Context, fi *os.File, o *SyncOpts, s *store.Layo
 				if i.Platform != "" {
 					platform = i.Platform
 				}
-								
+
 				err = storeImage(ctx, s, i, platform)
 				if err != nil {
 					return err


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- N/A

**Types of Changes:**


- Added some documentation to the `sync` subcommand usage text. Clarified it's usage for local Hauler manifests.  
- Included an example of using the `files` flag similar to `products` flag. 

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Provide clarifying language to the help text for the `sync` subcommand. I missed the `--files` flag my first time through the online Documentation and wanted to see it in the help text for the command.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- Run `hauler store sync --help` to see the changes

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- This is a small change to the usage text of a CLI subcommand. 
