### PR TITLE
clear default manifest name if product flag used with sync

### DIFF
--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -69,8 +69,12 @@ func addStoreSync(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 		Short: "Sync content to the content store",
 		Args:  cobra.ExactArgs(0),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
+			// Check if the products flag was passed
 			if len(o.Products) > 0 {
-				o.FileName = []string{}
+				// Only clear the default if the user did NOT explicitly set --filename
+				if !cmd.Flags().Changed("filename") {
+					o.FileName = []string{}
+				}
 			}
 			return nil
 		},

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -68,6 +68,12 @@ func addStoreSync(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 		Use:   "sync",
 		Short: "Sync content to the content store",
 		Args:  cobra.ExactArgs(0),
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if len(o.Products) > 0 {
+				o.FileName = []string{}
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- 

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- If `--products` is used on the sync command, clear the default manifest filename.  Otherwise hauler will process the `--products` flag and then attempt to process the "default" filename.

- This approach ensures: 
    ✅ --filename isn't forced when using --products.
    ✅ Users can still use both flags together if they explicitly provide --filename.
    ✅ If no flags are passed, filename retains its default value.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- Before:
![image](https://github.com/user-attachments/assets/32f0f22f-c34f-425b-8f23-6a0cc1735efe)

- After:
![image](https://github.com/user-attachments/assets/817d337c-b815-415b-97aa-f41f9ef673f0)

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
