### PR TITLE
add keyless signature verification support

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -68,6 +68,14 @@ func AddImageCmd(ctx context.Context, o *flags.AddImageOpts, s *store.Layout, re
 			return err
 		}
 		l.Infof("signature verified for image [%s]", cfg.Name)
+	} else if o.CertIdentityRegexp != "" || o.CertIdentity != "" {
+		// verify signature using the provided keyless details
+		l.Infof("verifying keyless signature for [%s]", cfg.Name)
+		err := cosign.VerifyKeylessSignature(ctx, s, o.CertIdentity, o.CertIdentityRegexp, o.CertOidcIssuer, o.CertOidcIssuerRegexp, o.CertGithubWorkflowRepository, o.Tlog, cfg.Name, rso, ro)
+		if err != nil {
+			return err
+		}
+		l.Infof("keyless signature verified for image [%s]", cfg.Name)
 	}
 
 	return storeImage(ctx, s, cfg, o.Platform, rso, ro)

--- a/internal/flags/add.go
+++ b/internal/flags/add.go
@@ -9,6 +9,11 @@ type AddImageOpts struct {
 	*StoreRootOpts
 	Name     string
 	Key      string
+	CertOidcIssuer					string
+	CertOidcIssuerRegexp			string
+	CertIdentity 					string
+	CertIdentityRegexp 				string
+	CertGithubWorkflowRepository 	string
 	Tlog     bool
 	Platform string
 }
@@ -16,6 +21,11 @@ type AddImageOpts struct {
 func (o *AddImageOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 	f.StringVarP(&o.Key, "key", "k", "", "(Optional) Location of public key to use for signature verification")
+	f.StringVar(&o.CertIdentity, "certificate-identity", "", "Cosign certificate-identity (either --certificate-identity or --certificate-identity-regexp required for keyless verification)")
+	f.StringVar(&o.CertIdentityRegexp, "certificate-identity-regexp", "", "Cosign certificate-identity-regexp (either --certificate-identity or --certificate-identity-regexp required for keyless verification)")
+	f.StringVar(&o.CertOidcIssuer, "certificate-oidc-issuer", "", "(Optional) Cosign option to validate oidc issuer")
+	f.StringVar(&o.CertOidcIssuerRegexp, "certificate-oidc-issuer-regexp", "", "(Optional) Cosign option to validate oidc issuer with regex")
+	f.StringVar(&o.CertGithubWorkflowRepository, "certificate-github-workflow-repository", "", "(Options) Cosign certificate-github-workflow-repository option")
 	f.BoolVarP(&o.Tlog, "use-tlog-verify", "v", false, "(Optional) Allow transparency log verification. (defaults to false)")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specifiy the platform of the image... i.e. linux/amd64 (defaults to all)")
 }

--- a/internal/flags/sync.go
+++ b/internal/flags/sync.go
@@ -9,6 +9,11 @@ type SyncOpts struct {
 	*StoreRootOpts
 	FileName        []string
 	Key             string
+	CertOidcIssuer					string
+	CertOidcIssuerRegexp			string
+	CertIdentity 					string
+	CertIdentityRegexp 				string
+	CertGithubWorkflowRepository 	string
 	Products        []string
 	Platform        string
 	Registry        string
@@ -22,6 +27,11 @@ func (o *SyncOpts) AddFlags(cmd *cobra.Command) {
 
 	f.StringSliceVarP(&o.FileName, "filename", "f", []string{consts.DefaultHaulerManifestName}, "Specify the name of manifest(s) to sync")
 	f.StringVarP(&o.Key, "key", "k", "", "(Optional) Location of public key to use for signature verification")
+	f.StringVar(&o.CertIdentity, "certificate-identity", "", "Cosign certificate-identity (either --certificate-identity or --certificate-identity-regexp required for keyless verification)")
+	f.StringVar(&o.CertIdentityRegexp, "certificate-identity-regexp", "", "Cosign certificate-identity-regexp (either --certificate-identity or --certificate-identity-regexp required for keyless verification)")
+	f.StringVar(&o.CertOidcIssuer, "certificate-oidc-issuer", "", "(Optional) Cosign option to validate oidc issuer")
+	f.StringVar(&o.CertOidcIssuerRegexp, "certificate-oidc-issuer-regexp", "", "(Optional) Cosign option to validate oidc issuer with regex")
+	f.StringVar(&o.CertGithubWorkflowRepository, "certificate-github-workflow-repository", "", "(Options) Cosign certificate-github-workflow-repository option")
 	f.StringSliceVar(&o.Products, "products", []string{}, "(Optional) Specify the product name to fetch collections from the product registry i.e. rancher=v2.10.1,rke2=v1.31.5+rke2r1")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform of the image... i.e linux/amd64 (defaults to all)")
 	f.StringVarP(&o.Registry, "registry", "g", "", "(Optional) Specify the registry of the image for images that do not alredy define one")

--- a/pkg/apis/hauler.cattle.io/v1/image.go
+++ b/pkg/apis/hauler.cattle.io/v1/image.go
@@ -27,6 +27,13 @@ type Image struct {
 	//Tlog string `json:"use-tlog-verify,omitempty"`
 	Tlog bool `json:"use-tlog-verify"`
 
+	// cosign keyless validation options
+	CertIdentity string `json:"certificate-identity"`
+	CertIdentityRegexp string `json:"certificate-identity-regexp"`
+	CertOidcIssuer string `json:"certificate-oidc-issuer"`
+	CertOidcIssuerRegexp string `json:"certificate-oidc-issuer-regexp"`
+	CertGithubWorkflowRepository string `json:"certificate-github-workflow-repository"`
+
 	// Platform of the image to be pulled.  If not specified, all platforms will be pulled.
 	//Platform string `json:"key,omitempty"`
 	Platform string `json:"platform"`

--- a/pkg/apis/hauler.cattle.io/v1alpha1/image.go
+++ b/pkg/apis/hauler.cattle.io/v1alpha1/image.go
@@ -27,6 +27,13 @@ type Image struct {
 	//Tlog string `json:"use-tlog-verify,omitempty"`
 	Tlog bool `json:"use-tlog-verify"`
 
+	// cosign keyless validation options
+	CertIdentity string `json:"certificate-identity"`
+	CertIdentityRegexp string `json:"certificate-identity-regexp"`
+	CertOidcIssuer string `json:"certificate-oidc-issuer"`
+	CertOidcIssuerRegexp string `json:"certificate-oidc-issuer-regexp"`
+	CertGithubWorkflowRepository string `json:"certificate-github-workflow-repository"`
+
 	// Platform of the image to be pulled.  If not specified, all platforms will be pulled.
 	//Platform string `json:"key,omitempty"`
 	Platform string `json:"platform"`

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -50,6 +50,13 @@ const (
 	ImageAnnotationRegistry = "hauler.dev/registry"
 	ImageAnnotationTlog     = "hauler.dev/use-tlog-verify"
 
+	// cosign keyless validation options
+	ImageAnnotationCertIdentity     				= "hauler.dev/certificate-identity"
+	ImageAnnotationCertIdentityRegexp     			= "hauler.dev/certificate-identity-regexp"
+	ImageAnnotationCertOidcIssuer     				= "hauler.dev/certificate-oidc-issuer"
+	ImageAnnotationCertOidcIssuerRegexp				= "hauler.dev/certificate-oidc-issuer-regexp"
+	ImageAnnotationCertGithubWorkflowRepository		= "hauler.dev/certificate-github-workflow-repository"
+
 	// content kinds
 	ImagesContentKind    = "Images"
 	ChartsContentKind    = "Charts"

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -18,13 +18,50 @@ import (
 	"oras.land/oras-go/pkg/content"
 )
 
-// VerifyFileSignature verifies the digital signature of a file using Sigstore/Cosign.
+// VerifySignature verifies the digital signature of a file using Sigstore/Cosign.
 func VerifySignature(ctx context.Context, s *store.Layout, keyPath string, useTlog bool, ref string, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
 	l := log.FromContext(ctx)
 	operation := func() error {
 		v := &verify.VerifyCommand{
 			KeyRef:     keyPath,
 			IgnoreTlog: true, // Ignore transparency log by default.
+		}
+
+		// if the user wants to use the transparency log, set the flag to false
+		if useTlog {
+			v.IgnoreTlog = false
+		}
+
+		err := log.CaptureOutput(l, true, func() error {
+			return v.Exec(ctx, []string{ref})
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	return RetryOperation(ctx, rso, ro, operation)
+}
+
+// VerifyKeylessSignature verifies the digital signature of a file using Sigstore/Cosign.
+func VerifyKeylessSignature(ctx context.Context, s *store.Layout, identity string, identityRegexp string, oidcIssuer string, oidcIssuerRegexp string, ghWorkflowRepository string, useTlog bool, ref string, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
+	l := log.FromContext(ctx)
+	operation := func() error {
+
+		certVerifyOptions := options.CertVerifyOptions{
+			CertOidcIssuer: oidcIssuer,
+			CertOidcIssuerRegexp: oidcIssuer,
+			CertIdentity: identity,
+			CertIdentityRegexp:	identityRegexp,
+			CertGithubWorkflowRepository: ghWorkflowRepository,
+		}
+
+		v := &verify.VerifyCommand{
+			CertVerifyOptions: certVerifyOptions,       
+			IgnoreTlog: false, // Ignore transparency log is set to false by default for keyless signature verification
+			CertGithubWorkflowRepository: ghWorkflowRepository,
 		}
 
 		// if the user wants to use the transparency log, set the flag to false


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**


<!-- Provide any associated or linked related to these change(s) -->

- https://github.com/hauler-dev/hauler/issues/432

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Hauler needs the ability to perform keyless verification of images, many registries use keyless signing and do not provide a public key to verify signatures.
- A lot of ghcr.io and quay.io images use keyless signatures https://docs.sigstore.dev/cosign/verifying/verify/#keyless-verification-using-openid-connect

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

```
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: americancode-images
spec:
  images:
    - name: ghcr.io/americancode/gitlab-cicd-k8s:v0.3.2
      certificate-identity-regexp: "https://github.com/americancode/gitlab-cicd-k8s/.github/workflows/docker-publish.yml@refs/tags/.*"
      certificate-oidc-issuer: https://token.actions.githubusercontent.com
      certificate-github-workflow-repository: americancode/gitlab-cicd-k8s
```
and
```
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: americancode-images
  annotations:
    hauler.dev/certificate-identity-regexp: "https://github.com/americancode/gitlab-cicd-k8s/.github/workflows/docker-publish.yml@refs/tags/.*"
    hauler.dev/certificate-oidc-issuer: https://token.actions.githubusercontent.com
    hauler.dev/certificate-github-workflow-repository: americancode/gitlab-cicd-k8s
spec:
  images:
    - name: ghcr.io/americancode/gitlab-cicd-k8s:v0.3.2
```
and
```
hauler store add image ghcr.io/americancode/gitlab-cicd-k8s:v0.3.2 --certificate-github-workflow-repository americancode/gitlab-cicd-k8s --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity "https://github.com/americancode/gitlab-cicd-k8s/.github/workflows/docker-publish.yml@refs/tags/v0.3.2"
```


example output 
```
2025-04-18 14:19:50 INF processing manifest [americancode.yaml] to store [/home/ubuntu/repos/hauler-ssh/store]
2025-04-18 14:19:50 INF syncing content [content.hauler.cattle.io/v1] with [kind=Images] to store [/home/ubuntu/repos/hauler-ssh/store]
2025-04-18 14:19:51 INF keyless signature verified for image [ghcr.io/americancode/gitlab-cicd-k8s:v0.3.2]
2025-04-18 14:19:51 INF adding image [ghcr.io/americancode/gitlab-cicd-k8s:v0.3.2] to the store
2025-04-18 14:19:52 INF successfully added image [ghcr.io/americancode/gitlab-cicd-k8s:v0.3.2]
2025-04-18 14:19:52 INF processing completed successfully
```

example failure output
```
2025-04-18 14:22:58 INF processing manifest [americancode.yaml] to store [/home/ubuntu/repos/hauler-ssh/store]
2025-04-18 14:22:58 INF syncing content [content.hauler.cattle.io/v1] with [kind=Images] to store [/home/ubuntu/repos/hauler-ssh/store]
2025-04-18 14:22:59 ERR error (attempt 1/3)... function execution failed: no matching signatures: none of the expected identities matched what was in the certificate, got subjects [https://github.com/americancode/gitlab-cicd-k8s/.github/workflows/docker-publish.yml@refs/tags/v0.3.2] with issuer https://token.actions.githubusercontent.com
 none of the expected identities matched what was in the certificate, got subjects [https://github.com/americancode/gitlab-cicd-k8s/.github/workflows/docker-publish.yml@refs/tags/v0.3.2] with issuer https://token.actions.githubusercontent.com
2025-04-18 14:23:04 ERR error (attempt 2/3)... function execution failed: no matching signatures: none of the expected identities matched what was in the certificate, got subjects [https://github.com/americancode/gitlab-cicd-k8s/.github/workflows/docker-publish.yml@refs/tags/v0.3.2] with issuer https://token.actions.githubusercontent.com
 none of the expected identities matched what was in the certificate, got subjects [https://github.com/americancode/gitlab-cicd-k8s/.github/workflows/docker-publish.yml@refs/tags/v0.3.2] with issuer https://token.actions.githubusercontent.com
2025-04-18 14:23:10 ERR error (attempt 3/3)... function execution failed: no matching signatures: none of the expected identities matched what was in the certificate, got subjects [https://github.com/americancode/gitlab-cicd-k8s/.github/workflows/docker-publish.yml@refs/tags/v0.3.2] with issuer https://token.actions.githubusercontent.com
 none of the expected identities matched what was in the certificate, got subjects [https://github.com/americancode/gitlab-cicd-k8s/.github/workflows/docker-publish.yml@refs/tags/v0.3.2] with issuer https://token.actions.githubusercontent.com
2025-04-18 14:23:10 ERR keyless signature verification failed for image [ghcr.io/americancode/gitlab-cicd-k8s:v0.3.2]... skipping...
operation unsuccessful after 3 attempts
2025-04-18 14:23:10 INF processing completed successfully
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- Hauler needs an automated way to keyless verify all images as they are getting pulled similar to the pub key verification
- This is my first open-source MR. go easy on me. 