### PR TITLE
pages: enable go install hauler.dev/go/hauler

### DIFF
--- a/static/go/hauler/index.html
+++ b/static/go/hauler/index.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+    <meta name="go-import" content="hauler.dev/go/hauler git https://github.com/hauler-dev/hauler">
+    <meta http-equiv="refresh" content="0;URL='https://docs.hauler.dev/docs/intro'">
+</head>
+<body>
+Redirecting you to the <a href="https://docs.hauler.dev/docs/intro">hauler docs</a>
+</body>
+</html>


### PR DESCRIPTION
should fix:
```
go install hauler.dev/go/hauler@latest
go: hauler.dev/go/hauler@latest: unrecognized import path "hauler.dev/go/hauler": reading https://hauler.dev/go/hauler?go-get=1: 404 Not Found
```
