### PR TITLE
fix: fix for clobbering of oci store on images and charts with same name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
     - go mod download
     - go fmt ./...
     - go vet ./...
-    - go test ./... -cover -race -covermode=atomic -coverprofile=coverage.out
+
 
 release:
   prerelease: auto

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
     - go mod download
     - go fmt ./...
     - go vet ./...
-
+    - go test ./... -cover -race -covermode=atomic -coverprofile=coverage.out
 
 release:
   prerelease: auto

--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -43,7 +43,7 @@ func storeFile(ctx context.Context, s *store.Layout, fi v1.File) error {
 	}
 
 	l.Infof("adding file [%s] to the store as [%s]", fi.Path, ref.Name())
-	_, err = s.AddOCI(ctx, f, ref.Name())
+	_, err = s.AddOCI(ctx, "Files", f, ref.Name())
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func storeChart(ctx context.Context, s *store.Layout, cfg v1.Chart, opts *action
 	if err != nil {
 		return err
 	}
-	_, err = s.AddOCI(ctx, chrt, ref.Name())
+	_, err = s.AddOCI(ctx, "Charts", chrt, ref.Name())
 	if err != nil {
 		return err
 	}

--- a/cmd/hauler/cli/store/sync.go
+++ b/cmd/hauler/cli/store/sync.go
@@ -538,7 +538,7 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 					if err != nil {
 						return err
 					}
-					if _, err := s.AddOCICollection(ctx, tc); err != nil {
+					if _, err := s.AddOCICollection(ctx, "Charts", tc); err != nil {
 						return err
 					}
 				}
@@ -556,7 +556,7 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 					if err != nil {
 						return err
 					}
-					if _, err := s.AddOCICollection(ctx, tc); err != nil {
+					if _, err := s.AddOCICollection(ctx, "Charts", tc); err != nil {
 						return err
 					}
 				}
@@ -586,7 +586,7 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 					if err != nil {
 						return fmt.Errorf("convert ImageTxt %s: %v", v1Cfg.Name, err)
 					}
-					if _, err := s.AddOCICollection(ctx, it); err != nil {
+					if _, err := s.AddOCICollection(ctx, "Images", it); err != nil {
 						return fmt.Errorf("add ImageTxt %s to store: %v", v1Cfg.Name, err)
 					}
 				}
@@ -604,7 +604,7 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 					if err != nil {
 						return fmt.Errorf("convert ImageTxt %s: %v", cfg.Name, err)
 					}
-					if _, err := s.AddOCICollection(ctx, it); err != nil {
+					if _, err := s.AddOCICollection(ctx, "Images", it); err != nil {
 						return fmt.Errorf("add ImageTxt %s to store: %v", cfg.Name, err)
 					}
 				}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module hauler.dev/go/hauler
 
-go 1.23.4
+go 1.23.8
+
 toolchain go1.24.2
 
 replace github.com/sigstore/cosign/v2 => github.com/hauler-dev/cosign/v2 v2.4.3-0.20250404165522-3a44ef646a65

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -46,14 +46,14 @@ func TestLayout_AddOCI(t *testing.T) {
 			}
 			moci := genArtifact(t, tt.args.ref)
 
-			got, err := s.AddOCI(ctx, moci, tt.args.ref)
+			got, err := s.AddOCI(ctx, "Images", moci, tt.args.ref)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AddOCI() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			_ = got
 
-			_, err = s.AddOCI(ctx, moci, tt.args.ref)
+			_, err = s.AddOCI(ctx, "Images", moci, tt.args.ref)
 			if err != nil {
 				t.Errorf("AddOCI() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [ ] Commit(s) and code follow the repositories guidelines.
- [x ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->


Summary of what I changed
Introduced type-prefixed references for charts and files

I modified the AddOCI and AddOCICollection functions to accept a kind parameter.

Introduced a helper function namespaceRefByKind that applies a prefix (charts/, files/) to the reference based on the kind.

This ensures charts are always stored under charts/<name>:<tag> and files under files/<name>:<tag>.

Patched all handlers for charts and files to pass the correct kind when adding to the store

Updated all calls to AddOCI and AddOCICollection in sync.go, add.go, and other relevant files to include the explicit kind.

Ensured test cases were updated to reflect the new function signatures.

Images remain unprefixed (stored at <name>:<tag>)

I chose to leave the image handling (storeImage and cosign.SaveImage) as-is, meaning images still use the standard reference path without the images/ prefix.

This works effectively because charts are now always stored under charts/, which prevents any collision even if the image uses the same name.
