### PR TITLE
skip unknown platforms for hauler save manifest.json

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -228,6 +228,17 @@ jobs:
           # verify store directory structure
           tree -hC store
 
+      - name: Verify - docker load
+        run: |
+          docker load --help
+          # verify via load
+          docker load --input haul.tar.zst
+      - name: Verify Docker Images Contents
+        run: |
+          docker images --help
+          # verify images
+          docker images --all
+
       - name: Remove Hauler Store Contents
         run: |
           rm -rf store haul.tar.zst store.tar.zst

--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -114,8 +114,8 @@ func writeExportsManifest(ctx context.Context, dir string) error {
 							return err
 						}
 						for _, ixd := range ixm.Manifests {
-							if ixd.Platform.Architecture != "unknown" && ixd.Platform.OS != "unknown" { // skip 'unknown' platforms... docker hates
-								if ixd.MediaType.IsImage() {
+							if ixd.MediaType.IsImage() {
+								if ixd.Platform.Architecture != "unknown" && ixd.Platform.OS != "unknown" { // skip 'unknown' platforms... docker hates
 									if err := x.record(ctx, iix, ixd, refName); err != nil {
 										return err
 									}

--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -114,9 +114,11 @@ func writeExportsManifest(ctx context.Context, dir string) error {
 							return err
 						}
 						for _, ixd := range ixm.Manifests {
-							if ixd.MediaType.IsImage() {
-								if err := x.record(ctx, iix, ixd, refName); err != nil {
-									return err
+							if ixd.Platform.Architecture != "unknown" && ixd.Platform.OS != "unknown" { // skip 'unknown' platforms... docker hates
+								if ixd.MediaType.IsImage() {
+									if err := x.record(ctx, iix, ixd, refName); err != nil {
+										return err
+									}
 								}
 							}
 						}


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- When constructing the manifest.json for use with docker load, if a multi-arch image contains a platform defined as "unknown/unknown" (looking at you, `busybox`), docker fails to load.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- 

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
