### PR TITLE
feat: add readonly flag

### DIFF
--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -25,9 +25,7 @@ type ServeRegistryOpts struct {
 	Port       int
 	RootDir    string
 	ConfigFile string
-	Writeable  bool
-
-	storedir string
+	ReadOnly   bool
 }
 
 func (o *ServeRegistryOpts) AddFlags(cmd *cobra.Command) {
@@ -36,8 +34,7 @@ func (o *ServeRegistryOpts) AddFlags(cmd *cobra.Command) {
 	f.IntVarP(&o.Port, "port", "p", 5000, "Port to listen on.")
 	f.StringVar(&o.RootDir, "directory", "registry", "Directory to use for backend.  Defaults to $PWD/registry")
 	f.StringVarP(&o.ConfigFile, "config", "c", "", "Path to a config file, will override all other configs")
-	// same as defining ConfigFile maintence.readonly.enable = true
-	f.BoolVar(&o.Writeable, "writeable", false, "Run registry in writeable mode. Defaults to false, readonly.")
+	f.BoolVar(&o.ReadOnly, "readonly", true, "Run the registry as readonly.")
 }
 
 func ServeRegistryCmd(ctx context.Context, o *ServeRegistryOpts, s *store.Layout) error {
@@ -84,8 +81,6 @@ type ServeFilesOpts struct {
 	Port    int
 	Timeout int
 	RootDir string
-
-	storedir string
 }
 
 func (o *ServeFilesOpts) AddFlags(cmd *cobra.Command) {
@@ -139,11 +134,9 @@ func (o *ServeRegistryOpts) defaultRegistryConfig() *configuration.Configuration
 		Storage: configuration.Storage{
 			"cache":      configuration.Parameters{"blobdescriptor": "inmemory"},
 			"filesystem": configuration.Parameters{"rootdirectory": o.RootDir},
-
-			// Default to readonly true (!false)
 			"maintenance": configuration.Parameters{
 				"readonly": map[interface{}]interface{}{
-					"enabled": !o.Writeable,
+					"enabled": !o.ReadOnly,
 				},
 			},
 		},

--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -137,7 +137,6 @@ func (o *ServeRegistryOpts) defaultRegistryConfig() *configuration.Configuration
 			"maintenance": configuration.Parameters{
 				"readonly": map[any]any{"enabled": o.ReadOnly},
 			},
-			},
 		},
 	}
 

--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -134,7 +134,9 @@ func (o *ServeRegistryOpts) defaultRegistryConfig() *configuration.Configuration
 		Storage: configuration.Storage{
 			"cache":      configuration.Parameters{"blobdescriptor": "inmemory"},
 			"filesystem": configuration.Parameters{"rootdirectory": o.RootDir},
-			"maintenance": configuration.Parameters{"readonly":
+			"maintenance": configuration.Parameters{
+				"readonly": map[any]any{"enabled": o.ReadOnly},
+			},
 				configuration.Parameters{"enabled": !o.ReadOnly},
 			},
 		},

--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -137,7 +137,6 @@ func (o *ServeRegistryOpts) defaultRegistryConfig() *configuration.Configuration
 			"maintenance": configuration.Parameters{"readonly":
 				configuration.Parameters{"enabled": !o.ReadOnly},
 			},
-			},
 		},
 	}
 

--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -134,10 +134,9 @@ func (o *ServeRegistryOpts) defaultRegistryConfig() *configuration.Configuration
 		Storage: configuration.Storage{
 			"cache":      configuration.Parameters{"blobdescriptor": "inmemory"},
 			"filesystem": configuration.Parameters{"rootdirectory": o.RootDir},
-			"maintenance": configuration.Parameters{
-				"readonly": map[interface{}]interface{}{
-					"enabled": !o.ReadOnly,
-				},
+			"maintenance": configuration.Parameters{"readonly":
+				configuration.Parameters{"enabled": !o.ReadOnly},
+			},
 			},
 		},
 	}

--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -137,7 +137,6 @@ func (o *ServeRegistryOpts) defaultRegistryConfig() *configuration.Configuration
 			"maintenance": configuration.Parameters{
 				"readonly": map[any]any{"enabled": o.ReadOnly},
 			},
-				configuration.Parameters{"enabled": !o.ReadOnly},
 			},
 		},
 	}

--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -25,6 +25,7 @@ type ServeRegistryOpts struct {
 	Port       int
 	RootDir    string
 	ConfigFile string
+	Writeable  bool
 
 	storedir string
 }
@@ -35,6 +36,8 @@ func (o *ServeRegistryOpts) AddFlags(cmd *cobra.Command) {
 	f.IntVarP(&o.Port, "port", "p", 5000, "Port to listen on.")
 	f.StringVar(&o.RootDir, "directory", "registry", "Directory to use for backend.  Defaults to $PWD/registry")
 	f.StringVarP(&o.ConfigFile, "config", "c", "", "Path to a config file, will override all other configs")
+	// same as defining ConfigFile maintence.readonly.enable = true
+	f.BoolVar(&o.Writeable, "writeable", false, "Run registry in writeable mode. Defaults to false, readonly.")
 }
 
 func ServeRegistryCmd(ctx context.Context, o *ServeRegistryOpts, s *store.Layout) error {
@@ -137,8 +140,12 @@ func (o *ServeRegistryOpts) defaultRegistryConfig() *configuration.Configuration
 			"cache":      configuration.Parameters{"blobdescriptor": "inmemory"},
 			"filesystem": configuration.Parameters{"rootdirectory": o.RootDir},
 
-			// TODO: Ensure this is toggleable via cli arg if necessary
-			// "maintenance": configuration.Parameters{"readonly.enabled": false},
+			// Default to readonly true (!false)
+			"maintenance": configuration.Parameters{
+				"readonly": map[interface{}]interface{}{
+					"enabled": !o.Writeable,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [x] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- https://github.com/hauler-dev/hauler/issues/201

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Defaults running registry to be readonly, adds `--readonly` to default readonly behavior.

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Additional `--readonly` flag.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- Add content to hauler store.
- Start hauler registry with no additional flags, see behavior of registry is able to push to. Tear down.
- Start hauler registry with `--readonly` flag, see behavior which denies push to registry.

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- See https://github.com/hauler-dev/hauler/issues/201
> Secure by default... :D
