### PR TITLE
fixed `hauler completion` commands

### DIFF
--- a/cmd/hauler/cli/completion.go
+++ b/cmd/hauler/cli/completion.go
@@ -9,7 +9,7 @@ import (
 
 func addCompletion(parent *cobra.Command) {
 	cmd := &cobra.Command{
-		Use:   "hauler completion",
+		Use:   "completion",
 		Short: "Generates completion scripts for various shells",
 		Long:  `The completion sub-command generates completion scripts for various shells.`,
 	}
@@ -22,11 +22,6 @@ func addCompletion(parent *cobra.Command) {
 	)
 
 	parent.AddCommand(cmd)
-}
-
-func completionError(err error) ([]string, cobra.ShellCompDirective) {
-	cobra.CompError(err.Error())
-	return nil, cobra.ShellCompDirectiveError
 }
 
 func addCompletionZsh() *cobra.Command {
@@ -51,7 +46,7 @@ func addCompletionZsh() *cobra.Command {
 	mv _hauler ~/.oh-my-zsh/completions  # oh-my-zsh
 	mv _hauler ~/.zprezto/modules/completion/external/src/  # zprezto`,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.GenZshCompletion(os.Stdout)
+			cmd.Root().GenZshCompletion(os.Stdout)
 			// Cobra doesn't source zsh completion file, explicitly doing it here
 			fmt.Println("compdef _hauler hauler")
 		},
@@ -73,7 +68,7 @@ func addCompletionBash() *cobra.Command {
 	# ~/.bashrc or ~/.profile
 	command -v hauler >/dev/null && . <(hauler completion bash)`,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.GenBashCompletion(os.Stdout)
+			cmd.Root().GenBashCompletion(os.Stdout)
 		},
 	}
 	return cmd
@@ -90,7 +85,7 @@ func addCompletionFish() *cobra.Command {
 
 	See http://fishshell.com/docs/current/index.html#completion-own for more details`,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.GenFishCompletion(os.Stdout, true)
+			cmd.Root().GenFishCompletion(os.Stdout, true)
 		},
 	}
 	return cmd
@@ -117,7 +112,7 @@ func addCompletionPowershell() *cobra.Command {
 	cd "${XDG_CONFIG_HOME:-"$HOME/.config/"}/powershell/modules"
 	hauler completion powershell >> hauler-completions.ps1`,
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.GenPowerShellCompletion(os.Stdout)
+			cmd.Root().GenPowerShellCompletion(os.Stdout)
 		},
 	}
 	return cmd


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- https://github.com/hauler-dev/hauler/issues/301
- https://github.com/hauler-dev/hauler/pull/304

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix on `v1.1.0-rc.1`

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Removed the additional top-level command and added `Root()` to each completion generation function
- After testing and validating the initial release candidate of `v1.1.0-rc.1`, I noticed that the recent PR of #304 did fix the issues with the outputted autocompletion scripts, but introduce a bug by creating an additional top-level command of `hauler hauler <shell>`, instead of properly nesting completion under hauler with the fixed outputted autocompletion scripts.
- Hopefully the new `Tests Workflow` will let me/us catch this better...

```bash
zackbradys@Zacks-MBP Downloads % curl -sfL https://get.hauler.dev | sudo HAULER_VERSION=1.1.0-rc.1 bash
Password:

[INFO] Hauler: Starting Preflight Checks...

[INFO] Hauler: Starting Installation...
- Version: v1.1.0-rc.1
- Platform: darwin
- Architecture: arm64
- Install Directory: /Users/zackbradys/Downloads/

[INFO] Hauler: Starting Download...

[INFO] Hauler: Starting Checksum Verification...
- Expected Checksum: 5c6586b8bf52773cf3e76c737e10d777c948028965bcc80695612ffeadbba22e
- Determined Checksum: 5c6586b8bf52773cf3e76c737e10d777c948028965bcc80695612ffeadbba22e
- Successfully Verified Checksum: hauler_1.1.0-rc.1_darwin_arm64.tar.gz

[INFO] Hauler: Successfully Installed Hauler at /usr/local/bin/hauler

[INFO] Hauler: Hauler v1.1.0-rc.1 is now available for use!
- Documentation: https://hauler.dev

zackbradys@Zacks-MBP Downloads % hauler --help
Airgap Swiss Army Knife

Usage:
  hauler [flags]
  hauler [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  hauler      Generates completion scripts for various shells
  help        Help about any command
  login       Log in to a registry
  store       Interact with hauler's embedded content store
  version     Print the current version

Flags:
  -h, --help               help for hauler
  -l, --log-level string    (default "info")

Use "hauler [command] --help" for more information about a command.

zackbradys@Zacks-MBP Downloads % hauler hauler --help
The completion sub-command generates completion scripts for various shells.

Usage:
  hauler hauler [command]

Available Commands:
  bash        Generates bash completion scripts
  fish        Generates fish completion scripts
  powershell  Generates powershell completion scripts
  zsh         Generates zsh completion scripts

Flags:
  -h, --help   help for hauler

Global Flags:
  -l, --log-level string    (default "info")

Use "hauler hauler [command] --help" for more information about a command.
```

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- View the PR `Tests Workflow`
- Clone the PR and run `make build`:

```bash
zackbradys@Zacks-MBP Downloads % ./dist/hauler_darwin_arm64/hauler --help
Airgap Swiss Army Knife

Usage:
  hauler [flags]
  hauler [command]

Available Commands:
  completion  Generate autocompletion scripts for various shells
  help        Help about any command
  login       Login to a registry
  store       Interact with the embedded content store
  version     Print the current version

Flags:
  -h, --help               help for hauler
  -l, --log-level string    (default "info")

Use "hauler [command] --help" for more information about a command.

zackbradys@Zacks-MBP Downloads % ./dist/hauler_darwin_arm64/hauler completion --help
Generate autocompletion scripts for various shells

Usage:
  hauler completion [command]

Available Commands:
  bash        Generates completion scripts for bash
  fish        Generates completion scripts for fish
  powershell  Generates completion scripts for powershell
  zsh         Generates completion scripts for zsh

Flags:
  -h, --help   help for completion

Global Flags:
  -l, --log-level string    (default "info")

Use "hauler completion [command] --help" for more information about a command.
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
