### PR TITLE
Add prepend-path option to store copy command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ all: fmt vet install test
 build:
 	rm -rf cmd/hauler/binaries;\
 	mkdir -p cmd/hauler/binaries;\
-    wget -P cmd/hauler/binaries/ https://github.com/rancher-government-carbide/cosign/releases/download/$(COSIGN_VERSION)/cosign-$(shell go env GOOS)-$(shell go env GOARCH);\
-	mkdir bin;\
+    curl -Lo cmd/hauler/binaries/cosign-$(shell go env GOOS)-$(shell go env GOARCH) https://github.com/rancher-government-carbide/cosign/releases/download/$(COSIGN_VERSION)/cosign-$(shell go env GOOS)-$(shell go env GOARCH);\
+	mkdir -p bin;\
 	CGO_ENABLED=0 go build -o bin ./cmd/...;\
 
 build-all: fmt vet
@@ -20,7 +20,7 @@ build-all: fmt vet
 install:
 	rm -rf cmd/hauler/binaries;\
 	mkdir -p cmd/hauler/binaries;\
-	wget -P cmd/hauler/binaries/ https://github.com/rancher-government-carbide/cosign/releases/download/$(COSIGN_VERSION)/cosign-$(shell go env GOOS)-$(shell go env GOARCH);\
+	curl -Lo cmd/hauler/binaries/cosign-$(shell go env GOOS)-$(shell go env GOARCH) https://github.com/rancher-government-carbide/cosign/releases/download/$(COSIGN_VERSION)/cosign-$(shell go env GOOS)-$(shell go env GOARCH);\
 	CGO_ENABLED=0 go install ./cmd/...;\
 
 vet:

--- a/cmd/hauler/cli/login.go
+++ b/cmd/hauler/cli/login.go
@@ -2,10 +2,11 @@ package cli
 
 import (
 	"context"
-	"strings"
-	"os"
-	"io"
 	"fmt"
+	"io"
+	"os"
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"oras.land/oras-go/pkg/content"
@@ -14,8 +15,8 @@ import (
 )
 
 type Opts struct {
-	Username  string
-	Password  string
+	Username      string
+	Password      string
 	PasswordStdin bool
 }
 
@@ -35,7 +36,7 @@ func addLogin(parent *cobra.Command) {
 		Example: `
 # Log in to reg.example.com
 hauler login reg.example.com -u bob -p haulin`,
-		Args:    cobra.ExactArgs(1),
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, arg []string) error {
 			ctx := cmd.Context()
 
@@ -47,7 +48,7 @@ hauler login reg.example.com -u bob -p haulin`,
 				o.Password = strings.TrimSuffix(string(contents), "\n")
 				o.Password = strings.TrimSuffix(o.Password, "\r")
 			}
-			
+
 			if o.Username == "" && o.Password == "" {
 				return fmt.Errorf("username and password required")
 			}
@@ -62,14 +63,14 @@ hauler login reg.example.com -u bob -p haulin`,
 
 func login(ctx context.Context, o *Opts, registry string) error {
 	ropts := content.RegistryOptions{
-		Username:  o.Username,
-		Password:  o.Password,
+		Username: o.Username,
+		Password: o.Password,
 	}
 
 	err := cosign.RegistryLogin(ctx, nil, registry, ropts)
 	if err != nil {
 		return err
 	}
-	
+
 	return nil
 }

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -1,9 +1,10 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	"helm.sh/helm/v3/pkg/action"
-	"fmt"
 
 	"github.com/rancherfederal/hauler/cmd/hauler/cli/store"
 )
@@ -125,11 +126,11 @@ func addStoreServe() *cobra.Command {
 
 // RegistryCmd serves the embedded registry
 func addStoreServeRegistry() *cobra.Command {
-    o := &store.ServeRegistryOpts{RootOpts: rootStoreOpts}
+	o := &store.ServeRegistryOpts{RootOpts: rootStoreOpts}
 	cmd := &cobra.Command{
-        Use:   "registry",
-        Short: "Serve the embedded registry",
-        RunE: func(cmd *cobra.Command, args []string) error {
+		Use:   "registry",
+		Short: "Serve the embedded registry",
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
 			s, err := o.Store(ctx)
@@ -138,21 +139,21 @@ func addStoreServeRegistry() *cobra.Command {
 			}
 
 			return store.ServeRegistryCmd(ctx, o, s)
-        },
-    }
+		},
+	}
 
-    o.AddFlags(cmd)
+	o.AddFlags(cmd)
 
-    return cmd
+	return cmd
 }
 
 // FileServerCmd serves the file server
 func addStoreServeFiles() *cobra.Command {
-    o := &store.ServeFilesOpts{RootOpts: rootStoreOpts}
+	o := &store.ServeFilesOpts{RootOpts: rootStoreOpts}
 	cmd := &cobra.Command{
-        Use:   "fileserver",
-        Short: "Serve the file server",
-        RunE: func(cmd *cobra.Command, args []string) error {
+		Use:   "fileserver",
+		Short: "Serve the file server",
+		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
 			s, err := o.Store(ctx)
@@ -161,12 +162,12 @@ func addStoreServeFiles() *cobra.Command {
 			}
 
 			return store.ServeFilesCmd(ctx, o, s)
-        },
-    }
+		},
+	}
 
-    o.AddFlags(cmd)
+	o.AddFlags(cmd)
 
-    return cmd
+	return cmd
 }
 
 func addStoreSave() *cobra.Command {
@@ -210,7 +211,7 @@ func addStoreInfo() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			
+
 			for _, allowed := range allowedValues {
 				if o.TypeFilter == allowed {
 					return store.InfoCmd(ctx, o, s)
@@ -230,7 +231,10 @@ func addStoreCopy() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "copy",
 		Short: "Copy all store contents to another OCI registry",
-		Args:  cobra.ExactArgs(1),
+		Example: `
+# Copy OCI artifacts to reg.example.com
+hauler store copy registry://reg.example.com -u bob -p haulin`,
+		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [x] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- https://github.com/rancherfederal/hauler/issues/241

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature
- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Feature: Add a new `--prepend-path` option to the `store copy` command that prepends a string to all artifacts.
- Bugfix: Change `Makefile` to use `curl` instead of `wget` to support platforms without wget installed.
- Feature: Add example to `store copy` command because, in my opinion, `registry://` is not obvious and hard to forget in an environment without docs.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- I verified in my environment that the problem I was running into in #241 is now resolved.

