### PR TITLE
fixed hauler login typo

### DIFF
--- a/cmd/hauler/cli/login.go
+++ b/cmd/hauler/cli/login.go
@@ -23,7 +23,7 @@ func (o *Opts) AddArgs(cmd *cobra.Command) {
 	f := cmd.Flags()
 	f.StringVarP(&o.Username, "username", "u", "", "Username")
 	f.StringVarP(&o.Password, "password", "p", "", "Password")
-	f.BoolVarP(&o.PasswordStdin, "password-stdin", "", false, "Take the password from stdin")
+	f.BoolVar(&o.PasswordStdin, "password-stdin", false, "Take the password from stdin")
 }
 
 func addLogin(parent *cobra.Command) {

--- a/cmd/hauler/cli/login.go
+++ b/cmd/hauler/cli/login.go
@@ -21,9 +21,9 @@ type Opts struct {
 
 func (o *Opts) AddArgs(cmd *cobra.Command) {
 	f := cmd.Flags()
-	f.StringVarP(&o.Username, "username", "u", "", "Username")
-	f.StringVarP(&o.Password, "password", "p", "", "Password")
-	f.BoolVar(&o.PasswordStdin, "password-stdin", false, "Take the password from stdin")
+	f.StringVarP(&o.Username, "username", "u", "", "Username to use for authentication")
+	f.StringVarP(&o.Password, "password", "p", "", "Password to use for authentication")
+	f.BoolVar(&o.PasswordStdin, "password-stdin", false, "Password to use for authentication (from stdin)")
 }
 
 func addLogin(parent *cobra.Command) {


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- N/A

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Updated `hauler login` to change `BoolVarP` to `BoolVar` due to typo/no shorthand flag for `--password-stdin`

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- Clone the repository and locally build `hauler` and run `hauler login`

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
