### PR TITLE
bump to cosign v2.2.3-carbide.3 for new annotation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,7 +13,7 @@ release:
 
 env:
   - vpkg=hauler.dev/go/hauler/internal/version
-  - cosign_version=v2.2.3+carbide.2
+  - cosign_version=v2.2.3+carbide.3
 
 builds:
   - main: cmd/hauler/main.go

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GO_FILES=$(shell go list ./... | grep -v /vendor/)
 GO_COVERPROFILE=coverage.out
 
 # set cosign variables
-COSIGN_VERSION=v2.2.3+carbide.2
+COSIGN_VERSION=v2.2.3+carbide.3
 
 # set build variables
 BIN_DIRECTORY=bin

--- a/cmd/hauler/cli/store/info.go
+++ b/cmd/hauler/cli/store/info.go
@@ -238,7 +238,11 @@ func newItem(s *store.Layout, desc ocispec.Descriptor, m ocispec.Manifest, plat 
 		ctype = "sbom"
 	}
 
-	ref, err := reference.Parse(desc.Annotations[ocispec.AnnotationRefName])
+	refName := desc.Annotations["io.containerd.image.name"]
+	if refName == "" {
+		refName = desc.Annotations[ocispec.AnnotationRefName]
+	}
+	ref, err := reference.Parse(refName)
 	if err != nil {
 		return item{}
 	}


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- https://github.com/hauler-dev/hauler/issues/321
- https://github.com/hauler-dev/cosign/pull/11

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- use the latest from our cosign fork that creates a new annotation in the `index.json` within the oci layout.
  - adds `io.containerd.image.name` as an annotation.
     - this is much like what's in the `org.opencontainers.image.ref.name` except it maintains the origin registry name.
  - existing annotation left alone to reduce the risk of breaking changes.
  - `hauler store info` will use the new annotation for image name.  
     - charts and files on the info list will remain unchanged.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- tested `hauler store info`
- tested `hauler store add image/chart`
- tested `hauler store sync --products rke2=v1.31.0+rke2r1 --platform linux/amd64`
- tested `hauler store serve`
- tested `hauler store copy`

```
{
   "schemaVersion": 2,
   "manifests": [
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 480,
         "digest": "sha256:65bbf2875bc748fbe2e2feeb9ec5b8e65f8b71770bdd3421531be693fdcfef31",
         "annotations": {
            "kind": "dev.cosignproject.cosign/image",
            "org.opencontainers.image.ref.name": "hauler/rancher:2.9.1"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 610,
         "digest": "sha256:9186e638ccc30c5d1a2efd5a2cd632f49bb5013f164f6f85c48ed6fce90fe38f",
         "annotations": {
            "io.containerd.image.name": "index.docker.io/library/busybox:latest",
            "kind": "dev.cosignproject.cosign/image",
            "org.opencontainers.image.ref.name": "library/busybox:latest"
         }
      },
      {
         "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
         "size": 708,
         "digest": "sha256:d6cbb5dbd733a118f541e5fe827d04b9efa4338efa6ef9e9c334f375f8e6e76a",
         "annotations": {
            "io.containerd.image.name": "rgcrprod.azurecr.us/rancher/mirrored-elemental-operator:1.6.4",
            "kind": "dev.cosignproject.cosign/imageIndex",
            "org.opencontainers.image.ref.name": "rancher/mirrored-elemental-operator:1.6.4"
         }
      },
      {
         "mediaType": "application/vnd.oci.image.manifest.v1+json",
         "size": 2995,
         "digest": "sha256:e8f14b91431fda303243a87fb5d47575374c3ef2e9b8fb90f6fab2dcb634b7fc",
         "annotations": {
            "io.containerd.image.name": "rgcrprod.azurecr.us/rancher/mirrored-elemental-operator:1.6.4",
            "kind": "dev.cosignproject.cosign/sigs",
            "org.opencontainers.image.ref.name": "rancher/mirrored-elemental-operator:1.6.4"
         }
      }
   ]
}
```

![image](https://github.com/user-attachments/assets/7e18f677-e484-4582-b71a-3171d0293193)


**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
