### PR TITLE
use new annotation for 'store save' manifest.json

### DIFF
--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -96,7 +96,7 @@ func writeExportsManifest(ctx context.Context, dir string) error {
 		if desc.Annotations != nil {
 			// we only care about images that cosign has added to the layout index
 			if kind, hasKind := desc.Annotations[consts.KindAnnotationName]; hasKind {
-				if refName, hasRefName := desc.Annotations[imagev1.AnnotationRefName]; hasRefName {
+				if refName, hasRefName := desc.Annotations["io.containerd.image.name"]; hasRefName {
 					// branch on image (aka image manifest) or image index
 					switch kind {
 					case consts.KindAnnotationImage:


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- https://github.com/hauler-dev/hauler/pull/320

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Use the new annotation "io.containerd.image.name" when generating the manifest.json during a `hauler store save`

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- example manifest.json
```
[
    {
        "Config": "blobs/sha256/5bb42776a4daa860852d73bfef3b676c37cf4e12e556cf6b751cdf90a6ade7da",
        "RepoTags": [
            "rgcrprod.azurecr.us/jetstack/cert-manager-cainjector:v1.15.3"
        ],
        "Layers": [
            "blobs/sha256/286c61c9a31ace5fa0b8832c8e8e30d66bf32138f2f787463235aa0071f714ea",
            "blobs/sha256/2bdf44d7aa71bf3a0da2de0563ad0e3882948d699b4991edf8c0ab44e7f26ae3",
            "blobs/sha256/452e9eed7ecfd0c2b44ac6fda20cee66ab98aec38ba30aa868e02445be7c8bb0",
            "blobs/sha256/0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5",
            "blobs/sha256/d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21",
            "blobs/sha256/c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768",
            "blobs/sha256/d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3",
            "blobs/sha256/1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc",
            "blobs/sha256/b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502",
            "blobs/sha256/3f4e2c5863480125882d92060440a5250766bce764fee10acdbac18c872e4dc7",
            "blobs/sha256/80a8c047508ae5cd6a591060fc43422cb8e3aea1bd908d913e8f0146e2297fea",
            "blobs/sha256/b3c96d508c5e9282623e6eebadcc8482ae46ee5a8a50b8f56c3b20e3662976df",
            "blobs/sha256/ed2df45d23986e59d74e13239d581d111b7ce2417c3da46d5e8d471f7bd21567",
            "blobs/sha256/7fce7127972683d032f05586bcb48705a1cbfe45586031a652056e045a3be77f"
        ]
    },
    {
        "Config": "blobs/sha256/ed07d40ff050c0ba06c07e2f5029161f0988479913d5674709184fb05cb85fe4",
        "RepoTags": [
            "rgcrprod.azurecr.us/jetstack/cert-manager-startupapicheck:v1.15.3"
        ],
        "Layers": [
            "blobs/sha256/286c61c9a31ace5fa0b8832c8e8e30d66bf32138f2f787463235aa0071f714ea",
            "blobs/sha256/2bdf44d7aa71bf3a0da2de0563ad0e3882948d699b4991edf8c0ab44e7f26ae3",
            "blobs/sha256/452e9eed7ecfd0c2b44ac6fda20cee66ab98aec38ba30aa868e02445be7c8bb0",
            "blobs/sha256/0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5",
            "blobs/sha256/d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21",
            "blobs/sha256/c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768",
            "blobs/sha256/d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3",
            "blobs/sha256/1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc",
            "blobs/sha256/b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502",
            "blobs/sha256/3f4e2c5863480125882d92060440a5250766bce764fee10acdbac18c872e4dc7",
            "blobs/sha256/80a8c047508ae5cd6a591060fc43422cb8e3aea1bd908d913e8f0146e2297fea",
            "blobs/sha256/5e960aaf7c83bbf4caaf87b5fd7b434e01d559c638bd09f67550000100e6f7eb",
            "blobs/sha256/ed2df45d23986e59d74e13239d581d111b7ce2417c3da46d5e8d471f7bd21567",
            "blobs/sha256/7fce7127972683d032f05586bcb48705a1cbfe45586031a652056e045a3be77f"
        ]
    },
    {
        "Config": "blobs/sha256/f1943017294a63342f7d3120a482223ac96d21d84c08f08ef0956d9fabf95def",
        "RepoTags": [
            "rgcrprod.azurecr.us/jetstack/cert-manager-controller:v1.15.3"
        ],
        "Layers": [
            "blobs/sha256/286c61c9a31ace5fa0b8832c8e8e30d66bf32138f2f787463235aa0071f714ea",
            "blobs/sha256/2bdf44d7aa71bf3a0da2de0563ad0e3882948d699b4991edf8c0ab44e7f26ae3",
            "blobs/sha256/452e9eed7ecfd0c2b44ac6fda20cee66ab98aec38ba30aa868e02445be7c8bb0",
            "blobs/sha256/0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5",
            "blobs/sha256/d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21",
            "blobs/sha256/c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768",
            "blobs/sha256/d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3",
            "blobs/sha256/1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc",
            "blobs/sha256/b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502",
            "blobs/sha256/3f4e2c5863480125882d92060440a5250766bce764fee10acdbac18c872e4dc7",
            "blobs/sha256/80a8c047508ae5cd6a591060fc43422cb8e3aea1bd908d913e8f0146e2297fea",
            "blobs/sha256/b93243da306f1c23df6e59b6e6a201477b0f307699613813eb472b170d4e7449",
            "blobs/sha256/55c474d9ba7da63a33ea39da25823a42156fd53caa2442d4700fa4f0a9844c36",
            "blobs/sha256/125dfaa3b67f5ae18fe3f6e877400bef8f3ad3fcd8f0a803bd27525cfb27e651"
        ]
    },
    {
        "Config": "blobs/sha256/6beb071efc8152664e26fb42d58e727840b01888eb884efea4010c14698c0cdc",
        "RepoTags": [
            "rgcrprod.azurecr.us/jetstack/cert-manager-webhook:v1.15.3"
        ],
        "Layers": [
            "blobs/sha256/286c61c9a31ace5fa0b8832c8e8e30d66bf32138f2f787463235aa0071f714ea",
            "blobs/sha256/2bdf44d7aa71bf3a0da2de0563ad0e3882948d699b4991edf8c0ab44e7f26ae3",
            "blobs/sha256/452e9eed7ecfd0c2b44ac6fda20cee66ab98aec38ba30aa868e02445be7c8bb0",
            "blobs/sha256/0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5",
            "blobs/sha256/d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21",
            "blobs/sha256/c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768",
            "blobs/sha256/d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3",
            "blobs/sha256/1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc",
            "blobs/sha256/b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502",
            "blobs/sha256/3f4e2c5863480125882d92060440a5250766bce764fee10acdbac18c872e4dc7",
            "blobs/sha256/80a8c047508ae5cd6a591060fc43422cb8e3aea1bd908d913e8f0146e2297fea",
            "blobs/sha256/39143c592545d855b009af7cc10e8c81429199a723c70ba9d4f460611f15752f",
            "blobs/sha256/810e03603a7860d2ea8323e494deaae89a6016e24a51d53be64fd43d8eea98fa",
            "blobs/sha256/e543f6606bf88f01078fc036025d2f2782dc95bac86bef0fedecc5a421af21d3"
        ]
    },
    {
        "Config": "blobs/sha256/ccca5eed1bdcf43032d69f64405047b67e7ea3fc63ca7698b48e72d805bbb466",
        "RepoTags": [
            "rgcrprod.azurecr.us/jetstack/cert-manager-acmesolver:v1.15.3"
        ],
        "Layers": [
            "blobs/sha256/286c61c9a31ace5fa0b8832c8e8e30d66bf32138f2f787463235aa0071f714ea",
            "blobs/sha256/2bdf44d7aa71bf3a0da2de0563ad0e3882948d699b4991edf8c0ab44e7f26ae3",
            "blobs/sha256/452e9eed7ecfd0c2b44ac6fda20cee66ab98aec38ba30aa868e02445be7c8bb0",
            "blobs/sha256/0f8b424aa0b96c1c388a5fd4d90735604459256336853082afb61733438872b5",
            "blobs/sha256/d557676654e572af3e3173c90e7874644207fda32cd87e9d3d66b5d7b98a7b21",
            "blobs/sha256/c8022d07192eddbb2a548ba83be5e412f7ba863bbba158d133c9653bb8a47768",
            "blobs/sha256/d858cbc252ade14879807ff8dbc3043a26bbdb92087da98cda831ee040b172b3",
            "blobs/sha256/1069fc2daed1aceff7232f4b8ab21200dd3d8b04f61be9da86977a34a105dfdc",
            "blobs/sha256/b40161cd83fc5d470d6abe50e87aa288481b6b89137012881d74187cfbf9f502",
            "blobs/sha256/3f4e2c5863480125882d92060440a5250766bce764fee10acdbac18c872e4dc7",
            "blobs/sha256/80a8c047508ae5cd6a591060fc43422cb8e3aea1bd908d913e8f0146e2297fea",
            "blobs/sha256/e489fa9a28610d16d29357c37015a1708ed9edde2546a0bf08925baaeaf5bb66",
            "blobs/sha256/897bf6c5a764cf186f98ac0f4d6b6a61e4d70950ddd05b9c25cfabd5f35d3ce8",
            "blobs/sha256/bc1304dc274d28699fd785513f8ac51996a2ed1854589088306e82a6f77e2023"
        ]
    }
]
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
