### PR TITLE
added remote sync updates

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -258,7 +258,7 @@ jobs:
           # download local helm repository
           curl -sfOL https://github.com/rancherfederal/rancher-cluster-templates/releases/download/rancher-cluster-templates-0.5.2/rancher-cluster-templates-0.5.2.tgz
           # verify via sync
-          hauler store sync --files testdata/hauler-manifest-pipeline.yaml
+          hauler store sync --filename testdata/hauler-manifest-pipeline.yaml
           # need more tests here
 
       - name: Verify - hauler store serve

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -258,7 +258,7 @@ jobs:
           # download local helm repository
           curl -sfOL https://github.com/rancherfederal/rancher-cluster-templates/releases/download/rancher-cluster-templates-0.5.2/rancher-cluster-templates-0.5.2.tgz
           # verify via sync
-          hauler store sync --filename testdata/hauler-manifest-pipeline.yaml
+          hauler store sync --files testdata/hauler-manifest-pipeline.yaml
           # need more tests here
 
       - name: Verify - hauler store serve

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -67,6 +67,7 @@ func addStoreSync(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 	cmd := &cobra.Command{
 		Use:   "sync",
 		Short: "Sync content to the content store",
+		Args:  cobra.ExactArgs(0),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 
@@ -75,7 +76,7 @@ func addStoreSync(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 				return err
 			}
 
-			return store.SyncCmd(ctx, o, s, rso, ro)
+			return store.SyncCmd(ctx, o, s, rso, ro, o.TempOverride)
 		},
 	}
 	o.AddFlags(cmd)

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -124,7 +124,6 @@ func addStoreServe(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comma
 	return cmd
 }
 
-// RegistryCmd serves the registry
 func addStoreServeRegistry(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Command {
 	o := &flags.ServeRegistryOpts{StoreRootOpts: rso}
 
@@ -148,7 +147,6 @@ func addStoreServeRegistry(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cob
 	return cmd
 }
 
-// FileServerCmd serves the file server
 func addStoreServeFiles(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Command {
 	o := &flags.ServeFilesOpts{StoreRootOpts: rso}
 

--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -42,13 +42,13 @@ func storeFile(ctx context.Context, s *store.Layout, fi v1alpha1.File) error {
 		return err
 	}
 
-	l.Infof("adding 'file' [%s] to the store as [%s]", fi.Path, ref.Name())
+	l.Infof("adding file [%s] to the store as [%s]", fi.Path, ref.Name())
 	_, err = s.AddOCI(ctx, f, ref.Name())
 	if err != nil {
 		return err
 	}
 
-	l.Infof("successfully added 'file' [%s]", ref.Name())
+	l.Infof("successfully added file [%s]", ref.Name())
 
 	return nil
 }
@@ -83,15 +83,15 @@ func storeImage(ctx context.Context, s *store.Layout, i v1alpha1.Image, platform
 		}
 	}
 
-	l.Infof("adding 'image' [%s] to the store", i.Name)
+	l.Infof("adding image [%s] to the store", i.Name)
 
 	r, err := name.ParseReference(i.Name)
 	if err != nil {
 		if ro.IgnoreErrors {
-			l.Warnf("unable to parse 'image' [%s]: %v... skipping...", i.Name, err)
+			l.Warnf("unable to parse image [%s]: %v... skipping...", i.Name, err)
 			return nil
 		} else {
-			l.Errorf("unable to parse 'image' [%s]: %v", i.Name, err)
+			l.Errorf("unable to parse image [%s]: %v", i.Name, err)
 			return err
 		}
 	}
@@ -99,15 +99,15 @@ func storeImage(ctx context.Context, s *store.Layout, i v1alpha1.Image, platform
 	err = cosign.SaveImage(ctx, s, r.Name(), platform, rso, ro)
 	if err != nil {
 		if ro.IgnoreErrors {
-			l.Warnf("unable to add 'image' [%s] to store: %v... skipping...", r.Name(), err)
+			l.Warnf("unable to add image [%s] to store: %v... skipping...", r.Name(), err)
 			return nil
 		} else {
-			l.Errorf("unable to add 'image' [%s] to store: %v", r.Name(), err)
+			l.Errorf("unable to add image [%s] to store: %v", r.Name(), err)
 			return err
 		}
 	}
 
-	l.Infof("successfully added 'image' [%s]", r.Name())
+	l.Infof("successfully added image [%s]", r.Name())
 	return nil
 }
 
@@ -125,7 +125,7 @@ func AddChartCmd(ctx context.Context, o *flags.AddChartOpts, s *store.Layout, ch
 func storeChart(ctx context.Context, s *store.Layout, cfg v1alpha1.Chart, opts *action.ChartPathOptions) error {
 	l := log.FromContext(ctx)
 
-	l.Infof("adding 'chart' [%s] to the store", cfg.Name)
+	l.Infof("adding chart [%s] to the store", cfg.Name)
 
 	// TODO: This shouldn't be necessary
 	opts.RepoURL = cfg.RepoURL
@@ -150,6 +150,6 @@ func storeChart(ctx context.Context, s *store.Layout, cfg v1alpha1.Chart, opts *
 		return err
 	}
 
-	l.Infof("successfully added 'chart' [%s]", ref.Name())
+	l.Infof("successfully added chart [%s]", ref.Name())
 	return nil
 }

--- a/cmd/hauler/cli/store/sync.go
+++ b/cmd/hauler/cli/store/sync.go
@@ -77,6 +77,7 @@ func SyncCmd(ctx context.Context, o *flags.SyncOpts, s *store.Layout, rso *flags
 		if err != nil {
 			return err
 		}
+		l.Infof("processing completed successfully")
 	}
 
 	// if passed a manifest... process it
@@ -102,6 +103,7 @@ func SyncCmd(ctx context.Context, o *flags.SyncOpts, s *store.Layout, rso *flags
 		if err != nil {
 			return err
 		}
+		l.Infof("processing completed successfully")
 	}
 
 	return nil

--- a/internal/flags/store.go
+++ b/internal/flags/store.go
@@ -41,6 +41,8 @@ func (o *StoreRootOpts) Store(ctx context.Context) (*store.Layout, error) {
 		return nil, err
 	}
 
+	o.StoreDir = abs
+
 	l.Debugf("using store at [%s]", abs)
 
 	if _, err := os.Stat(abs); errors.Is(err, os.ErrNotExist) {

--- a/internal/flags/sync.go
+++ b/internal/flags/sync.go
@@ -19,7 +19,7 @@ type SyncOpts struct {
 func (o *SyncOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	f.StringSliceVarP(&o.Filename, "filename", "f", []string{consts.DefaultHaulerManifestName}, "(Optional) Specify the name of inputted manifest(s)")
+	f.StringSliceVarP(&o.Filename, "files", "f", []string{consts.DefaultHaulerManifestName}, "Specify the name of manifest(s) to sync")
 	f.StringVarP(&o.Key, "key", "k", "", "(Optional) Location of public key to use for signature verification")
 	f.StringSliceVar(&o.Products, "products", []string{}, "(Optional) Specify the product name to fetch collections from the product registry i.e. rancher=v2.8.5,rke2=v1.28.11+rke2r1")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform of the image... i.e linux/amd64 (defaults to all)")

--- a/internal/flags/sync.go
+++ b/internal/flags/sync.go
@@ -19,7 +19,7 @@ type SyncOpts struct {
 func (o *SyncOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	f.StringSliceVarP(&o.Filename, "files", "f", []string{consts.DefaultHaulerManifestName}, "Specify the name of manifest(s) to sync")
+	f.StringSliceVarP(&o.Filename, "filename", "f", []string{consts.DefaultHaulerManifestName}, "Specify the name of manifest(s) to sync")
 	f.StringVarP(&o.Key, "key", "k", "", "(Optional) Location of public key to use for signature verification")
 	f.StringSliceVar(&o.Products, "products", []string{}, "(Optional) Specify the product name to fetch collections from the product registry i.e. rancher=v2.8.5,rke2=v1.28.11+rke2r1")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform of the image... i.e linux/amd64 (defaults to all)")

--- a/internal/flags/sync.go
+++ b/internal/flags/sync.go
@@ -1,24 +1,29 @@
 package flags
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/spf13/cobra"
+	"hauler.dev/go/hauler/pkg/consts"
+)
 
 type SyncOpts struct {
 	*StoreRootOpts
-	ContentFiles    []string
+	Filename        []string
 	Key             string
 	Products        []string
 	Platform        string
 	Registry        string
 	ProductRegistry string
+	TempOverride    string
 }
 
 func (o *SyncOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	f.StringSliceVarP(&o.ContentFiles, "files", "f", []string{}, "Location of content manifests (files)... i.e. --files ./rke2-files.yaml")
+	f.StringSliceVarP(&o.Filename, "filename", "f", []string{consts.DefaultHaulerManifestName}, "(Optional) Specify the name of inputted manifest(s)")
 	f.StringVarP(&o.Key, "key", "k", "", "(Optional) Location of public key to use for signature verification")
 	f.StringSliceVar(&o.Products, "products", []string{}, "(Optional) Specify the product name to fetch collections from the product registry i.e. rancher=v2.8.5,rke2=v1.28.11+rke2r1")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform of the image... i.e linux/amd64 (defaults to all)")
 	f.StringVarP(&o.Registry, "registry", "g", "", "(Optional) Specify the registry of the image for images that do not alredy define one")
 	f.StringVarP(&o.ProductRegistry, "product-registry", "c", "", "(Optional) Specify the product registry. Defaults to RGS Carbide Registry (rgcrprod.azurecr.us)")
+	f.StringVarP(&o.TempOverride, "tempdir", "t", "", "(Optional) Override the default temporary directiory determined by the OS")
 }

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -75,20 +75,21 @@ const (
 	ImageConfigFile    = "config.json"
 
 	// other constraints
-	CarbideRegistry          = "rgcrprod.azurecr.us"
-	APIVersion               = "v1alpha1"
-	DefaultNamespace         = "hauler"
-	DefaultTag               = "latest"
-	DefaultStoreName         = "store"
-	DefaultHaulerDirName     = ".hauler"
-	DefaultHaulerTempDirName = "hauler"
-	DefaultRegistryRootDir   = "registry"
-	DefaultRegistryPort      = 5000
-	DefaultFileserverRootDir = "fileserver"
-	DefaultFileserverPort    = 8080
-	DefaultFileserverTimeout = 60
-	DefaultHaulArchiveName   = "haul.tar.zst"
-	DefaultRetries           = 3
-	RetriesInterval          = 5
-	CustomTimeFormat         = "2006-01-02 15:04:05"
+	CarbideRegistry           = "rgcrprod.azurecr.us"
+	APIVersion                = "v1alpha1"
+	DefaultNamespace          = "hauler"
+	DefaultTag                = "latest"
+	DefaultStoreName          = "store"
+	DefaultHaulerDirName      = ".hauler"
+	DefaultHaulerTempDirName  = "hauler"
+	DefaultRegistryRootDir    = "registry"
+	DefaultRegistryPort       = 5000
+	DefaultFileserverRootDir  = "fileserver"
+	DefaultFileserverPort     = 8080
+	DefaultFileserverTimeout  = 60
+	DefaultHaulArchiveName    = "haul.tar.zst"
+	DefaultHaulerManifestName = "hauler-manifest.yaml"
+	DefaultRetries            = 3
+	RetriesInterval           = 5
+	CustomTimeFormat          = "2006-01-02 15:04:05"
 )


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- Partially resolves... https://github.com/hauler-dev/hauler/issues/208

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- [Feature] Added support for `hauler store sync` to accept multiple local and remote archives of `http`/`https`
- [Feature] Improved logging for related commands and outputs of `hauler store sync`
- [Feature] defaulted local file of `hauler-manifest.yaml (new behavior) to matches other commands...

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

```bash
zackbradys@Zacks-MacBook-Pro test % ls -la
total 40
drwxr-xr-x    5 zackbradys  staff    160 Feb  3 02:41 .
drwxr-xr-x  213 zackbradys  staff   6816 Feb  2 10:17 ..
-rwxr-xr-x    1 zackbradys  staff   1266 Feb  3 02:38 hauler-manifest.yaml
-rw-r--r--    1 zackbradys  staff  14970 Feb  3 02:33 rancher-cluster-templates-0.5.2.tgz
drwxr-xr-x    8 zackbradys  staff    256 Feb  3 00:29 tmp
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store sync         
2025-02-03 02:41:24 INF processing manifest [hauler-manifest.yaml] to store [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 02:41:24 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Images]
2025-02-03 02:41:24 INF adding 'image' [busybox] to the store
2025-02-03 02:41:30 INF successfully added 'image' [index.docker.io/library/busybox:latest]
2025-02-03 02:41:30 INF adding 'image' [busybox:stable] to the store
2025-02-03 02:41:31 INF successfully added 'image' [index.docker.io/library/busybox:stable]
2025-02-03 02:41:31 INF adding 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5] to the store
2025-02-03 02:41:33 INF successfully added 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5]
2025-02-03 02:41:33 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Charts]
2025-02-03 02:41:33 INF adding 'chart' [rancher] to the store
2025-02-03 02:41:35 INF successfully added 'chart' [hauler/rancher:2.10.2]
2025-02-03 02:41:35 INF adding 'chart' [rancher] to the store
2025-02-03 02:41:36 INF successfully added 'chart' [hauler/rancher:2.8.4]
2025-02-03 02:41:36 INF adding 'chart' [rancher] to the store
2025-02-03 02:41:38 INF successfully added 'chart' [hauler/rancher:2.8.3]
2025-02-03 02:41:38 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.1.1
Digest: sha256:3957fc2bf560f2ccd64e38b59651b097dddb38863124745df264053cae1b807a
2025-02-03 02:41:38 INF successfully added 'chart' [hauler/hauler-helm:1.1.1]
2025-02-03 02:41:38 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.6
Digest: sha256:c4befb2f4939f4b077e3fa3986ab11090a603ac8dc7f8f4ac61dc7a896d20455
2025-02-03 02:41:39 INF successfully added 'chart' [hauler/hauler-helm:1.0.6]
2025-02-03 02:41:39 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.4
Digest: sha256:6a0a7317980309f4551404bd11ee43d1a9d1f1fe97294c7ab051625e435c3d81
2025-02-03 02:41:39 INF successfully added 'chart' [hauler/hauler-helm:1.0.4]
2025-02-03 02:41:39 INF adding 'chart' [rancher-cluster-templates-0.5.2.tgz] to the store
2025-02-03 02:41:39 INF successfully added 'chart' [hauler/rancher-cluster-templates:0.5.2]
2025-02-03 02:41:39 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Files]
2025-02-03 02:41:39 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/install.sh:latest]
2025-02-03 02:41:39 INF successfully added 'file' [hauler/install.sh:latest]
2025-02-03 02:41:39 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/rke2-install.sh:latest]
2025-02-03 02:41:39 INF successfully added 'file' [hauler/rke2-install.sh:latest]
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % rm -rf store
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info
+-----------+------+----------+----------+------+
| REFERENCE | TYPE | PLATFORM | # LAYERS | SIZE |
+-----------+------+----------+----------+------+
+-----------+------+----------+----------+------+
|                                TOTAL   | 0 B  |
+-----------+------+----------+----------+------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store sync -l debug
2025-02-03 02:41:55 DBG running cli command [hauler store sync]
2025-02-03 02:41:55 DBG using store at [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 02:41:55 DBG using temporary directory at [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler1037744451]
2025-02-03 02:41:55 INF processing manifest [hauler-manifest.yaml] to store [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 02:41:55 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Images]
2025-02-03 02:41:55 INF adding 'image' [busybox] to the store
2025-02-03 02:41:56 DBG multi-arch image [true]
2025-02-03 02:42:00 INF successfully added 'image' [index.docker.io/library/busybox:latest]
2025-02-03 02:42:00 INF adding 'image' [busybox:stable] to the store
2025-02-03 02:42:00 DBG multi-arch image [true]
2025-02-03 02:42:00 DBG platform for image [linux/amd64]
2025-02-03 02:42:00 INF successfully added 'image' [index.docker.io/library/busybox:stable]
2025-02-03 02:42:00 INF adding 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5] to the store
2025-02-03 02:42:01 DBG multi-arch image [false]
2025-02-03 02:42:02 INF successfully added 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5]
2025-02-03 02:42:02 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Charts]
2025-02-03 02:42:02 INF adding 'chart' [rancher] to the store
2025-02-03 02:42:04 INF successfully added 'chart' [hauler/rancher:2.10.2]
2025-02-03 02:42:04 INF adding 'chart' [rancher] to the store
2025-02-03 02:42:05 INF successfully added 'chart' [hauler/rancher:2.8.4]
2025-02-03 02:42:05 INF adding 'chart' [rancher] to the store
2025-02-03 02:42:07 INF successfully added 'chart' [hauler/rancher:2.8.3]
2025-02-03 02:42:07 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.1.1
Digest: sha256:3957fc2bf560f2ccd64e38b59651b097dddb38863124745df264053cae1b807a
2025-02-03 02:42:08 INF successfully added 'chart' [hauler/hauler-helm:1.1.1]
2025-02-03 02:42:08 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.6
Digest: sha256:c4befb2f4939f4b077e3fa3986ab11090a603ac8dc7f8f4ac61dc7a896d20455
2025-02-03 02:42:08 INF successfully added 'chart' [hauler/hauler-helm:1.0.6]
2025-02-03 02:42:08 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.4
Digest: sha256:6a0a7317980309f4551404bd11ee43d1a9d1f1fe97294c7ab051625e435c3d81
2025-02-03 02:42:08 INF successfully added 'chart' [hauler/hauler-helm:1.0.4]
2025-02-03 02:42:08 INF adding 'chart' [rancher-cluster-templates-0.5.2.tgz] to the store
2025-02-03 02:42:08 INF successfully added 'chart' [hauler/rancher-cluster-templates:0.5.2]
2025-02-03 02:42:08 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Files]
2025-02-03 02:42:08 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/install.sh:latest]
2025-02-03 02:42:09 INF successfully added 'file' [hauler/install.sh:latest]
2025-02-03 02:42:09 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/rke2-install.sh:latest]
2025-02-03 02:42:09 INF successfully added 'file' [hauler/rke2-install.sh:latest]
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % rm -rf store
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info
+-----------+------+----------+----------+------+
| REFERENCE | TYPE | PLATFORM | # LAYERS | SIZE |
+-----------+------+----------+----------+------+
+-----------+------+----------+----------+------+
|                                TOTAL   | 0 B  |
+-----------+------+----------+----------+------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store sync -f https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml         
2025-02-03 02:43:17 INF processing manifest [https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml] to store [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 02:43:17 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Images]
2025-02-03 02:43:17 INF adding 'image' [busybox] to the store
2025-02-03 02:43:23 INF successfully added 'image' [index.docker.io/library/busybox:latest]
2025-02-03 02:43:23 INF adding 'image' [busybox:stable] to the store
2025-02-03 02:43:24 INF successfully added 'image' [index.docker.io/library/busybox:stable]
2025-02-03 02:43:24 INF adding 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5] to the store
2025-02-03 02:43:26 INF successfully added 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5]
2025-02-03 02:43:26 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Charts]
2025-02-03 02:43:26 INF adding 'chart' [rancher] to the store
2025-02-03 02:43:27 INF successfully added 'chart' [hauler/rancher:2.10.2]
2025-02-03 02:43:27 INF adding 'chart' [rancher] to the store
2025-02-03 02:43:29 INF successfully added 'chart' [hauler/rancher:2.8.4]
2025-02-03 02:43:29 INF adding 'chart' [rancher] to the store
2025-02-03 02:43:30 INF successfully added 'chart' [hauler/rancher:2.8.3]
2025-02-03 02:43:30 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.1.1
Digest: sha256:3957fc2bf560f2ccd64e38b59651b097dddb38863124745df264053cae1b807a
2025-02-03 02:43:31 INF successfully added 'chart' [hauler/hauler-helm:1.1.1]
2025-02-03 02:43:31 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.6
Digest: sha256:c4befb2f4939f4b077e3fa3986ab11090a603ac8dc7f8f4ac61dc7a896d20455
2025-02-03 02:43:31 INF successfully added 'chart' [hauler/hauler-helm:1.0.6]
2025-02-03 02:43:31 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.4
Digest: sha256:6a0a7317980309f4551404bd11ee43d1a9d1f1fe97294c7ab051625e435c3d81
2025-02-03 02:43:31 INF successfully added 'chart' [hauler/hauler-helm:1.0.4]
2025-02-03 02:43:31 INF adding 'chart' [rancher-cluster-templates-0.5.2.tgz] to the store
2025-02-03 02:43:31 INF successfully added 'chart' [hauler/rancher-cluster-templates:0.5.2]
2025-02-03 02:43:31 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Files]
2025-02-03 02:43:32 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/install.sh:latest]
2025-02-03 02:43:32 INF successfully added 'file' [hauler/install.sh:latest]
2025-02-03 02:43:32 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/rke2-install.sh:latest]
2025-02-03 02:43:32 INF successfully added 'file' [hauler/rke2-install.sh:latest]
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % rm -rf store                                                                                  
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info
+-----------+------+----------+----------+------+
| REFERENCE | TYPE | PLATFORM | # LAYERS | SIZE |
+-----------+------+----------+----------+------+
+-----------+------+----------+----------+------+
|                                TOTAL   | 0 B  |
+-----------+------+----------+----------+------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store sync -l debug -f https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml
2025-02-03 02:44:13 DBG running cli command [hauler store sync]
2025-02-03 02:44:13 DBG using store at [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 02:44:13 DBG using temporary directory at [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler3233246142]
2025-02-03 02:44:13 INF processing manifest [https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml] to store [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 02:44:13 DBG detected remote manifest... starting download... [https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml]
2025-02-03 02:44:13 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Images]
2025-02-03 02:44:13 INF adding 'image' [busybox] to the store
2025-02-03 02:44:14 DBG multi-arch image [true]
2025-02-03 02:44:18 INF successfully added 'image' [index.docker.io/library/busybox:latest]
2025-02-03 02:44:18 INF adding 'image' [busybox:stable] to the store
2025-02-03 02:44:18 DBG multi-arch image [true]
2025-02-03 02:44:18 DBG platform for image [linux/amd64]
2025-02-03 02:44:19 INF successfully added 'image' [index.docker.io/library/busybox:stable]
2025-02-03 02:44:19 INF adding 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5] to the store
2025-02-03 02:44:19 DBG multi-arch image [false]
2025-02-03 02:44:21 INF successfully added 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5]
2025-02-03 02:44:21 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Charts]
2025-02-03 02:44:21 INF adding 'chart' [rancher] to the store
2025-02-03 02:44:23 INF successfully added 'chart' [hauler/rancher:2.10.2]
2025-02-03 02:44:23 INF adding 'chart' [rancher] to the store
2025-02-03 02:44:24 INF successfully added 'chart' [hauler/rancher:2.8.4]
2025-02-03 02:44:24 INF adding 'chart' [rancher] to the store
2025-02-03 02:44:26 INF successfully added 'chart' [hauler/rancher:2.8.3]
2025-02-03 02:44:26 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.1.1
Digest: sha256:3957fc2bf560f2ccd64e38b59651b097dddb38863124745df264053cae1b807a
2025-02-03 02:44:27 INF successfully added 'chart' [hauler/hauler-helm:1.1.1]
2025-02-03 02:44:27 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.6
Digest: sha256:c4befb2f4939f4b077e3fa3986ab11090a603ac8dc7f8f4ac61dc7a896d20455
2025-02-03 02:44:27 INF successfully added 'chart' [hauler/hauler-helm:1.0.6]
2025-02-03 02:44:27 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.4
Digest: sha256:6a0a7317980309f4551404bd11ee43d1a9d1f1fe97294c7ab051625e435c3d81
2025-02-03 02:44:27 INF successfully added 'chart' [hauler/hauler-helm:1.0.4]
2025-02-03 02:44:27 INF adding 'chart' [rancher-cluster-templates-0.5.2.tgz] to the store
2025-02-03 02:44:27 INF successfully added 'chart' [hauler/rancher-cluster-templates:0.5.2]
2025-02-03 02:44:27 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Files]
2025-02-03 02:44:27 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/install.sh:latest]
2025-02-03 02:44:28 INF successfully added 'file' [hauler/install.sh:latest]
2025-02-03 02:44:28 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/rke2-install.sh:latest]
2025-02-03 02:44:28 INF successfully added 'file' [hauler/rke2-install.sh:latest]
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % rm -rf store                
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store info

+-----------+------+----------+----------+------+
| REFERENCE | TYPE | PLATFORM | # LAYERS | SIZE |
+-----------+------+----------+----------+------+
+-----------+------+----------+----------+------+
|                                TOTAL   | 0 B  |
+-----------+------+----------+----------+------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % export HAULER_TEMP_DIR=/Users/zackbradys/Downloads/RGS/test/tmp
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store sync -l debug -f https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml
2025-02-03 02:45:38 DBG running cli command [hauler store sync]
2025-02-03 02:45:38 DBG using store at [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 02:45:38 DBG using temporary directory at [/Users/zackbradys/Downloads/RGS/test/tmp/hauler61401760]
2025-02-03 02:45:38 INF processing manifest [https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml] to store [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 02:45:38 DBG detected remote manifest... starting download... [https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml]
2025-02-03 02:45:39 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Images]
2025-02-03 02:45:39 INF adding 'image' [busybox] to the store
2025-02-03 02:45:39 DBG multi-arch image [true]
2025-02-03 02:45:43 INF successfully added 'image' [index.docker.io/library/busybox:latest]
2025-02-03 02:45:43 INF adding 'image' [busybox:stable] to the store
2025-02-03 02:45:44 DBG multi-arch image [true]
2025-02-03 02:45:44 DBG platform for image [linux/amd64]
2025-02-03 02:45:44 INF successfully added 'image' [index.docker.io/library/busybox:stable]
2025-02-03 02:45:44 INF adding 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5] to the store
2025-02-03 02:45:45 DBG multi-arch image [false]
2025-02-03 02:45:46 INF successfully added 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5]
2025-02-03 02:45:46 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Charts]
2025-02-03 02:45:46 INF adding 'chart' [rancher] to the store
2025-02-03 02:45:48 INF successfully added 'chart' [hauler/rancher:2.10.2]
2025-02-03 02:45:48 INF adding 'chart' [rancher] to the store
2025-02-03 02:45:50 INF successfully added 'chart' [hauler/rancher:2.8.4]
2025-02-03 02:45:50 INF adding 'chart' [rancher] to the store
2025-02-03 02:45:51 INF successfully added 'chart' [hauler/rancher:2.8.3]
2025-02-03 02:45:51 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.1.1
Digest: sha256:3957fc2bf560f2ccd64e38b59651b097dddb38863124745df264053cae1b807a
2025-02-03 02:45:52 INF successfully added 'chart' [hauler/hauler-helm:1.1.1]
2025-02-03 02:45:52 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.6
Digest: sha256:c4befb2f4939f4b077e3fa3986ab11090a603ac8dc7f8f4ac61dc7a896d20455
2025-02-03 02:45:52 INF successfully added 'chart' [hauler/hauler-helm:1.0.6]
2025-02-03 02:45:52 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.4
Digest: sha256:6a0a7317980309f4551404bd11ee43d1a9d1f1fe97294c7ab051625e435c3d81
2025-02-03 02:45:52 INF successfully added 'chart' [hauler/hauler-helm:1.0.4]
2025-02-03 02:45:52 INF adding 'chart' [rancher-cluster-templates-0.5.2.tgz] to the store
2025-02-03 02:45:52 INF successfully added 'chart' [hauler/rancher-cluster-templates:0.5.2]
2025-02-03 02:45:52 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Files]
2025-02-03 02:45:53 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/install.sh:latest]
2025-02-03 02:45:53 INF successfully added 'file' [hauler/install.sh:latest]
2025-02-03 02:45:53 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/rke2-install.sh:latest]
2025-02-03 02:45:53 INF successfully added 'file' [hauler/rke2-install.sh:latest]
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % rm -rf store
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % unset HAULER_TEMP_DIR
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % hauler store sync -l debug -t /Users/zackbradys/Downloads/RGS/test/tmp -f https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml 
2025-02-03 02:46:34 DBG running cli command [hauler store sync]
2025-02-03 02:46:34 DBG using store at [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 02:46:34 DBG using temporary directory at [/Users/zackbradys/Downloads/RGS/test/tmp/hauler1717808495]
2025-02-03 02:46:34 INF processing manifest [https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml] to store [/Users/zackbradys/Downloads/RGS/test/store]
2025-02-03 02:46:34 DBG detected remote manifest... starting download... [https://carbide.s3.us-gov-east-1.amazonaws.com/tests/hauler-manifest.yaml]
2025-02-03 02:46:35 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Images]
2025-02-03 02:46:35 INF adding 'image' [busybox] to the store
2025-02-03 02:46:35 DBG multi-arch image [true]
2025-02-03 02:46:39 INF successfully added 'image' [index.docker.io/library/busybox:latest]
2025-02-03 02:46:39 INF adding 'image' [busybox:stable] to the store
2025-02-03 02:46:39 DBG multi-arch image [true]
2025-02-03 02:46:39 DBG platform for image [linux/amd64]
2025-02-03 02:46:40 INF successfully added 'image' [index.docker.io/library/busybox:stable]
2025-02-03 02:46:40 INF adding 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5] to the store
2025-02-03 02:46:40 DBG multi-arch image [false]
2025-02-03 02:46:42 INF successfully added 'image' [gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5]
2025-02-03 02:46:42 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Charts]
2025-02-03 02:46:42 INF adding 'chart' [rancher] to the store
2025-02-03 02:46:43 INF successfully added 'chart' [hauler/rancher:2.10.2]
2025-02-03 02:46:43 INF adding 'chart' [rancher] to the store
2025-02-03 02:46:45 INF successfully added 'chart' [hauler/rancher:2.8.4]
2025-02-03 02:46:45 INF adding 'chart' [rancher] to the store
2025-02-03 02:46:46 INF successfully added 'chart' [hauler/rancher:2.8.3]
2025-02-03 02:46:46 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.1.1
Digest: sha256:3957fc2bf560f2ccd64e38b59651b097dddb38863124745df264053cae1b807a
2025-02-03 02:46:47 INF successfully added 'chart' [hauler/hauler-helm:1.1.1]
2025-02-03 02:46:47 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.6
Digest: sha256:c4befb2f4939f4b077e3fa3986ab11090a603ac8dc7f8f4ac61dc7a896d20455
2025-02-03 02:46:47 INF successfully added 'chart' [hauler/hauler-helm:1.0.6]
2025-02-03 02:46:47 INF adding 'chart' [hauler-helm] to the store
Pulled: ghcr.io/hauler-dev/hauler-helm:1.0.4
Digest: sha256:6a0a7317980309f4551404bd11ee43d1a9d1f1fe97294c7ab051625e435c3d81
2025-02-03 02:46:48 INF successfully added 'chart' [hauler/hauler-helm:1.0.4]
2025-02-03 02:46:48 INF adding 'chart' [rancher-cluster-templates-0.5.2.tgz] to the store
2025-02-03 02:46:48 INF successfully added 'chart' [hauler/rancher-cluster-templates:0.5.2]
2025-02-03 02:46:48 INF syncing [content.hauler.cattle.io/v1alpha1, Kind=Files]
2025-02-03 02:46:48 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/install.sh:latest]
2025-02-03 02:46:48 INF successfully added 'file' [hauler/install.sh:latest]
2025-02-03 02:46:48 INF adding 'file' [https://get.rke2.io/install.sh] to the store as [hauler/rke2-install.sh:latest]
2025-02-03 02:46:48 INF successfully added 'file' [hauler/rke2-install.sh:latest]
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
