### PR TITLE
add platform flag to store save

### DIFF
--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	referencev3 "github.com/distribution/distribution/v3/reference"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -46,7 +48,7 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, outputFile string) error {
 		return err
 	}
 
-	if err := writeExportsManifest(ctx, "."); err != nil {
+	if err := writeExportsManifest(ctx, ".", o.Platform); err != nil {
 		return err
 	}
 
@@ -64,8 +66,13 @@ type exports struct {
 	records map[string]tarball.Descriptor
 }
 
-func writeExportsManifest(ctx context.Context, dir string) error {
+func writeExportsManifest(ctx context.Context, dir string, platform string) error {
 	l := log.FromContext(ctx)
+
+	os, architecture, err := splitPlatform(platform)
+	if err != nil {
+		return err
+	}
 
 	oci, err := layout.FromPath(dir)
 	if err != nil {
@@ -105,6 +112,11 @@ func writeExportsManifest(ctx context.Context, dir string) error {
 						}
 					case consts.KindAnnotationIndex:
 						l.Debugf("index [%s]: digest=%s, type=%s, size=%d", refName, desc.Digest.String(), desc.MediaType, desc.Size)
+
+						if platform == "" {
+							l.Warnf("index [%s]: contains multiple platforms and could cause issues when importing into docker/containerd", refName)
+						}
+
 						iix, err := idx.ImageIndex(desc.Digest)
 						if err != nil {
 							return err
@@ -115,6 +127,20 @@ func writeExportsManifest(ctx context.Context, dir string) error {
 						}
 						for _, ixd := range ixm.Manifests {
 							if ixd.MediaType.IsImage() {
+								// check if platform is provided, if so, skip anything that doesn't match
+								if platform != "" {
+									if ixd.Platform.Architecture != architecture || ixd.Platform.OS != os {
+										l.Warnf("index [%s]: digest=%s, platform=%s/%s: does not match the supplied platform, skipping", refName, desc.Digest.String(), ixd.Platform.OS, ixd.Platform.Architecture)
+										continue
+									}
+								}
+
+								// skip 'unknown' platforms... docker hates
+								if ixd.Platform.Architecture == "unknown" && ixd.Platform.OS == "unknown" {
+									l.Warnf("index [%s]: digest=%s, platform=%s/%s: skipping 'unknown/unknown' platform", refName, desc.Digest.String(), ixd.Platform.OS, ixd.Platform.Architecture)
+									continue
+								}
+
 								if err := x.record(ctx, iix, ixd, refName); err != nil {
 									return err
 								}
@@ -208,4 +234,16 @@ func (x *exports) record(ctx context.Context, index libv1.ImageIndex, desc libv1
 	x.records[digest] = xd
 
 	return nil
+}
+
+func splitPlatform(platform string) (string, string, error) {
+	if platform == "" {
+		return "", "", nil // Skip processing if no platform is provided
+	}
+
+	parts := strings.Split(platform, "/")
+	if len(parts) != 2 {
+		return "", "", errors.New("invalid platform format")
+	}
+	return parts[0], parts[1], nil
 }

--- a/internal/flags/save.go
+++ b/internal/flags/save.go
@@ -5,10 +5,12 @@ import "github.com/spf13/cobra"
 type SaveOpts struct {
 	*StoreRootOpts
 	FileName string
+	Platform string
 }
 
 func (o *SaveOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
 	f.StringVarP(&o.FileName, "filename", "f", "haul.tar.zst", "(Optional) Specify the name of outputted archive")
+	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specifiy the platform of the images for the outputted archive... i.e. linux/amd64 (defaults to all)")
 }


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [ ] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- https://github.com/hauler-dev/hauler/pull/322

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- An image index a.k.a. multi-arch image isn't really docker compatible so this PR adjusts `hauler store save` to have a `--platform` flag to give the user a chance to only export the platform of their choice.  Any platform skipped as a result of this flag will be logged as a warning.

- If the `--platform` flag isn't provided, a warning gets logged during save if your store contains an image index... just as a heads up.

- Docker also isn't compatible with the `unknown/unknown` platform that some image index might contain.  we're going to skip those or otherwise `docker load` will fail to import.  

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- example of omitting the `platform` flag and hauler just throwing a warning when it processes an image index.
```
> hauler store save                                                                                                                                                                                                                                                           
2024-09-23 15:18:20 WRN index [index.docker.io/bitnami/cert-manager:1.15.3]: contains multiple platforms and could cause issues when importing into docker/containerd
```

- example of using the `--platform` flag to skip anything other than what's specified.
```
> hauler store save --platform linux/arm64                                                                                                                                                                                                                                     
2024-09-23 15:19:05 WRN index [index.docker.io/bitnami/cert-manager:1.15.3]: digest=sha256:5c827d71196f865e168e3fed85ed1bd54863fc8f01760a833253474aed4a1441, platform=linux/amd64: does not match the supplied platform, skipping
2024-09-23 15:19:05 INF saved store [store] -> [/Users/amartin/projects/hauler/haul.tar.zst]
```

- example of an image index containing `unknown/unknown`
```
2024-09-23 15:18:20 WRN index [index.docker.io/library/busybox:latest]: digest=sha256:c230832bd3b0be59a6c47ed64294f9ce71e91b327957920b6929a0caa8353140, platform=unknown/unknown: skipping 'unknown/unknown' platform
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
