### PR TITLE
added remote load updates and cleaned up load and save

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -209,9 +209,9 @@ jobs:
           # verify via save
           hauler store save
           # verify via save with filename
-          hauler store save --filename store.tar.zst
+          hauler store save store.tar.zst
           # verify via save with filename and platform (amd64)
-          hauler store save --filename store-amd64.tar.zst --platform linux/amd64
+          hauler store save store-amd64.tar.zst --platform linux/amd64
 
       - name: Remove Hauler Store Contents
         run: |
@@ -222,11 +222,11 @@ jobs:
         run: |
           hauler store load --help
           # verify via load
-          hauler store load --filename haul.tar.zst
+          hauler store load haul.tar.zst
           # verify via load with filename and temp directory
-          hauler store load --filename store.tar.zst --tempdir /opt
+          hauler store load store.tar.zst --tempdir /opt
           # verify via load with filename and platform (amd64)
-          hauler store load --filename store-amd64.tar.zst
+          hauler store load store-amd64.tar.zst
 
       - name: Verify Hauler Store Contents
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -223,6 +223,8 @@ jobs:
           hauler store load --help
           # verify via load
           hauler store load
+          # verify via load with multiple files
+          hauler store load haul.tar.zst store.tar.zst
           # verify via load with filename and temp directory
           hauler store load store.tar.zst --tempdir /opt
           # verify via load with filename and platform (amd64)
@@ -259,6 +261,8 @@ jobs:
           curl -sfOL https://github.com/rancherfederal/rancher-cluster-templates/releases/download/rancher-cluster-templates-0.5.2/rancher-cluster-templates-0.5.2.tgz
           # verify via sync
           hauler store sync --files testdata/hauler-manifest-pipeline.yaml
+          # verify via sync with multiple files
+          hauler store sync --files testdata/hauler-manifest-pipeline.yaml --files testdata/hauler-manifest-pipeline.yaml
           # need more tests here
 
       - name: Verify - hauler store serve

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -209,9 +209,9 @@ jobs:
           # verify via save
           hauler store save
           # verify via save with filename
-          hauler store save store.tar.zst
+          hauler store save --filename store.tar.zst
           # verify via save with filename and platform (amd64)
-          hauler store save store-amd64.tar.zst --platform linux/amd64
+          hauler store save --filname store-amd64.tar.zst --platform linux/amd64
 
       - name: Remove Hauler Store Contents
         run: |
@@ -224,11 +224,11 @@ jobs:
           # verify via load
           hauler store load
           # verify via load with multiple files
-          hauler store load haul.tar.zst store.tar.zst
+          hauler store load --filename haul.tar.zst --filename store.tar.zst
           # verify via load with filename and temp directory
-          hauler store load store.tar.zst --tempdir /opt
+          hauler store load --filename store.tar.zst --tempdir /opt
           # verify via load with filename and platform (amd64)
-          hauler store load store-amd64.tar.zst
+          hauler store load --filename store-amd64.tar.zst
 
       - name: Verify Hauler Store Contents
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -222,7 +222,7 @@ jobs:
         run: |
           hauler store load --help
           # verify via load
-          hauler store load haul.tar.zst
+          hauler store load
           # verify via load with filename and temp directory
           hauler store load store.tar.zst --tempdir /opt
           # verify via load with filename and platform (amd64)

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -222,11 +222,11 @@ jobs:
         run: |
           hauler store load --help
           # verify via load
-          hauler store load haul.tar.zst
+          hauler store load --filename haul.tar.zst
           # verify via load with filename and temp directory
-          hauler store load store.tar.zst --tempdir /opt
+          hauler store load --filename store.tar.zst --tempdir /opt
           # verify via load with filename and platform (amd64)
-          hauler store load store-amd64.tar.zst
+          hauler store load --filename store-amd64.tar.zst
 
       - name: Verify Hauler Store Contents
         run: |

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -8,7 +8,6 @@ import (
 
 	"hauler.dev/go/hauler/cmd/hauler/cli/store"
 	"hauler.dev/go/hauler/internal/flags"
-	"hauler.dev/go/hauler/pkg/consts"
 )
 
 func addStore(parent *cobra.Command, ro *flags.CliRootOpts) {
@@ -90,6 +89,7 @@ func addStoreLoad(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "load",
 		Short: "Load a content store from a store archive",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -99,11 +99,7 @@ func addStoreLoad(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 			}
 			_ = s
 
-			if len(args) == 0 {
-				args = []string{consts.DefaultHaulerArchiveName}
-			}
-
-			return store.LoadCmd(ctx, o, rso, ro, args...)
+			return store.LoadCmd(ctx, o, rso, ro)
 		},
 	}
 	o.AddFlags(cmd)
@@ -179,7 +175,7 @@ func addStoreSave(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "save",
 		Short: "Save a content store to a store archive",
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -189,12 +185,7 @@ func addStoreSave(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 			}
 			_ = s
 
-			fileName := consts.DefaultHaulerArchiveName
-			if len(args) > 0 && args[0] != "" {
-				fileName = args[0]
-			}
-
-			return store.SaveCmd(ctx, o, rso, ro, fileName)
+			return store.SaveCmd(ctx, o, rso, ro)
 		},
 	}
 	o.AddFlags(cmd)

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -99,7 +99,7 @@ func addStoreLoad(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 			}
 			_ = s
 
-			return store.LoadCmd(ctx, o)
+			return store.LoadCmd(ctx, o, rso, ro)
 		},
 	}
 	o.AddFlags(cmd)
@@ -187,7 +187,7 @@ func addStoreSave(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 			}
 			_ = s
 
-			return store.SaveCmd(ctx, o, o.FileName)
+			return store.SaveCmd(ctx, o, rso, ro)
 		},
 	}
 	o.AddFlags(cmd)

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -99,7 +99,7 @@ func addStoreLoad(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 			}
 			_ = s
 
-			return store.LoadCmd(ctx, o, o.FileName)
+			return store.LoadCmd(ctx, o)
 		},
 	}
 	o.AddFlags(cmd)

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -89,7 +89,7 @@ func addStoreLoad(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "load",
 		Short: "Load a content store from a store archive",
-		Args:  cobra.ExactArgs(0),
+		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -99,7 +99,7 @@ func addStoreLoad(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 			}
 			_ = s
 
-			return store.LoadCmd(ctx, o, rso, ro)
+			return store.LoadCmd(ctx, o, rso, ro, args...)
 		},
 	}
 	o.AddFlags(cmd)
@@ -123,7 +123,6 @@ func addStoreServe(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comma
 	return cmd
 }
 
-// RegistryCmd serves the registry
 func addStoreServeRegistry(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Command {
 	o := &flags.ServeRegistryOpts{StoreRootOpts: rso}
 
@@ -147,7 +146,6 @@ func addStoreServeRegistry(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cob
 	return cmd
 }
 
-// FileServerCmd serves the file server
 func addStoreServeFiles(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Command {
 	o := &flags.ServeFilesOpts{StoreRootOpts: rso}
 

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -186,7 +186,11 @@ func addStoreSave(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 			}
 			_ = s
 
-			fileName := append([]string{consts.DefaultHaulerArchiveName}, args...)[0]
+			fileName := consts.DefaultHaulerArchiveName
+			if len(args) > 0 && args[0] != "" {
+				fileName = args[0]
+			}
+
 			return store.SaveCmd(ctx, o, rso, ro, fileName)
 		},
 	}

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -8,6 +8,7 @@ import (
 
 	"hauler.dev/go/hauler/cmd/hauler/cli/store"
 	"hauler.dev/go/hauler/internal/flags"
+	"hauler.dev/go/hauler/pkg/consts"
 )
 
 func addStore(parent *cobra.Command, ro *flags.CliRootOpts) {
@@ -175,7 +176,7 @@ func addStoreSave(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "save",
 		Short: "Save a content store to a store archive",
-		Args:  cobra.ExactArgs(0),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -185,7 +186,8 @@ func addStoreSave(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 			}
 			_ = s
 
-			return store.SaveCmd(ctx, o, rso, ro)
+			fileName := append([]string{consts.DefaultHaulerArchiveName}, args...)[0]
+			return store.SaveCmd(ctx, o, rso, ro, fileName)
 		},
 	}
 	o.AddFlags(cmd)

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -90,7 +90,6 @@ func addStoreLoad(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "load",
 		Short: "Load a content store from a store archive",
-		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -99,6 +98,10 @@ func addStoreLoad(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 				return err
 			}
 			_ = s
+
+			if len(args) == 0 {
+				args = []string{consts.DefaultHaulerArchiveName}
+			}
 
 			return store.LoadCmd(ctx, o, rso, ro, args...)
 		},

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -89,7 +89,7 @@ func addStoreLoad(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "load",
 		Short: "Load a content store from a store archive",
-		Args:  cobra.MinimumNArgs(1),
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -99,7 +99,7 @@ func addStoreLoad(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 			}
 			_ = s
 
-			return store.LoadCmd(ctx, o, args...)
+			return store.LoadCmd(ctx, o, o.FileName)
 		},
 	}
 	o.AddFlags(cmd)

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -18,12 +18,12 @@ import (
 )
 
 // loads a content store from one or more store archives
-func LoadCmd(ctx context.Context, o *flags.LoadOpts, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
+func LoadCmd(ctx context.Context, o *flags.LoadOpts, rso *flags.StoreRootOpts, ro *flags.CliRootOpts, fileNames ...string) error {
 	l := log.FromContext(ctx)
 
-	for _, archiveRef := range o.FileName {
-		l.Infof("loading archive [%s] to store [%s]", archiveRef, o.StoreDir)
-		if err := unarchiveLayoutTo(ctx, archiveRef, o.StoreDir, o.TempOverride); err != nil {
+	for _, fileName := range fileNames {
+		l.Infof("loading archive [%s] to store [%s]", fileName, o.StoreDir)
+		if err := unarchiveLayoutTo(ctx, fileName, o.StoreDir, o.TempOverride); err != nil {
 			return err
 		}
 	}

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -17,24 +17,25 @@ import (
 	"hauler.dev/go/hauler/pkg/store"
 )
 
-// LoadCmd
-// TODO: Just use mholt/archiver for now, even though we don't need most of it
-func LoadCmd(ctx context.Context, o *flags.LoadOpts, archiveRefs ...string) error {
+// loads a content store from one or more store archives.
+func LoadCmd(ctx context.Context, o *flags.LoadOpts) error {
 	l := log.FromContext(ctx)
 
 	storeDir := o.StoreDir
+
 	if storeDir == "" {
 		storeDir = os.Getenv(consts.HaulerStoreDir)
 	}
+
 	if storeDir == "" {
 		storeDir = consts.DefaultStoreName
 	}
 
-	archiveRef := o.FileName
-
-	l.Infof("loading archive [%s] to store [%s]", archiveRef, storeDir)
-	if err := unarchiveLayoutTo(ctx, archiveRef, storeDir, o.TempOverride); err != nil {
-		return err
+	for _, archiveRef := range o.FileName {
+		l.Infof("loading archive [%s] to store [%s]", archiveRef, storeDir)
+		if err := unarchiveLayoutTo(ctx, archiveRef, storeDir, o.TempOverride); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -21,7 +21,7 @@ import (
 func LoadCmd(ctx context.Context, o *flags.LoadOpts, rso *flags.StoreRootOpts, ro *flags.CliRootOpts, fileNames ...string) error {
 	l := log.FromContext(ctx)
 
-	for _, fileName := range fileNames {
+	for _, fileName := range o.FileName {
 		l.Infof("loading archive [%s] to store [%s]", fileName, o.StoreDir)
 		if err := unarchiveLayoutTo(ctx, fileName, o.StoreDir, o.TempOverride); err != nil {
 			return err

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -17,23 +17,13 @@ import (
 	"hauler.dev/go/hauler/pkg/store"
 )
 
-// loads a content store from one or more store archives.
-func LoadCmd(ctx context.Context, o *flags.LoadOpts) error {
+// loads a content store from one or more store archives
+func LoadCmd(ctx context.Context, o *flags.LoadOpts, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
 	l := log.FromContext(ctx)
 
-	storeDir := o.StoreDir
-
-	if storeDir == "" {
-		storeDir = os.Getenv(consts.HaulerStoreDir)
-	}
-
-	if storeDir == "" {
-		storeDir = consts.DefaultStoreName
-	}
-
 	for _, archiveRef := range o.FileName {
-		l.Infof("loading archive [%s] to store [%s]", archiveRef, storeDir)
-		if err := unarchiveLayoutTo(ctx, archiveRef, storeDir, o.TempOverride); err != nil {
+		l.Infof("loading archive [%s] to store [%s]", archiveRef, o.StoreDir)
+		if err := unarchiveLayoutTo(ctx, archiveRef, o.StoreDir, o.TempOverride); err != nil {
 			return err
 		}
 	}

--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -23,20 +23,9 @@ import (
 	"hauler.dev/go/hauler/pkg/log"
 )
 
-// SaveCmd
-// TODO: Just use mholt/archiver for now, even though we don't need most of it
-func SaveCmd(ctx context.Context, o *flags.SaveOpts, outputFile string) error {
+// saves a content store to store archives
+func SaveCmd(ctx context.Context, o *flags.SaveOpts, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
 	l := log.FromContext(ctx)
-
-	storeDir := o.StoreDir
-
-	if storeDir == "" {
-		storeDir = os.Getenv(consts.HaulerStoreDir)
-	}
-
-	if storeDir == "" {
-		storeDir = consts.DefaultStoreName
-	}
 
 	// Maps to handle compression and archival types
 	compressionMap := archives.CompressionMap
@@ -47,7 +36,7 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, outputFile string) error {
 	compression := compressionMap["zst"]
 	archival := archivalMap["tar"]
 
-	absOutputfile, err := filepath.Abs(outputFile)
+	absOutputfile, err := filepath.Abs(o.FileName)
 	if err != nil {
 		return err
 	}
@@ -57,7 +46,7 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, outputFile string) error {
 		return err
 	}
 	defer os.Chdir(cwd)
-	if err := os.Chdir(storeDir); err != nil {
+	if err := os.Chdir(o.StoreDir); err != nil {
 		return err
 	}
 
@@ -72,7 +61,7 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, outputFile string) error {
 		return err
 	}
 
-	l.Infof("saved store [%s] -> [%s]", storeDir, absOutputfile)
+	l.Infof("saved store [%s] -> [%s]", o.StoreDir, absOutputfile)
 	return nil
 }
 
@@ -154,7 +143,7 @@ func writeExportsManifest(ctx context.Context, dir string, platformStr string) e
 
 								// skip 'unknown' platforms... docker hates
 								if ixd.Platform.Architecture == "unknown" && ixd.Platform.OS == "unknown" {
-									l.Debugf("index [%s]: digest=[%s], platform=[%s/%s]: mathces unknown platform... skipping...", refName, desc.Digest.String(), ixd.Platform.OS, ixd.Platform.Architecture)
+									l.Debugf("index [%s]: digest=[%s], platform=[%s/%s]: matches unknown platform... skipping...", refName, desc.Digest.String(), ixd.Platform.OS, ixd.Platform.Architecture)
 									continue
 								}
 

--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -111,7 +111,7 @@ func writeExportsManifest(ctx context.Context, dir string, platformStr string) e
 	}
 
 	for _, desc := range imx.Manifests {
-		l.Debugf("descriptor [%s] >>> %s", desc.Digest.String(), desc.MediaType)
+		l.Debugf("descriptor [%s] = [%s]", desc.Digest.String(), desc.MediaType)
 		if artifactType := types.MediaType(desc.ArtifactType); artifactType != "" && !artifactType.IsImage() && !artifactType.IsIndex() {
 			l.Debugf("descriptor [%s] <<< SKIPPING ARTIFACT [%q]", desc.Digest.String(), desc.ArtifactType)
 			continue
@@ -127,11 +127,11 @@ func writeExportsManifest(ctx context.Context, dir string, platformStr string) e
 							return err
 						}
 					case consts.KindAnnotationIndex:
-						l.Debugf("index [%s]: digest=%s, type=%s, size=%d", refName, desc.Digest.String(), desc.MediaType, desc.Size)
+						l.Debugf("index [%s]: digest=[%s]... type=[%s]... size=[%d]", refName, desc.Digest.String(), desc.MediaType, desc.Size)
 
 						// when no platform is provided, warn the user of potential mismatch on import
 						if platform.String() == "" {
-							l.Warnf("index [%s]: provide an export platform to prevent potential platform mismatch on import", refName)
+							l.Warnf("specify an export platform to prevent potential platform mismatch on import of index [%s]", refName)
 						}
 
 						iix, err := idx.ImageIndex(desc.Digest)
@@ -147,14 +147,14 @@ func writeExportsManifest(ctx context.Context, dir string, platformStr string) e
 								// check if platform is provided, if so, skip anything that doesn't match
 								if platform.String() != "" {
 									if ixd.Platform.Architecture != platform.Architecture || ixd.Platform.OS != platform.OS {
-										l.Warnf("index [%s]: digest=%s, platform=%s/%s: does not match the supplied platform, skipping", refName, desc.Digest.String(), ixd.Platform.OS, ixd.Platform.Architecture)
+										l.Debugf("index [%s]: digest=[%s], platform=[%s/%s]: does not match the supplied platform... skipping...", refName, desc.Digest.String(), ixd.Platform.OS, ixd.Platform.Architecture)
 										continue
 									}
 								}
 
 								// skip 'unknown' platforms... docker hates
 								if ixd.Platform.Architecture == "unknown" && ixd.Platform.OS == "unknown" {
-									l.Warnf("index [%s]: digest=%s, platform=%s/%s: skipping 'unknown/unknown' platform", refName, desc.Digest.String(), ixd.Platform.OS, ixd.Platform.Architecture)
+									l.Debugf("index [%s]: digest=[%s], platform=[%s/%s]: mathces unknown platform... skipping...", refName, desc.Digest.String(), ixd.Platform.OS, ixd.Platform.Architecture)
 									continue
 								}
 

--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -24,7 +24,7 @@ import (
 )
 
 // saves a content store to store archives
-func SaveCmd(ctx context.Context, o *flags.SaveOpts, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
+func SaveCmd(ctx context.Context, o *flags.SaveOpts, rso *flags.StoreRootOpts, ro *flags.CliRootOpts, fileName string) error {
 	l := log.FromContext(ctx)
 
 	// Maps to handle compression and archival types
@@ -36,7 +36,7 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, rso *flags.StoreRootOpts, r
 	compression := compressionMap["zst"]
 	archival := archivalMap["tar"]
 
-	absOutputfile, err := filepath.Abs(o.FileName)
+	absOutputfile, err := filepath.Abs(fileName)
 	if err != nil {
 		return err
 	}

--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -24,7 +24,7 @@ import (
 )
 
 // saves a content store to store archives
-func SaveCmd(ctx context.Context, o *flags.SaveOpts, rso *flags.StoreRootOpts, ro *flags.CliRootOpts, fileName string) error {
+func SaveCmd(ctx context.Context, o *flags.SaveOpts, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
 	l := log.FromContext(ctx)
 
 	// Maps to handle compression and archival types
@@ -36,7 +36,7 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, rso *flags.StoreRootOpts, r
 	compression := compressionMap["zst"]
 	archival := archivalMap["tar"]
 
-	absOutputfile, err := filepath.Abs(fileName)
+	absOutputfile, err := filepath.Abs(o.FileName)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, rso *flags.StoreRootOpts, r
 		return err
 	}
 
-	l.Infof("saved store [%s] -> [%s]", o.StoreDir, absOutputfile)
+	l.Infof("saving store [%s] to archive [%s]", o.StoreDir, o.FileName)
 	return nil
 }
 

--- a/internal/flags/load.go
+++ b/internal/flags/load.go
@@ -2,12 +2,10 @@ package flags
 
 import (
 	"github.com/spf13/cobra"
-	"hauler.dev/go/hauler/pkg/consts"
 )
 
 type LoadOpts struct {
 	*StoreRootOpts
-	FileName     []string
 	TempOverride string
 }
 
@@ -16,6 +14,5 @@ func (o *LoadOpts) AddFlags(cmd *cobra.Command) {
 
 	// On Unix, the default is $TMPDIR if non-empty, else /tmp.
 	// On Windows, the default is GetTempPath, returning the first non-empty value from %TMP%, %TEMP%, %USERPROFILE%, or the Windows directory.
-	f.StringSliceVarP(&o.FileName, "filename", "f", []string{consts.DefaultHaulArchiveName}, "(Optional) Specify the name of inputted archive(s)")
 	f.StringVarP(&o.TempOverride, "tempdir", "t", "", "(Optional) Override the default temporary directory determined by the OS")
 }

--- a/internal/flags/load.go
+++ b/internal/flags/load.go
@@ -2,10 +2,12 @@ package flags
 
 import (
 	"github.com/spf13/cobra"
+	"hauler.dev/go/hauler/pkg/consts"
 )
 
 type LoadOpts struct {
 	*StoreRootOpts
+	FileName     []string
 	TempOverride string
 }
 
@@ -14,5 +16,6 @@ func (o *LoadOpts) AddFlags(cmd *cobra.Command) {
 
 	// On Unix, the default is $TMPDIR if non-empty, else /tmp.
 	// On Windows, the default is GetTempPath, returning the first non-empty value from %TMP%, %TEMP%, %USERPROFILE%, or the Windows directory.
+	f.StringSliceVarP(&o.FileName, "filename", "f", []string{consts.DefaultHaulerArchiveName}, "(Optional) Specify the name of inputted archive(s)")
 	f.StringVarP(&o.TempOverride, "tempdir", "t", "", "(Optional) Override the default temporary directory determined by the OS")
 }

--- a/internal/flags/load.go
+++ b/internal/flags/load.go
@@ -1,18 +1,21 @@
 package flags
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+	"hauler.dev/go/hauler/pkg/consts"
+)
 
 type LoadOpts struct {
 	*StoreRootOpts
+	FileName     string
 	TempOverride string
 }
 
 func (o *LoadOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	// On Unix systems, the default is $TMPDIR if non-empty, else /tmp.
-	// On Windows, the default is GetTempPath, returning the first non-empty
-	// value from %TMP%, %TEMP%, %USERPROFILE%, or the Windows directory.
-	// On Plan 9, the default is /tmp.
+	// On Unix, the default is $TMPDIR if non-empty, else /tmp.
+	// On Windows, the default is GetTempPath, returning the first non-empty value from %TMP%, %TEMP%, %USERPROFILE%, or the Windows directory.
+	f.StringVarP(&o.FileName, "filename", "f", consts.DefaultHaulArchiveName, "(Optional) Specify the name of inputted archive")
 	f.StringVarP(&o.TempOverride, "tempdir", "t", "", "(Optional) Override the default temporary directiory determined by the OS")
 }

--- a/internal/flags/load.go
+++ b/internal/flags/load.go
@@ -7,7 +7,7 @@ import (
 
 type LoadOpts struct {
 	*StoreRootOpts
-	FileName     string
+	FileName     []string
 	TempOverride string
 }
 
@@ -16,6 +16,6 @@ func (o *LoadOpts) AddFlags(cmd *cobra.Command) {
 
 	// On Unix, the default is $TMPDIR if non-empty, else /tmp.
 	// On Windows, the default is GetTempPath, returning the first non-empty value from %TMP%, %TEMP%, %USERPROFILE%, or the Windows directory.
-	f.StringVarP(&o.FileName, "filename", "f", consts.DefaultHaulArchiveName, "(Optional) Specify the name of inputted archive")
-	f.StringVarP(&o.TempOverride, "tempdir", "t", "", "(Optional) Override the default temporary directiory determined by the OS")
+	f.StringSliceVarP(&o.FileName, "filename", "f", []string{consts.DefaultHaulArchiveName}, "(Optional) Specify the name of inputted archive(s)")
+	f.StringVarP(&o.TempOverride, "tempdir", "t", "", "(Optional) Override the default temporary directory determined by the OS")
 }

--- a/internal/flags/save.go
+++ b/internal/flags/save.go
@@ -2,15 +2,18 @@ package flags
 
 import (
 	"github.com/spf13/cobra"
+	"hauler.dev/go/hauler/pkg/consts"
 )
 
 type SaveOpts struct {
 	*StoreRootOpts
+	FileName string
 	Platform string
 }
 
 func (o *SaveOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
+	f.StringVarP(&o.FileName, "filename", "f", consts.DefaultHaulerArchiveName, "(Optional) Specify the name of outputted archive")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform for runtime imports... i.e. linux/amd64 (unspecified implies all)")
 }

--- a/internal/flags/save.go
+++ b/internal/flags/save.go
@@ -2,18 +2,15 @@ package flags
 
 import (
 	"github.com/spf13/cobra"
-	"hauler.dev/go/hauler/pkg/consts"
 )
 
 type SaveOpts struct {
 	*StoreRootOpts
-	FileName string
 	Platform string
 }
 
 func (o *SaveOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	f.StringVarP(&o.FileName, "filename", "f", consts.DefaultHaulArchiveName, "(Optional) Specify the name of outputted archive")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform for runtime imports... i.e. linux/amd64 (unspecified implies all)")
 }

--- a/internal/flags/store.go
+++ b/internal/flags/store.go
@@ -41,6 +41,8 @@ func (o *StoreRootOpts) Store(ctx context.Context) (*store.Layout, error) {
 		return nil, err
 	}
 
+	o.StoreDir = abs
+
 	l.Debugf("using store at [%s]", abs)
 
 	if _, err := os.Stat(abs); errors.Is(err, os.ErrNotExist) {

--- a/pkg/archives/archiver.go
+++ b/pkg/archives/archiver.go
@@ -38,24 +38,24 @@ func isExist(path string) bool {
 // archival: the archival to use (tar, zip, etc.)
 func Archive(ctx context.Context, dir, outfile string, compression archives.Compression, archival archives.Archival) error {
 	l := log.FromContext(ctx)
-	l.Debugf("Starting the archival process for directory: %s", dir)
+	l.Debugf("starting the archival process for [%s]", dir)
 
 	// remove outfile
-	l.Debugf("Removing any existing output file: %s", outfile)
+	l.Debugf("removing existing output file: [%s]", outfile)
 	if err := os.RemoveAll(outfile); err != nil {
-		errMsg := fmt.Errorf("failed to remove existing output file '%s': %w", outfile, err)
+		errMsg := fmt.Errorf("failed to remove existing output file [%s]: %w", outfile, err)
 		l.Debugf(errMsg.Error())
 		return errMsg
 	}
 
 	if !isExist(dir) {
-		errMsg := fmt.Errorf("directory '%s' does not exist, cannot proceed with archival", dir)
+		errMsg := fmt.Errorf("directory [%s] does not exist, cannot proceed with archival", dir)
 		l.Debugf(errMsg.Error())
 		return errMsg
 	}
 
 	// map files on disk to their paths in the archive
-	l.Debugf("Mapping files in directory: %s", dir)
+	l.Debugf("mapping files in directory [%s]", dir)
 	archiveDirName := filepath.Base(filepath.Clean(dir))
 	if dir == "." {
 		archiveDirName = ""
@@ -64,40 +64,40 @@ func Archive(ctx context.Context, dir, outfile string, compression archives.Comp
 		dir: archiveDirName,
 	})
 	if err != nil {
-		errMsg := fmt.Errorf("error mapping files from directory '%s': %w", dir, err)
+		errMsg := fmt.Errorf("error mapping files from directory [%s]: %w", dir, err)
 		l.Debugf(errMsg.Error())
 		return errMsg
 	}
-	l.Debugf("Successfully mapped files for directory: %s", dir)
+	l.Debugf("successfully mapped files for directory [%s]", dir)
 
 	// create the output file we'll write to
-	l.Debugf("Creating output file: %s", outfile)
+	l.Debugf("creating output file [%s]", outfile)
 	outf, err := os.Create(outfile)
 	if err != nil {
-		errMsg := fmt.Errorf("error creating output file '%s': %w", outfile, err)
+		errMsg := fmt.Errorf("error creating output file [%s]: %w", outfile, err)
 		l.Debugf(errMsg.Error())
 		return errMsg
 	}
 	defer func() {
-		l.Debugf("Closing output file: %s", outfile)
+		l.Debugf("closing output file [%s]", outfile)
 		outf.Close()
 	}()
 
 	// define the archive format
-	l.Debugf("Defining the archive format with compression: %T and archival: %T", compression, archival)
+	l.Debugf("defining the archive format: [%T]/[%T]", archival, compression)
 	format := archives.CompressedArchive{
 		Compression: compression,
 		Archival:    archival,
 	}
 
 	// create the archive
-	l.Debugf("Starting archive creation: %s", outfile)
+	l.Debugf("starting archive for [%s]", outfile)
 	err = format.Archive(context.Background(), outf, files)
 	if err != nil {
-		errMsg := fmt.Errorf("error during archive creation for output file '%s': %w", outfile, err)
+		errMsg := fmt.Errorf("error during archive creation for output file [%s]: %w", outfile, err)
 		l.Debugf(errMsg.Error())
 		return errMsg
 	}
-	l.Debugf("Archive created successfully: %s", outfile)
+	l.Debugf("archive created successfully [%s]", outfile)
 	return nil
 }

--- a/pkg/archives/unarchiver.go
+++ b/pkg/archives/unarchiver.go
@@ -33,9 +33,9 @@ func securePath(basePath, relativePath string) (string, error) {
 // createDirWithPermissions creates a directory with specified permissions.
 func createDirWithPermissions(ctx context.Context, path string, mode os.FileMode) error {
 	l := log.FromContext(ctx)
-	l.Debugf("Creating directory: %s", path)
+	l.Debugf("creating directory [%s]", path)
 	if err := os.MkdirAll(path, mode); err != nil {
-		return fmt.Errorf("mkdir: %w", err)
+		return fmt.Errorf("failed to mkdir: %w", err)
 	}
 	return nil
 }
@@ -43,7 +43,7 @@ func createDirWithPermissions(ctx context.Context, path string, mode os.FileMode
 // setPermissions applies permissions to a file or directory.
 func setPermissions(path string, mode os.FileMode) error {
 	if err := os.Chmod(path, mode); err != nil {
-		return fmt.Errorf("chmod: %w", err)
+		return fmt.Errorf("failed to chmod: %w", err)
 	}
 	return nil
 }
@@ -51,7 +51,7 @@ func setPermissions(path string, mode os.FileMode) error {
 // handleFile handles the extraction of a file from the archive.
 func handleFile(ctx context.Context, f archives.FileInfo, dst string) error {
 	l := log.FromContext(ctx)
-	l.Debugf("Handling file: %s", f.NameInArchive)
+	l.Debugf("handling file [%s]", f.NameInArchive)
 
 	// Validate and construct the destination path
 	dstPath, pathErr := securePath(dst, f.NameInArchive)
@@ -69,34 +69,34 @@ func handleFile(ctx context.Context, f archives.FileInfo, dst string) error {
 	if f.IsDir() {
 		// Create the directory with permissions from the archive
 		if dirErr := createDirWithPermissions(ctx, dstPath, f.Mode()); dirErr != nil {
-			return fmt.Errorf("creating directory: %w", dirErr)
+			return fmt.Errorf("failed to create directory: %w", dirErr)
 		}
-		l.Debugf("Successfully created directory: %s", dstPath)
+		l.Debugf("successfully created directory [%s]", dstPath)
 		return nil
 	}
 
 	// Ignore symlinks (or hardlinks)
 	if f.LinkTarget != "" {
-		l.Debugf("Skipping symlink: %s -> %s", dstPath, f.LinkTarget)
+		l.Debugf("skipping symlink [%s] to [%s]", dstPath, f.LinkTarget)
 		return nil
 	}
 
 	// Check and handle parent directory permissions
 	originalMode, statErr := os.Stat(parentDir)
 	if statErr != nil {
-		return fmt.Errorf("stat parent directory: %w", statErr)
+		return fmt.Errorf("failed to stat parent directory: %w", statErr)
 	}
 
 	// If parent directory is read-only, temporarily make it writable
 	if originalMode.Mode().Perm()&0o200 == 0 {
-		l.Debugf("Parent directory is read-only, temporarily making it writable: %s", parentDir)
+		l.Debugf("parent directory is read only... temporarily making it writable [%s]", parentDir)
 		if chmodErr := os.Chmod(parentDir, originalMode.Mode()|0o200); chmodErr != nil {
-			return fmt.Errorf("chmod parent directory: %w", chmodErr)
+			return fmt.Errorf("failed to chmod parent directory: %w", chmodErr)
 		}
 		defer func() {
 			// Restore the original permissions after writing
 			if chmodErr := os.Chmod(parentDir, originalMode.Mode()); chmodErr != nil {
-				l.Debugf("Failed to restore original permissions for %s: %v", parentDir, chmodErr)
+				l.Debugf("failed to restore original permissions for [%s]: %v", parentDir, chmodErr)
 			}
 		}()
 	}
@@ -104,36 +104,36 @@ func handleFile(ctx context.Context, f archives.FileInfo, dst string) error {
 	// Handle regular files
 	reader, openErr := f.Open()
 	if openErr != nil {
-		return fmt.Errorf("open file: %w", openErr)
+		return fmt.Errorf("failed to open file: %w", openErr)
 	}
 	defer reader.Close()
 
 	dstFile, createErr := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY, f.Mode())
 	if createErr != nil {
-		return fmt.Errorf("create file: %w", createErr)
+		return fmt.Errorf("failed to create file: %w", createErr)
 	}
 	defer dstFile.Close()
 
 	if _, copyErr := io.Copy(dstFile, reader); copyErr != nil {
-		return fmt.Errorf("copy: %w", copyErr)
+		return fmt.Errorf("failed to copy: %w", copyErr)
 	}
-	l.Debugf("Successfully extracted file: %s", dstPath)
+	l.Debugf("successfully extracted file [%s]", dstPath)
 	return nil
 }
 
 // Unarchive unarchives a tarball to a directory, symlinks and hardlinks are ignored.
 func Unarchive(ctx context.Context, tarball, dst string) error {
 	l := log.FromContext(ctx)
-	l.Debugf("Unarchiving %s to %s", tarball, dst)
+	l.Debugf("unarchiving temporary archive [%s] to temporary store [%s]", tarball, dst)
 	archiveFile, openErr := os.Open(tarball)
 	if openErr != nil {
-		return fmt.Errorf("open tarball %s: %w", tarball, openErr)
+		return fmt.Errorf("failed to open tarball %s: %w", tarball, openErr)
 	}
 	defer archiveFile.Close()
 
 	format, input, identifyErr := archives.Identify(context.Background(), tarball, archiveFile)
 	if identifyErr != nil {
-		return fmt.Errorf("identify format: %w", identifyErr)
+		return fmt.Errorf("failed to identify format: %w", identifyErr)
 	}
 
 	extractor, ok := format.(archives.Extractor)
@@ -142,7 +142,7 @@ func Unarchive(ctx context.Context, tarball, dst string) error {
 	}
 
 	if dirErr := createDirWithPermissions(ctx, dst, dirPermissions); dirErr != nil {
-		return fmt.Errorf("creating destination directory: %w", dirErr)
+		return fmt.Errorf("failed to create destination directory: %w", dirErr)
 	}
 
 	handler := func(ctx context.Context, f archives.FileInfo) error {
@@ -150,9 +150,9 @@ func Unarchive(ctx context.Context, tarball, dst string) error {
 	}
 
 	if extractErr := extractor.Extract(context.Background(), input, handler); extractErr != nil {
-		return fmt.Errorf("extracting files: %w", extractErr)
+		return fmt.Errorf("failed to extract: %w", extractErr)
 	}
 
-	l.Debugf("Unarchiving completed successfully.")
+	l.Infof("unarchiving completed successfully")
 	return nil
 }

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -84,7 +84,7 @@ const (
 	DefaultFileserverRootDir = "fileserver"
 	DefaultFileserverPort    = 8080
 	DefaultFileserverTimeout = 60
-	DefaultHaulArchiveName   = "haul.tar.zst"
+	DefaultHaulerArchiveName = "haul.tar.zst"
 	DefaultRetries           = 3
 	RetriesInterval          = 5
 	CustomTimeFormat         = "2006-01-02 15:04:05"


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- Partially resolves... https://github.com/hauler-dev/hauler/issues/208

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature
- Breaking Change

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- [Feature] Added support for `hauler store load` to accept multiple local and remote archives of `http`/`https`
- [Feature] Improved logging for related commands and outputs of `hauler store load`/`hauler store save`
- [Feature] Defaulted local file of `haul.tar.zst` to match the functionality between both commands
- **[Breaking Change] Removed the `flag` of `--filename/-f` for `hauler store save`** (argument)

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

```bash
zackbradys@Zacks-MacBook-Pro test % ls -la
total 1124216
drwxr-xr-x    5 zackbradys  staff        160 Feb  3 00:09 .
drwxr-xr-x  213 zackbradys  staff       6816 Feb  2 10:17 ..
-rw-r--r--    1 zackbradys  staff  575594527 Feb  3 00:01 haul.tar.zst
drwxr-xr-x    4 zackbradys  staff        128 Feb  3 00:09 store
drwxr-xr-x    7 zackbradys  staff        224 Feb  3 00:09 tmp
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % rm -rf store 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info
+-----------+------+----------+----------+------+
| REFERENCE | TYPE | PLATFORM | # LAYERS | SIZE |
+-----------+------+----------+----------+------+
+-----------+------+----------+----------+------+
|                                TOTAL   | 0 B  |
+-----------+------+----------+----------+------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store load -h
Load a content store from a store archive

Usage:
  hauler store load [flags]

Flags:
  -h, --help              help for load
  -t, --tempdir string    (Optional) Override the default temporary directiory determined by the OS

Global Flags:
  -d, --haulerdir string   Set the location of the hauler directory (default $HOME/.hauler)
      --ignore-errors      Ignore/Bypass errors (i.e. warn on error) (defaults false)
  -l, --log-level string   Set the logging level (i.e. info, debug, warn) (default "info")
  -r, --retries int        Set the number of retries for operations (default 3)
  -s, --store string       Set the directory to use for the content store
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store load       
2025-02-03 00:12:32 INF loading archive [haul.tar.zst] to store [store]
2025-02-03 00:12:33 INF unarchiving completed successfully
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info
+---------------------------------------+-------+-----------------+----------+----------+
| REFERENCE                             | TYPE  | PLATFORM        | # LAYERS | SIZE     |
+---------------------------------------+-------+-----------------+----------+----------+
| index.docker.io/library/alpine:latest | image | linux/386       |        1 | 3.5 MB   |
|                                       | image | linux/amd64     |        1 | 3.6 MB   |
|                                       | image | linux/arm       |        1 | 3.1 MB   |
|                                       | image | linux/arm       |        1 | 3.4 MB   |
|                                       | image | linux/arm64     |        1 | 4.0 MB   |
|                                       | image | linux/ppc64le   |        1 | 3.6 MB   |
|                                       | image | linux/riscv64   |        1 | 3.4 MB   |
|                                       | image | linux/s390x     |        1 | 3.5 MB   |
|                                       | image | unknown/unknown |        2 | 84.4 kB  |
|                                       | image | unknown/unknown |        2 | 84.3 kB  |
|                                       | image | unknown/unknown |        2 | 84.2 kB  |
|                                       | image | unknown/unknown |        2 | 84.3 kB  |
|                                       | image | unknown/unknown |        2 | 82.4 kB  |
|                                       | image | unknown/unknown |        1 | 5.5 kB   |
|                                       | image | unknown/unknown |        2 | 82.4 kB  |
|                                       | image | unknown/unknown |        2 | 82.3 kB  |
| index.docker.io/library/nginx:latest  | image | linux/386       |        7 | 70.4 MB  |
|                                       | image | linux/amd64     |        7 | 72.1 MB  |
|                                       | image | linux/arm       |        7 | 62.4 MB  |
|                                       | image | linux/arm       |        7 | 60.7 MB  |
|                                       | image | linux/arm64     |        7 | 68.5 MB  |
|                                       | image | linux/mips64le  |        7 | 68.1 MB  |
|                                       | image | linux/ppc64le   |        7 | 76.7 MB  |
|                                       | image | linux/s390x     |        7 | 66.7 MB  |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        1 | 34.5 kB  |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
+---------------------------------------+-------+-----------------+----------+----------+
|                                                                    TOTAL   | 595.2 MB |
+---------------------------------------+-------+-----------------+----------+----------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % rm -rf store
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info   
+-----------+------+----------+----------+------+
| REFERENCE | TYPE | PLATFORM | # LAYERS | SIZE |
+-----------+------+----------+----------+------+
+-----------+------+----------+----------+------+
|                                TOTAL   | 0 B  |
+-----------+------+----------+----------+------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store load https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst
2025-02-03 00:12:49 INF loading archive [https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst] to store [store]
2025-02-03 00:12:51 INF unarchiving completed successfully
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info                                                                 
+---------------------------------------+-------+-----------------+----------+---------+
| REFERENCE                             | TYPE  | PLATFORM        | # LAYERS | SIZE    |
+---------------------------------------+-------+-----------------+----------+---------+
| index.docker.io/library/alpine:latest | image | linux/386       |        1 | 3.5 MB  |
|                                       | image | linux/amd64     |        1 | 3.6 MB  |
|                                       | image | linux/arm       |        1 | 3.1 MB  |
|                                       | image | linux/arm       |        1 | 3.4 MB  |
|                                       | image | linux/arm64     |        1 | 4.0 MB  |
|                                       | image | linux/ppc64le   |        1 | 3.6 MB  |
|                                       | image | linux/riscv64   |        1 | 3.4 MB  |
|                                       | image | linux/s390x     |        1 | 3.5 MB  |
|                                       | image | unknown/unknown |        2 | 84.4 kB |
|                                       | image | unknown/unknown |        2 | 84.3 kB |
|                                       | image | unknown/unknown |        2 | 84.2 kB |
|                                       | image | unknown/unknown |        2 | 84.3 kB |
|                                       | image | unknown/unknown |        2 | 82.4 kB |
|                                       | image | unknown/unknown |        1 | 5.5 kB  |
|                                       | image | unknown/unknown |        2 | 82.4 kB |
|                                       | image | unknown/unknown |        2 | 82.3 kB |
+---------------------------------------+-------+-----------------+----------+---------+
|                                                                    TOTAL   | 28.5 MB |
+---------------------------------------+-------+-----------------+----------+---------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % rm -rf store
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info
+-----------+------+----------+----------+------+
| REFERENCE | TYPE | PLATFORM | # LAYERS | SIZE |
+-----------+------+----------+----------+------+
+-----------+------+----------+----------+------+
|                                TOTAL   | 0 B  |
+-----------+------+----------+----------+------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store load -l debug -t /Users/zackbradys/Downloads/RGS/test/tmp https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst
2025-02-03 00:13:58 DBG running cli command [hauler store load]
2025-02-03 00:13:58 DBG using store at [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 00:13:58 INF loading archive [https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst] to store [store]
2025-02-03 00:13:58 DBG using temporary directory [/Users/zackbradys/Downloads/RGS/test/tmp]
2025-02-03 00:13:58 DBG detected remote archive... starting download... [https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst]
2025-02-03 00:14:00 DBG unarchiving temporary archive [/Users/zackbradys/Downloads/RGS/test/tmp/stores.tar.zst] to temporary store [/Users/zackbradys/Downloads/RGS/test/tmp]
2025-02-03 00:14:00 DBG creating directory [/Users/zackbradys/Downloads/RGS/test/tmp]
2025-02-03 00:14:00 INF unarchiving completed successfully
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info
+---------------------------------------+-------+-----------------+----------+---------+
| REFERENCE                             | TYPE  | PLATFORM        | # LAYERS | SIZE    |
+---------------------------------------+-------+-----------------+----------+---------+
| index.docker.io/library/alpine:latest | image | linux/386       |        1 | 3.5 MB  |
|                                       | image | linux/amd64     |        1 | 3.6 MB  |
|                                       | image | linux/arm       |        1 | 3.1 MB  |
|                                       | image | linux/arm       |        1 | 3.4 MB  |
|                                       | image | linux/arm64     |        1 | 4.0 MB  |
|                                       | image | linux/ppc64le   |        1 | 3.6 MB  |
|                                       | image | linux/riscv64   |        1 | 3.4 MB  |
|                                       | image | linux/s390x     |        1 | 3.5 MB  |
|                                       | image | unknown/unknown |        2 | 84.4 kB |
|                                       | image | unknown/unknown |        2 | 84.3 kB |
|                                       | image | unknown/unknown |        2 | 84.2 kB |
|                                       | image | unknown/unknown |        2 | 84.3 kB |
|                                       | image | unknown/unknown |        2 | 82.4 kB |
|                                       | image | unknown/unknown |        1 | 5.5 kB  |
|                                       | image | unknown/unknown |        2 | 82.4 kB |
|                                       | image | unknown/unknown |        2 | 82.3 kB |
+---------------------------------------+-------+-----------------+----------+---------+
|                                                                    TOTAL   | 28.5 MB |
+---------------------------------------+-------+-----------------+----------+---------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % rm -rf store 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info                                                                                                                      
+-----------+------+----------+----------+------+
| REFERENCE | TYPE | PLATFORM | # LAYERS | SIZE |
+-----------+------+----------+----------+------+
+-----------+------+----------+----------+------+
|                                TOTAL   | 0 B  |
+-----------+------+----------+----------+------+
zackbradys@Zacks-MacBook-Pro test % export HAULER_TEMP_DIR=/Users/zackbradys/Downloads/RGS/test/tmp
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store load -l debug https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst                                         
2025-02-03 00:14:29 DBG running cli command [hauler store load]
2025-02-03 00:14:29 DBG using store at [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 00:14:29 INF loading archive [https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst] to store [store]
2025-02-03 00:14:29 DBG using temporary directory [/Users/zackbradys/Downloads/RGS/test/tmp/hauler3685394917]
2025-02-03 00:14:29 DBG detected remote archive... starting download... [https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst]
2025-02-03 00:14:30 DBG unarchiving temporary archive [/Users/zackbradys/Downloads/RGS/test/tmp/hauler3685394917/stores.tar.zst] to temporary store [/Users/zackbradys/Downloads/RGS/test/tmp/hauler3685394917]
2025-02-03 00:14:30 DBG creating directory [/Users/zackbradys/Downloads/RGS/test/tmp/hauler3685394917]
2025-02-03 00:14:30 INF unarchiving completed successfully
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info
+---------------------------------------+-------+-----------------+----------+---------+
| REFERENCE                             | TYPE  | PLATFORM        | # LAYERS | SIZE    |
+---------------------------------------+-------+-----------------+----------+---------+
| index.docker.io/library/alpine:latest | image | linux/386       |        1 | 3.5 MB  |
|                                       | image | linux/amd64     |        1 | 3.6 MB  |
|                                       | image | linux/arm       |        1 | 3.1 MB  |
|                                       | image | linux/arm       |        1 | 3.4 MB  |
|                                       | image | linux/arm64     |        1 | 4.0 MB  |
|                                       | image | linux/ppc64le   |        1 | 3.6 MB  |
|                                       | image | linux/riscv64   |        1 | 3.4 MB  |
|                                       | image | linux/s390x     |        1 | 3.5 MB  |
|                                       | image | unknown/unknown |        2 | 84.4 kB |
|                                       | image | unknown/unknown |        2 | 84.3 kB |
|                                       | image | unknown/unknown |        2 | 84.2 kB |
|                                       | image | unknown/unknown |        2 | 84.3 kB |
|                                       | image | unknown/unknown |        2 | 82.4 kB |
|                                       | image | unknown/unknown |        1 | 5.5 kB  |
|                                       | image | unknown/unknown |        2 | 82.4 kB |
|                                       | image | unknown/unknown |        2 | 82.3 kB |
+---------------------------------------+-------+-----------------+----------+---------+
|                                                                    TOTAL   | 28.5 MB |
+---------------------------------------+-------+-----------------+----------+---------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % rm -rf store 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info                                                                                                                      
+-----------+------+----------+----------+------+
| REFERENCE | TYPE | PLATFORM | # LAYERS | SIZE |
+-----------+------+----------+----------+------+
+-----------+------+----------+----------+------+
|                                TOTAL   | 0 B  |
+-----------+------+----------+----------+------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store load -l debug -t /Users/zackbradys/Downloads/RGS/test/tmp https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst https://carbide.s3.us-gov-east-1.amazonaws.com/store.tar.zst
2025-02-03 00:39:13 DBG running cli command [hauler store load]
2025-02-03 00:39:13 DBG using store at [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 00:39:13 INF loading archive [https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst] to store [store]
2025-02-03 00:39:13 DBG using temporary directory [/Users/zackbradys/Downloads/RGS/test/tmp]
2025-02-03 00:39:13 DBG detected remote archive... starting download... [https://carbide.s3.us-gov-east-1.amazonaws.com/stores.tar.zst]
2025-02-03 00:39:14 DBG unarchiving temporary archive [/Users/zackbradys/Downloads/RGS/test/tmp/stores.tar.zst] to temporary store [/Users/zackbradys/Downloads/RGS/test/tmp]
2025-02-03 00:39:14 DBG creating directory [/Users/zackbradys/Downloads/RGS/test/tmp]
2025-02-03 00:39:14 INF unarchiving completed successfully
2025-02-03 00:39:14 INF loading archive [https://carbide.s3.us-gov-east-1.amazonaws.com/store.tar.zst] to store [store]
2025-02-03 00:39:14 DBG using temporary directory [/Users/zackbradys/Downloads/RGS/test/tmp]
2025-02-03 00:39:14 DBG detected remote archive... starting download... [https://carbide.s3.us-gov-east-1.amazonaws.com/store.tar.zst]
2025-02-03 00:39:35 DBG unarchiving temporary archive [/Users/zackbradys/Downloads/RGS/test/tmp/store.tar.zst] to temporary store [/Users/zackbradys/Downloads/RGS/test/tmp]
2025-02-03 00:39:35 DBG creating directory [/Users/zackbradys/Downloads/RGS/test/tmp]
2025-02-03 00:39:36 INF unarchiving completed successfully
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info
+---------------------------------------+-------+-----------------+----------+----------+
| REFERENCE                             | TYPE  | PLATFORM        | # LAYERS | SIZE     |
+---------------------------------------+-------+-----------------+----------+----------+
| index.docker.io/library/alpine:latest | image | linux/386       |        1 | 3.5 MB   |
|                                       | image | linux/amd64     |        1 | 3.6 MB   |
|                                       | image | linux/arm       |        1 | 3.1 MB   |
|                                       | image | linux/arm       |        1 | 3.4 MB   |
|                                       | image | linux/arm64     |        1 | 4.0 MB   |
|                                       | image | linux/ppc64le   |        1 | 3.6 MB   |
|                                       | image | linux/riscv64   |        1 | 3.4 MB   |
|                                       | image | linux/s390x     |        1 | 3.5 MB   |
|                                       | image | unknown/unknown |        2 | 84.4 kB  |
|                                       | image | unknown/unknown |        2 | 84.3 kB  |
|                                       | image | unknown/unknown |        2 | 84.2 kB  |
|                                       | image | unknown/unknown |        2 | 84.3 kB  |
|                                       | image | unknown/unknown |        2 | 82.4 kB  |
|                                       | image | unknown/unknown |        1 | 5.5 kB   |
|                                       | image | unknown/unknown |        2 | 82.4 kB  |
|                                       | image | unknown/unknown |        2 | 82.3 kB  |
| index.docker.io/library/nginx:latest  | image | linux/386       |        7 | 70.4 MB  |
|                                       | image | linux/amd64     |        7 | 72.1 MB  |
|                                       | image | linux/arm       |        7 | 62.4 MB  |
|                                       | image | linux/arm       |        7 | 60.7 MB  |
|                                       | image | linux/arm64     |        7 | 68.5 MB  |
|                                       | image | linux/mips64le  |        7 | 68.1 MB  |
|                                       | image | linux/ppc64le   |        7 | 76.7 MB  |
|                                       | image | linux/s390x     |        7 | 66.7 MB  |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        1 | 34.5 kB  |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
|                                       | image | unknown/unknown |        2 | 3.0 MB   |
+---------------------------------------+-------+-----------------+----------+----------+
|                                                                    TOTAL   | 595.2 MB |
+---------------------------------------+-------+-----------------+----------+----------+
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A