### PR TITLE
have extract use proper ref from store info

### DIFF
--- a/cmd/hauler/cli/store/extract.go
+++ b/cmd/hauler/cli/store/extract.go
@@ -23,10 +23,12 @@ func ExtractCmd(ctx context.Context, o *flags.ExtractOpts, s *store.Layout, ref 
 		return err
 	}
 
+	// use the repository from the context and the identifier from the reference
+	repo := r.Context().RepositoryStr() + ":" + r.Identifier()
+
 	found := false
 	if err := s.Walk(func(reference string, desc ocispec.Descriptor) error {
-
-		if !strings.Contains(reference, r.Name()) {
+		if !strings.Contains(reference, repo) {
 			return nil
 		}
 		found = true


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [ ] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Now that images so the origin registry in `hauler store info`, `hauler store extract` wasn't expecting the registry to be specified.  

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- tested extract with registry and without.

```
hauler store extract rgcrprod.azurecr.us/busybox:latest 
```
and
```
hauler_darwin_arm64/hauler store extract busybox:latest 
```
and
```
hauler_darwin_arm64/hauler store extract hauler/busybox:latest  
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
