### PR TITLE
use cosign v2.4.1+carbide.2 to address containerd annotation in index.json

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 toolchain go1.23.4
 
-replace github.com/sigstore/cosign/v2 => github.com/hauler-dev/cosign/v2 v2.4.2-0.20250108143133-b8416a2c645e
+replace github.com/sigstore/cosign/v2 => github.com/hauler-dev/cosign/v2 v2.4.2-0.20250118012335-ee9b762a922a
 
 require (
 	github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be

--- a/go.sum
+++ b/go.sum
@@ -584,8 +584,8 @@ github.com/hashicorp/hcl v1.0.1-vault-5 h1:kI3hhbbyzr4dldA8UdTb7ZlVVlI2DACdCfz31
 github.com/hashicorp/hcl v1.0.1-vault-5/go.mod h1:XYhtn6ijBSAj6n4YqAaf7RBPS4I06AItNorpy+MoQNM=
 github.com/hashicorp/vault/api v1.14.0 h1:Ah3CFLixD5jmjusOgm8grfN9M0d+Y8fVR2SW0K6pJLU=
 github.com/hashicorp/vault/api v1.14.0/go.mod h1:pV9YLxBGSz+cItFDd8Ii4G17waWOQ32zVjMWHe/cOqk=
-github.com/hauler-dev/cosign/v2 v2.4.2-0.20250108143133-b8416a2c645e h1:3mxxFvo8sX+jexXcLI+MdR/YP4kG9sIwUFeLl4C81aM=
-github.com/hauler-dev/cosign/v2 v2.4.2-0.20250108143133-b8416a2c645e/go.mod h1:GvzjBeUKigI+XYnsoVQDmMAsMMc6engxztRSuxE+x9I=
+github.com/hauler-dev/cosign/v2 v2.4.2-0.20250118012335-ee9b762a922a h1:/l+VaobyY00HyBYvOEtu6o9EQUDygmK89SDJ6k++/q8=
+github.com/hauler-dev/cosign/v2 v2.4.2-0.20250118012335-ee9b762a922a/go.mod h1:GvzjBeUKigI+XYnsoVQDmMAsMMc6engxztRSuxE+x9I=
 github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef h1:A9HsByNhogrvm9cWb28sjiS3i7tcKCkflWFEkHfuAgM=
 github.com/howeyc/gopass v0.0.0-20210920133722-c8aef6fb66ef/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- In order to support Hauler hauls seeding RKE2 in an air-gapped installation, we needed to adjust an annotation in the image.json created by our cosign fork.

- the annotation for default registry needs to be `docker.io` instead of `index.docker.io` despite them being the same thing.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

Doesn't work:
```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 526,
         "digest": "sha256:c2280d2f5f56cf9c9a01bb64b2db4651e35efd6d62a54dcfc12049fe6449c5e4",
         "annotations": {
            "io.containerd.image.name": "index.docker.io/rancher/mirrored-pause:3.6",
            "kind": "dev.cosignproject.cosign/image",
            "org.opencontainers.image.ref.name": "rancher/mirrored-pause:3.6"
         }
      }
   ]
}
```

Works:
```json
{
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.index.v1+json",
   "manifests": [
      {
         "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
         "size": 526,
         "digest": "sha256:c2280d2f5f56cf9c9a01bb64b2db4651e35efd6d62a54dcfc12049fe6449c5e4",
         "annotations": {
            "io.containerd.image.name": "docker.io/rancher/mirrored-pause:3.6",
            "kind": "dev.cosignproject.cosign/image",
            "org.opencontainers.image.ref.name": "rancher/mirrored-pause:3.6"
         }
      }
   ]
}
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


- Libraries like `github.com/google/go-containerregistry` default to `index.docker.io` when parsing an image reference. This behavior originates from historical conventions tied to Docker Hub's full domain name (`index.docker.io`), which was explicitly used in the early days of Docker.

- Why `index.docker.io` in `go-containerregistry`?
   - Historical Naming:
    Docker Hub was initially identified as `index.docker.io`, and this full domain persisted in older tooling and libraries.
    While `docker.io` became the shorthand, `index.docker.io` remained the "canonical" name in certain libraries and APIs.
   - Standardized Parsing:
    The `go-containerregistry` library adheres to a stricter parsing approach, considering the full domain name (`index.docker.io`) rather than relying on the default alias `docker.io`.
    This avoids ambiguities when working with other registries or configurations that might not alias `docker.io` correctly.
   - Compatibility with OCI Image Spec:
     The library prioritizes adherence to the OCI image spec, where fully qualified references are preferred.
     Using `index.docker.io` ensures an explicit, unambiguous reference to the Docker Hub.

- Impact on `containerd` and Similar Tools:
   - When using `go-containerregistry` or similar libraries, the explicit reference to `index.docker.io` might cause issues with tools like `containerd` that do not treat `index.docker.io` as a default alias for `docker.io`.
