### PR TITLE
fixed makefile for goreleaser v2 changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build:
 	CGO_ENABLED=0 go build -o bin ./cmd/...;\
 
 build-all: fmt vet
-	goreleaser build --rm-dist --snapshot
+	goreleaser build --clean --snapshot
 
 install:
 	rm -rf cmd/hauler/binaries;\


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- N/A

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Fixed the `makefile` to use `--clean` vs `--rm-dist` due to changes in the goreleaser `v2`
- GitHub Actions workflow already had this updated... https://github.com/hauler-dev/hauler/blob/47549615c4c93527920509142dce44b741741068/.github/workflows/release.yaml#L35

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- N/A

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
