### PR TITLE
fix missing version info in release build

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,7 +12,7 @@ release:
   make_latest: false
 
 env:
-  - vpkg=github.com/hauler-dev/hauler/internal/version
+  - vpkg=github.com/rancherfederal/hauler/internal/version
   - cosign_version=v2.2.3+carbide.2
 
 builds:
@@ -29,7 +29,7 @@ builds:
     hooks:
       pre:
         - mkdir -p cmd/hauler/binaries
-        - wget -P cmd/hauler/binaries/ https://github.com/rancher-government-carbide/cosign/releases/download/{{ .Env.cosign_version }}/cosign-{{ .Os }}-{{ .Arch }}{{ if eq .Os "windows" }}.exe{{ end }}
+        - wget -P cmd/hauler/binaries/ https://github.com/hauler-dev/cosign/releases/download/{{ .Env.cosign_version }}/cosign-{{ .Os }}-{{ .Arch }}{{ if eq .Os "windows" }}.exe{{ end }}
       post:
         - rm -rf cmd/hauler/binaries
     env:


### PR DESCRIPTION
```
./dist/hauler_linux_amd64_v1/hauler version
 __    __       ___       __    __   __       _______ .______
|  |  |  |     /   \     |  |  |  | |  |     |   ____||   _  \
|  |__|  |    /  ^  \    |  |  |  | |  |     |  |__   |  |_)  |
|   __   |   /  /_\  \   |  |  |  | |  |     |   __|  |      /
|  |  |  |  /  _____  \  |  `--'  | |  `----.|  |____ |  |\  \----.
|__|  |__| /__/     \__\  \______/  |_______||_______|| _| `._____|
hauler: Airgap Swiss Army Knife

GitVersion:    1.0.5+dweomer
GitCommit:     f5b874b
GitTreeState:  clean
BuildDate:     2024-08-05T17:04:15Z
GoVersion:     go1.22.5
Compiler:      gc
Platform:      linux/amd64
```