### PR TITLE
default public transparency log verification to false to be airgap friendly but allow override

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -63,7 +63,7 @@ func AddImageCmd(ctx context.Context, o *flags.AddImageOpts, s *store.Layout, re
 	// Check if the user provided a key.
 	if o.Key != "" {
 		// verify signature using the provided key.
-		err := cosign.VerifySignature(ctx, s, o.Key, cfg.Name, rso, ro)
+		err := cosign.VerifySignature(ctx, s, o.Key, o.Tlog, cfg.Name, rso, ro)
 		if err != nil {
 			return err
 		}

--- a/cmd/hauler/cli/store/sync.go
+++ b/cmd/hauler/cli/store/sync.go
@@ -248,7 +248,16 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 						}
 						l.Debugf("key for image [%s]", key)
 
-						if err := cosign.VerifySignature(ctx, s, key, i.Name, rso, ro); err != nil {
+						tlog := o.Tlog
+						if !o.Tlog && a[consts.ImageAnnotationTlog] == "true" {
+							tlog = true
+						}
+						if i.Tlog {
+							tlog = i.Tlog
+						}
+						l.Debugf("transparency log for verification [%b]", tlog)
+
+						if err := cosign.VerifySignature(ctx, s, key, tlog, i.Name, rso, ro); err != nil {
 							l.Errorf("signature verification failed for image [%s]... skipping...\n%v", i.Name, err)
 							continue
 						}
@@ -309,7 +318,16 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 						}
 						l.Debugf("key for image [%s]", key)
 
-						if err := cosign.VerifySignature(ctx, s, key, i.Name, rso, ro); err != nil {
+						tlog := o.Tlog
+						if !o.Tlog && a[consts.ImageAnnotationTlog] == "true" {
+							tlog = true
+						}
+						if i.Tlog {
+							tlog = i.Tlog
+						}
+						l.Debugf("transparency log for verification [%b]", tlog)
+
+						if err := cosign.VerifySignature(ctx, s, key, tlog, i.Name, rso, ro); err != nil {
 							l.Errorf("signature verification failed for image [%s]... skipping...\n%v", i.Name, err)
 							continue
 						}

--- a/internal/flags/add.go
+++ b/internal/flags/add.go
@@ -9,12 +9,14 @@ type AddImageOpts struct {
 	*StoreRootOpts
 	Name     string
 	Key      string
+	Tlog     bool
 	Platform string
 }
 
 func (o *AddImageOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 	f.StringVarP(&o.Key, "key", "k", "", "(Optional) Location of public key to use for signature verification")
+	f.BoolVar(&o.Tlog, "use-tlog-verify", false, "(Optional) Allow transparency log verification. (defaults to false))")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specifiy the platform of the image... i.e. linux/amd64 (defaults to all)")
 }
 

--- a/internal/flags/sync.go
+++ b/internal/flags/sync.go
@@ -14,6 +14,7 @@ type SyncOpts struct {
 	Registry        string
 	ProductRegistry string
 	TempOverride    string
+	Tlog            bool
 }
 
 func (o *SyncOpts) AddFlags(cmd *cobra.Command) {
@@ -26,4 +27,5 @@ func (o *SyncOpts) AddFlags(cmd *cobra.Command) {
 	f.StringVarP(&o.Registry, "registry", "g", "", "(Optional) Specify the registry of the image for images that do not alredy define one")
 	f.StringVarP(&o.ProductRegistry, "product-registry", "c", "", "(Optional) Specify the product registry. Defaults to RGS Carbide Registry (rgcrprod.azurecr.us)")
 	f.StringVarP(&o.TempOverride, "tempdir", "t", "", "(Optional) Override the default temporary directiory determined by the OS")
+	f.BoolVar(&o.Tlog, "use-tlog-verify", false, "(Optional) Allow transparency log verification. (defaults to false))")
 }

--- a/pkg/apis/hauler.cattle.io/v1/image.go
+++ b/pkg/apis/hauler.cattle.io/v1/image.go
@@ -23,6 +23,10 @@ type Image struct {
 	//Key string `json:"key,omitempty"`
 	Key string `json:"key"`
 
+	// Path is the path to the cosign public key used for verifying image signatures
+	//Tlog string `json:"use-tlog-verify,omitempty"`
+	Tlog bool `json:"use-tlog-verify"`
+
 	// Platform of the image to be pulled.  If not specified, all platforms will be pulled.
 	//Platform string `json:"key,omitempty"`
 	Platform string `json:"platform"`

--- a/pkg/apis/hauler.cattle.io/v1alpha1/image.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha1/image.go
@@ -23,6 +23,10 @@ type Image struct {
 	//Key string `json:"key,omitempty"`
 	Key string `json:"key"`
 
+	// Path is the path to the cosign public key used for verifying image signatures
+	//Tlog string `json:"use-tlog-verify,omitempty"`
+	Tlog bool `json:"use-tlog-verify"`
+
 	// Platform of the image to be pulled.  If not specified, all platforms will be pulled.
 	//Platform string `json:"key,omitempty"`
 	Platform string `json:"platform"`

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -48,6 +48,7 @@ const (
 	ImageAnnotationKey      = "hauler.dev/key"
 	ImageAnnotationPlatform = "hauler.dev/platform"
 	ImageAnnotationRegistry = "hauler.dev/registry"
+	ImageAnnotationTlog     = "hauler.dev/use-tlog-verify"
 
 	// content kinds
 	ImagesContentKind    = "Images"

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -17,11 +17,17 @@ import (
 )
 
 // VerifyFileSignature verifies the digital signature of a file using Sigstore/Cosign.
-func VerifySignature(ctx context.Context, s *store.Layout, keyPath string, ref string, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
+func VerifySignature(ctx context.Context, s *store.Layout, keyPath string, useTlog bool, ref string, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
 	l := log.FromContext(ctx)
 	operation := func() error {
 		v := &verify.VerifyCommand{
-			KeyRef: keyPath,
+			KeyRef:     keyPath,
+			IgnoreTlog: true, // Ignore transparency log by default.
+		}
+
+		// if the user wants to use the transparency log, set the flag to false
+		if useTlog {
+			v.IgnoreTlog = false
 		}
 
 		err := log.CaptureOutput(l, true, func() error {


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

- Older images signed with Cosign v1 was failing tlog verification used with Cosign v2.
- Images needing verification inside of an airgap would potentially fail public tlog verification.

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Default the public tlog verification to false but allow user to pass a flag to enable with `--use-tlog-verify` added to:
   - `hauler store add image`
   - `hauler store sync`
- new hauler manifest annotation:  `hauler.dev/use-tlog-verify: true`
- new hauler manifest image spec option: `use-tlog-verify: true`
  
**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

Using image with v1 signature with new default.
```
❯ hauler store add image rgcrprod.azurecr.us/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5 --platform linux/amd64 --key ~/ssf-key.pub                                                                                                              
2025-03-26 20:32:25 INF signature verified for image [rgcrprod.azurecr.us/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5]
2025-03-26 20:32:25 INF adding image [rgcrprod.azurecr.us/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5] to the store
2025-03-26 20:32:34 INF successfully added image [rgcrprod.azurecr.us/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5]
```

Using image with v1 signature with flag to force public tlog verification.
```
❯ hauler store add image rgcrprod.azurecr.us/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5 --platform linux/amd64 --key ~/ssf-key.pub --use-tlog-verify                                                                                                                
2025-03-26 20:32:40 ERR error (attempt 1/3)... function execution failed: no matching signatures: rekor client not provided for online verification
rekor client not provided for online verification
```

Sample manifest using new annotation or image option.
```
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: rancher-images
  annotations:
    hauler.dev/key: ~/ssf-key.pub
    hauler.dev/platform: linux/amd64
    #hauler.dev/use-tlog-verify: true
spec:       
  images:
    - name: rgcrprod.azurecr.us/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5
      #use-tlog-verify: true
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
