### PR TITLE
fix image ref keys getting squashed when containing sigs/atts

### DIFF
--- a/pkg/content/oci.go
+++ b/pkg/content/oci.go
@@ -55,7 +55,7 @@ func (o *OCI) AddIndex(desc ocispec.Descriptor) error {
 	if strings.TrimSpace(key.String()) != "--" {
 		switch key.(type) {
 		case name.Digest:
-			o.nameMap.Store(fmt.Sprintf("%s-%s", key.Context().String(), desc.Annotations[consts.KindAnnotationName]), desc)	
+			o.nameMap.Store(fmt.Sprintf("%s-%s", key.Context().String(), desc.Annotations[consts.KindAnnotationName]), desc)
 		case name.Tag:
 			o.nameMap.Store(fmt.Sprintf("%s-%s", key.String(), desc.Annotations[consts.KindAnnotationName]), desc)
 		}

--- a/pkg/content/oci.go
+++ b/pkg/content/oci.go
@@ -55,9 +55,9 @@ func (o *OCI) AddIndex(desc ocispec.Descriptor) error {
 	if strings.TrimSpace(key.String()) != "--" {
 		switch key.(type) {
 		case name.Digest:
-			o.nameMap.Store(key.Context().String(), desc)
+			o.nameMap.Store(fmt.Sprintf("%s-%s", key.Context().String(), desc.Annotations[consts.KindAnnotationName]), desc)	
 		case name.Tag:
-			o.nameMap.Store(key.String(), desc)
+			o.nameMap.Store(fmt.Sprintf("%s-%s", key.String(), desc.Annotations[consts.KindAnnotationName]), desc)
 		}
 	}
 	return o.SaveIndex()
@@ -93,9 +93,9 @@ func (o *OCI) LoadIndex() error {
 		if strings.TrimSpace(key.String()) != "--" {
 			switch key.(type) {
 			case name.Digest:
-				o.nameMap.Store(key.Context().String(), desc)
+				o.nameMap.Store(fmt.Sprintf("%s-%s", key.Context().String(), desc.Annotations[consts.KindAnnotationName]), desc)
 			case name.Tag:
-				o.nameMap.Store(key.String(), desc)
+				o.nameMap.Store(fmt.Sprintf("%s-%s", key.String(), desc.Annotations[consts.KindAnnotationName]), desc)
 			}
 		}
 	}


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- A recent change removed the `KindAnnotationName` from a map key of OCI objects, so when an image with a signature and/or attestations were added, the key value used for them matched the image itself so they were getting squashed out of the map.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- Added an `<image:tag>` with signatures and attestations.  
  - `hauler store info` showed everything present.
  - `hauler store serve registry` served fine.
  - `hauler store save/load` worked appropriately

- Added an `<image:sha>` with signatures and attestations.  
  - `hauler store info` showed everything present.
  - `hauler store serve registry` served fine.
  - `hauler store save/load` worked appropriately

- Added an `<image:tag>` WITHOUT signatures or attestations.  
  - `hauler store info` showed everything present.
  - `hauler store serve registry` served fine.
  - `hauler store save/load` worked appropriately

- Added an `<image:sha>` WITHOUT signatures or attestations.  
  - `hauler store info` showed everything present.
  - `hauler store serve registry` served fine.
  - `hauler store save/load` worked appropriately

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
