### PR TITLE
Adding the timeout flag for fileserver command and setting default timeout to 60 seconds

### DIFF
--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -80,6 +80,7 @@ type ServeFilesOpts struct {
 	*RootOpts
 
 	Port    int
+	Timeout int
 	RootDir string
 
 	storedir string
@@ -89,6 +90,7 @@ func (o *ServeFilesOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
 	f.IntVarP(&o.Port, "port", "p", 8080, "Port to listen on.")
+	f.IntVarP(&o.Timeout, "timeout", "t", 60, "Set the http request timeout duration in seconds for both reads and write.")
 	f.StringVar(&o.RootDir, "directory", "fileserver", "Directory to use for backend.  Defaults to $PWD/fileserver")
 }
 
@@ -102,8 +104,9 @@ func ServeFilesCmd(ctx context.Context, o *ServeFilesOpts, s *store.Layout) erro
 	}
 
 	cfg := server.FileConfig{
-		Root: o.RootDir,
-		Port: o.Port,
+		Root:    o.RootDir,
+		Port:    o.Port,
+		Timeout: o.Timeout,
 	}
 
 	f, err := server.NewFile(ctx, cfg)

--- a/internal/server/file.go
+++ b/internal/server/file.go
@@ -12,9 +12,10 @@ import (
 )
 
 type FileConfig struct {
-	Root string
-	Host string
-	Port int
+	Root    string
+	Host    string
+	Port    int
+	Timeout int
 }
 
 // NewFile returns a fileserver
@@ -30,11 +31,15 @@ func NewFile(ctx context.Context, cfg FileConfig) (Server, error) {
 		cfg.Port = 8080
 	}
 
+	if cfg.Timeout == 0 {
+		cfg.Timeout = 60
+	}
+
 	srv := &http.Server{
 		Handler:      r,
 		Addr:         fmt.Sprintf(":%d", cfg.Port),
-		WriteTimeout: 15 * time.Second,
-		ReadTimeout:  15 * time.Second,
+		WriteTimeout: time.Duration(cfg.Timeout) * time.Second,
+		ReadTimeout:  time.Duration(cfg.Timeout) * time.Second,
 	}
 
 	return srv, nil


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [x] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- Issue: #243 
- Documentation PR: [19](https://github.com/rancherfederal/hauler-docs/pull/19) 

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Changing the default fileserver http timeout from 15 seconds to 60 seconds to account for larger files.
- Adding an additional flag to the fileserver command to manipulate the desired timeout. This will allow end users to stipulate the timeout if they require excessively large file transfers or have a slow network connection.
- Proposed new command:
```
Serve the file server

Usage:
  hauler store serve fileserver [flags]

Flags:
      --directory string   Directory to use for backend.  Defaults to $PWD/fileserver (default "fileserver")
  -h, --help               help for fileserver
  -p, --port int           Port to listen on. (default 8080)
  -t, --timeout int        Set the http request timeout duration in seconds for both reads and write. (default 60)

Global Flags:
      --cache string       (deprecated flag and currently not used)
  -l, --log-level string    (default "info")
  -s, --store string       Location to create store at (default "store")
```

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

1. Load a large file into the store.
2. Serve the fileserver with the following flag `--timeout 1`
3. Attempt to curl for the large file and note the immediate timeout after 1 second.
4. Close the fileserver
5. Reserve with either no flag (60 second timeout) or a large timeout `--timeout 300`
6. Attempt to curl for the large file and and note the download proceeds with no issues.

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- Edit: Opened a new PR with signed commits.
- This was a rather simple change that meets both requested ideas from the linked github issue.
1. Extends the default timeout as 15 seconds appears to be too short in some cases.
2. Allows the end user to support their needs with a variable timeout.