### PR TITLE
Configure chart commands to use helm clients for OCI and private regi…

### DIFF
--- a/pkg/content/chart/chart_test.go
+++ b/pkg/content/chart/chart_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/mholt/archiver/v3"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"helm.sh/helm/v3/pkg/action"
 
@@ -15,20 +14,12 @@ import (
 	"github.com/rancherfederal/hauler/pkg/content/chart"
 )
 
-var (
-	chartpath = "../../../testdata/rancher-cluster-templates-0.4.4.tgz"
-)
-
 func TestNewChart(t *testing.T) {
 	tmpdir, err := os.MkdirTemp("", "hauler")
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpdir)
-
-	if err := archiver.Unarchive(chartpath, tmpdir); err != nil {
-		t.Fatal(err)
-	}
 
 	type args struct {
 		name string
@@ -43,8 +34,8 @@ func TestNewChart(t *testing.T) {
 		{
 			name: "should create from a chart archive",
 			args: args{
-				name: chartpath,
-				opts: &action.ChartPathOptions{},
+				name: "rancher-cluster-templates-0.4.4.tgz",
+				opts: &action.ChartPathOptions{RepoURL: "../../../testdata"},
 			},
 			want: v1.Descriptor{
 				MediaType: consts.ChartLayerMediaType,


### PR DESCRIPTION
Configure chart commands to use helm clients for OCI and private registry support

**Please check below, if the PR fulfills these requirements:**
- [ ] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

This PR extends the chart implementation to use the existing `helm install` mechanics for chart resolution, primarily to support using OCI references and local `repository.yaml` configs needed for accessing private registries. With these changes, users can define their chart manifests like

```yaml
apiVersion: content.hauler.cattle.io/v1alpha1
kind: Charts
metadata:
  name: hauler-content-charts-example
spec:
  charts:
    # fetch helm chart
    - name: rancher
      repoURL: https://releases.rancher.com/server-charts/stable
    - name: rancher
      repoURL: rancher-stable # From `helm repo add rancher-stable https://releases.rancher.com/server-charts/stable`
      version: 2.8.2
    - name: nginx
      repoURL: oci://registry-1.docker.io/bitnamicharts
```

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

-

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

Create a chart manifest using oci registries and `hauler sync -f oci-hauler.yaml`

```yaml
apiVersion: content.hauler.cattle.io/v1alpha1
kind: Charts
metadata:
  name: hauler-content-charts-example
spec:
  charts:
    - name: nginx
      repoURL: oci://registry-1.docker.io/bitnamicharts
```

Or with `hauler store add chart nginx --repo "oci://registry-1.docker.io/bitnamicharts"`

For local repositories resolution create another file using a local repo alias and `hauler sync -f aliased-hauler.yaml`

```yaml
apiVersion: content.hauler.cattle.io/v1alpha1
kind: Charts
metadata:
  name: hauler-content-charts-example
spec:
  charts:
    - name: rancher
      repoURL: rancher-stable
```

or `hauler store add chart rancher --repo rancher-stable

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

I recently ran into some issues trying to pull charts from a private registry, which I have a local `repositories.yaml` file configured for. It makes sense why using the `repoURL: https://my-private-repo` would 401, but hauler is unable to use the local repositories.yaml config I have which make it difficult to use locally and in CI. Using the helm mechanics though, this config gets read under the hood and as a result picks up OCI support basically for free.
