### PR TITLE
deprecate auth from hauler store copy

### DIFF
--- a/cmd/hauler/cli/store/copy.go
+++ b/cmd/hauler/cli/store/copy.go
@@ -16,6 +16,10 @@ import (
 func CopyCmd(ctx context.Context, o *flags.CopyOpts, s *store.Layout, targetRef string, ro *flags.CliRootOpts) error {
 	l := log.FromContext(ctx)
 
+	if o.Username != "" || o.Password != "" {
+		return fmt.Errorf("--username/--password have been deprecated, please use 'hauler login'")
+	}
+
 	components := strings.SplitN(targetRef, "://", 2)
 	switch components[0] {
 	case "dir":
@@ -31,8 +35,6 @@ func CopyCmd(ctx context.Context, o *flags.CopyOpts, s *store.Layout, targetRef 
 	case "registry":
 		l.Debugf("identified registry target reference of [%s]", components[1])
 		ropts := content.RegistryOptions{
-			Username:  o.Username,
-			Password:  o.Password,
 			Insecure:  o.Insecure,
 			PlainHTTP: o.PlainHTTP,
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module hauler.dev/go/hauler
 
-go 1.23.4
-toolchain go1.24.2
+go 1.23.8
+
+toolchain go1.24.3
 
 replace github.com/sigstore/cosign/v2 => github.com/hauler-dev/cosign/v2 v2.4.3-0.20250404165522-3a44ef646a65
 

--- a/internal/flags/copy.go
+++ b/internal/flags/copy.go
@@ -15,9 +15,22 @@ type CopyOpts struct {
 func (o *CopyOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
-	f.StringVarP(&o.Username, "username", "u", "", "(Optional) Username to use for authentication")
-	f.StringVarP(&o.Password, "password", "p", "", "(Optional) Password to use for authentication")
+	f.StringVarP(&o.Username, "username", "u", "", "(Deprecated) Please use 'hauler login'")
+	f.StringVarP(&o.Password, "password", "p", "", "(Deprecated) Please use 'hauler login'")
 	f.BoolVar(&o.Insecure, "insecure", false, "(Optional) Allow insecure connections")
 	f.BoolVar(&o.PlainHTTP, "plain-http", false, "(Optional) Allow plain HTTP connections")
-	f.StringVarP(&o.Only, "only", "o", "", "(Optional) Custom string array to only copy specific 'image' items, this flag is comma delimited. ex: --only=sig,att,sbom")
+	f.StringVarP(&o.Only, "only", "o", "", "(Optional) Custom string array to only copy specific 'image' items")
+
+	if err := f.MarkDeprecated("username", "please use 'hauler login'"); err != nil {
+		panic(err)
+	}
+	if err := f.MarkDeprecated("password", "please use 'hauler login'"); err != nil {
+		panic(err)
+	}
+	if err := f.MarkHidden("username"); err != nil {
+		panic(err)
+	}
+	if err := f.MarkHidden("password"); err != nil {
+		panic(err)
+	}
 }


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- Closes https://github.com/hauler-dev/hauler/issues/241

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Deprecation / Breaking Change

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Deprecate and remove the use of `--username/-u` and `--password/-p` for `hauler store copy` since we fully support authentication via `hauler login`
- Resolves issues with copying to registries with a path and confusion around how to authenticate with `hauler`

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

```bash
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store copy -h           
Copy all store content to another location

Usage:
  hauler store copy [flags]

Flags:
  -h, --help          help for copy
      --insecure      (Optional) Allow insecure connections
  -o, --only string   (Optional) Custom string array to only copy specific 'image' items
      --plain-http    (Optional) Allow plain HTTP connections

Global Flags:
  -d, --haulerdir string   Set the location of the hauler directory (default $HOME/.hauler)
      --ignore-errors      Ignore/Bypass errors (i.e. warn on error) (defaults false)
  -l, --log-level string   Set the logging level (i.e. info, debug, warn) (default "info")
  -r, --retries int        Set the number of retries for operations (default 3)
  -s, --store string       Set the directory to use for the content store
```

---

```bash
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store copy -u test -p pw 
Flag --username has been deprecated, please use 'hauler login'
Flag --password has been deprecated, please use 'hauler login'
Error: accepts 1 arg(s), received 0
Usage:
  hauler store copy [flags]

Flags:
  -h, --help          help for copy
      --insecure      (Optional) Allow insecure connections
  -o, --only string   (Optional) Custom string array to only copy specific 'image' items
      --plain-http    (Optional) Allow plain HTTP connections

Global Flags:
  -d, --haulerdir string   Set the location of the hauler directory (default $HOME/.hauler)
      --ignore-errors      Ignore/Bypass errors (i.e. warn on error) (defaults false)
  -l, --log-level string   Set the logging level (i.e. info, debug, warn) (default "info")
  -r, --retries int        Set the number of retries for operations (default 3)
  -s, --store string       Set the directory to use for the content store

2025-05-30 11:11:18 ERR accepts 1 arg(s), received 0
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
