### PR TITLE
updated install.sh to remove github api

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -92,11 +92,11 @@ fi
 # set version environment variable
 if [ -z "${HAULER_VERSION}" ]; then
     # attempt to retrieve the latest version from GitHub
-    HAULER_VERSION=$(curl -s https://api.github.com/repos/hauler-dev/hauler/releases/latest | grep '"tag_name":' | sed 's/.*"v\([^"]*\)".*/\1/')
+    HAULER_VERSION=$(curl -sI https://github.com/hauler-dev/hauler/releases/latest | grep -i location | sed 's#.*tag/v##')
 
     # exit if the version could not be detected
     if [ -z "${HAULER_VERSION}" ]; then
-        fatal "HAULER_VERSION is unable to be detected and/or retrieved from GitHub"
+        fatal "HAULER_VERSION is unable to be detected and/or retrieved from GitHub. Please set: HAULER_VERSION"
     fi
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -92,7 +92,7 @@ fi
 # set version environment variable
 if [ -z "${HAULER_VERSION}" ]; then
     # attempt to retrieve the latest version from GitHub
-    HAULER_VERSION=$(curl -sI https://github.com/hauler-dev/hauler/releases/latest | grep -i location | sed 's#.*tag/v##')
+    HAULER_VERSION=$(curl -sI https://github.com/hauler-dev/hauler/releases/latest | grep -i location | sed -e 's#.*tag/v##' -e 's/^[[:space:]]*//g' -e 's/[[:space:]]*$//g')
 
     # exit if the version could not be detected
     if [ -z "${HAULER_VERSION}" ]; then


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- https://github.com/hauler-dev/hauler/issues/286

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Updated the `install.sh` script to use the GitHub Releases page instead of the GitHub API due to unauthenticated rate limiting from the GitHub API.
- Added additional logging to inform users to set `HAULER_VERSION`

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- `curl -sfL https://raw.githubusercontent.com/zackbradys/hauler/main/install.sh | bash`

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
