### PR TITLE
Fix tlog verification error/warning output

### DIFF
--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -145,13 +145,13 @@ func RetryOperation(ctx context.Context, rso *flags.StoreRootOpts, ro *flags.Cli
 		}
 
 		if ro.IgnoreErrors {
-			if strings.HasPrefix(err.Error(), "function execution failed: no matching signatures") {
+			if strings.HasPrefix(err.Error(), "function execution failed: no matching signatures: rekor client not provided for online verification") {
 				l.Warnf("warning (attempt %d/%d)... failed tlog verification", attempt, rso.Retries)
 			} else {
 				l.Warnf("warning (attempt %d/%d)... %v", attempt, rso.Retries, err)
 			}
 		} else {
-			if strings.HasPrefix(err.Error(), "function execution failed: no matching signatures") {
+			if strings.HasPrefix(err.Error(), "function execution failed: no matching signatures: rekor client not provided for online verification") {
 				l.Errorf("error (attempt %d/%d)... failed tlog verification", attempt, rso.Retries)
 			} else {
 				l.Errorf("error (attempt %d/%d)... %v", attempt, rso.Retries, err)


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [x] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

- Resolves #427 

**Types of Changes:**

- Streamline error handling for tlog verification failures

**Proposed Changes:**


- Streamline error handling for tlog verification failures

**Verification/Testing of Changes:**

`sync` validation:
```
[02:10:23] /tmp $ hauler store sync --ignore-errors -v -f /tmp/man.yaml
2025-04-01 14:10:24 INF processing manifest [/tmp/man.yaml] to store [/tmp/store]
2025-04-01 14:10:24 INF syncing content [content.hauler.cattle.io/v1] with [kind=Images] to store [/tmp/store]
2025-04-01 14:10:25 WRN warning (attempt 1/3)... failed tlog verification
2025-04-01 14:10:30 WRN warning (attempt 2/3)... failed tlog verification
2025-04-01 14:10:35 WRN warning (attempt 3/3)... failed tlog verification
2025-04-01 14:10:35 ERR signature verification failed for image [rgcrprod.azurecr.us/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5]... skipping...
operation unsuccessful after 3 attempts
2025-04-01 14:10:36 INF signature verified for image [rgcrprod.azurecr.us/rancher/rancher:v2.10.3]
2025-04-01 14:10:36 INF adding image [rgcrprod.azurecr.us/rancher/rancher:v2.10.3] to the store
2025-04-01 14:12:03 INF successfully added image [rgcrprod.azurecr.us/rancher/rancher:v2.10.3]
2025-04-01 14:12:09 INF processing completed successfully
```

`add image` validation:
```
[02:12:09] /tmp $ hauler store add --ignore-errors image -k /tmp/carbide-key.pub -v rgcrprod.azurecr.us/rancher/mirrored-banzaicloud-fluentd:v1.14.6-alpine-5
2025-04-01 14:12:48 WRN warning (attempt 1/3)... failed tlog verification
2025-04-01 14:12:53 WRN warning (attempt 2/3)... failed tlog verification
2025-04-01 14:12:58 WRN warning (attempt 3/3)... failed tlog verification
Error: operation unsuccessful after 3 attempts
```

**Additional Context:**

N/A
