### PR TITLE
fixed cli desc for store env var

### DIFF
--- a/cmd/hauler/cli/cli.go
+++ b/cmd/hauler/cli/cli.go
@@ -16,7 +16,7 @@ func New(ctx context.Context, binaries embed.FS, ro *flags.CliRootOpts) *cobra.C
 	cmd := &cobra.Command{
 		Use:     "hauler",
 		Short:   "Airgap Swiss Army Knife",
-		Example: "  View the Docs: https://docs.hauler.dev\n  Environment Variables: " + consts.HaulerDir + " | " + consts.HaulerTempDir + " | " + consts.HaulerIgnoreErrors,
+		Example: "  View the Docs: https://docs.hauler.dev\n  Environment Variables: " + consts.HaulerDir + " | " + consts.HaulerTempDir + " | " + consts.HaulerStoreDir + " | " + consts.HaulerIgnoreErrors,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			l := log.FromContext(ctx)
 			l.SetLevel(ro.LogLevel)


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- N/A

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Fixed `CLI` description to include the env var for `HAULER_STORE_DIR`

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

```bash
zackbradys@Zacks-MacBook-Pro-2 hauler % ./dist/hauler_darwin_arm64_v8.0/hauler help
Airgap Swiss Army Knife

Usage:
  hauler [flags]
  hauler [command]

Examples:
  View the Docs: https://docs.hauler.dev
  Environment Variables: HAULER_DIR | HAULER_TEMP_DIR | HAULER_STORE_DIR | HAULER_IGNORE_ERRORS

Available Commands:
  completion  Generate auto-completion scripts for various shells
  help        Help about any command
  login       Login to a registry
  store       Interact with the content store
  version     Print the current version

Flags:
  -d, --haulerdir string   Set the location of the hauler directory (default $HOME/.hauler)
  -h, --help               help for hauler
      --ignore-errors      Ignore/Bypass errors (i.e. warn on error) (defaults false)
  -l, --log-level string   Set the logging level (i.e. info, debug, warn) (default "info")

Use "hauler [command] --help" for more information about a command.
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
