### PR TITLE
updated hauler store load to work with all tarballs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -63,7 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit-tests]
     timeout-minutes: 30
-    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -238,6 +237,11 @@ jobs:
           # verify store directory structure
           tree -hC store
 
+      - name: Remove Hauler Store Contents
+        run: |
+          rm -rf store
+          hauler store info
+
       - name: Verify - docker load
         run: |
           docker load --help
@@ -250,12 +254,20 @@ jobs:
           # verify images
           docker images --all
 
+      - name: Verify Hauler Store Contents
+        run: |
+          # verify store
+          hauler store info
+          # verify store directory structure
+          tree -hC store
+
       - name: Remove Hauler Store Contents
         run: |
           rm -rf store haul.tar.zst store.tar.zst store-amd64.tar.zst
           hauler store info
 
       - name: Verify - hauler store sync
+        continue-on-error: true
         run: |
           hauler store sync --help
           # download local helm repository

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,6 +31,20 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
+      - name: Authenticate to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Authenticate to DockerHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Install Go Releaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -79,6 +93,20 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y unzip
           sudo apt-get install -y tree
+
+      - name: Authenticate to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Authenticate to DockerHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,9 +117,9 @@ jobs:
           hauler login docker.io --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_TOKEN }}
           echo ${{ secrets.GITHUB_TOKEN }} | hauler login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-      - name: Remove Hauler Store Credentials
-        run: |
-          rm -rf ~/.docker/config.json
+      # - name: Remove Hauler Store Credentials
+      #   run: |
+      #     rm -rf ~/.docker/config.json
 
       - name: Verify - hauler store
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,20 +31,6 @@ jobs:
           go-version-file: go.mod
           check-latest: true
 
-      - name: Authenticate to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Authenticate to DockerHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Install Go Releaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -77,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [unit-tests]
     timeout-minutes: 30
+    continue-on-error: true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,20 +80,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y unzip
           sudo apt-get install -y tree
-
-      - name: Authenticate to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Authenticate to DockerHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Download Artifacts
         uses: actions/download-artifact@v4

--- a/cmd/hauler/cli/store/info.go
+++ b/cmd/hauler/cli/store/info.go
@@ -229,7 +229,7 @@ func newItem(s *store.Layout, desc ocispec.Descriptor, m ocispec.Manifest, plat 
 		ctype = "image"
 	}
 
-	switch desc.Annotations["kind"] {
+	switch desc.Annotations[consts.KindAnnotationName] {
 	case "dev.cosignproject.cosign/sigs":
 		ctype = "sigs"
 	case "dev.cosignproject.cosign/atts":

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // LoadCmd extracts the contents of an archived oci layout into an existing store
@@ -132,7 +133,7 @@ func unarchiveLayoutTo(ctx context.Context, haulPath, dest, tempDir string) erro
 
 		// update the oci layout with the image
 		annotations := map[string]string{
-			consts.OCIImageRefName: tag.String(),
+			ocispec.AnnotationRefName: tag.String(),
 		}
 		if err := p.AppendImage(img, layout.WithAnnotations(annotations)); err != nil {
 			return fmt.Errorf("failed to append image to oci layout: %w", err)

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -157,8 +157,7 @@ func unarchiveLayoutTo(ctx context.Context, haulPath, dest, tempDir string) erro
 	if err != nil {
 		return err
 	}
-	_, err = s.CopyAll(ctx, ts, nil)
-	if err != nil {
+	if _, err := s.CopyAll(ctx, ts, nil); err != nil {
 		return err
 	}
 

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -76,7 +76,7 @@ func unarchiveLayoutTo(ctx context.Context, haulPath, dest, tempDir string) erro
 			fileName = filepath.Base(parsedURL.Path)
 		}
 
-		// create temp directory for remote archive
+		// create temp file for remote archive
 		tempTar, err := os.CreateTemp(tempDir, fileName)
 		if err != nil {
 			return err
@@ -94,12 +94,12 @@ func unarchiveLayoutTo(ctx context.Context, haulPath, dest, tempDir string) erro
 		return os.Open(haulPath)
 	}
 
-	// attempt to load the tarball as a docker-save manifest
-	l.Debugf("attempt to inspect [%s] as a docker archive tarball", haulPath)
+	// attempt to load the tarball as a docker archive manifest
+	l.Debugf("attempting to inspect [%s] as a docker archive tarball", haulPath)
 	manifests, err := tarball.LoadManifest(opener)
 	// If LoadManifest fails, it's not a valid docker archive so proccess as an oci layout
 	if err != nil || len(manifests) == 0 {
-		l.Debugf("failed to read as docker-save format (likely an OCI haul), falling back to standard unarchive: %v", err)
+		l.Debugf("unable to determine docker archive format... processing as oci layout tarball")
 		if err := archives.Unarchive(ctx, haulPath, tempDir); err != nil {
 			return err
 		}
@@ -157,7 +157,8 @@ func unarchiveLayoutTo(ctx context.Context, haulPath, dest, tempDir string) erro
 	if err != nil {
 		return err
 	}
-	if _, err = s.CopyAll(ctx, ts, nil); err != nil {
+	_, err = s.CopyAll(ctx, ts, nil)
+	if err != nil {
 		return err
 	}
 

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -110,10 +110,11 @@ func unarchiveLayoutTo(ctx context.Context, haulPath, dest, tempDir string) erro
 		l.Infof("converting docker archive to oci layout...")
 
 		// fetch the tag to identify the image
-		if len(manifests[0].RepoTags) == 0 {
+		manifest := manifests[0]
+		if len(manifest.RepoTags) == 0 {
 			return fmt.Errorf("could not identify the image from the repotags from docker archive tarball")
 		}
-		repoTag := manifests[0].RepoTags[0]
+		repoTag := manifest.RepoTags[0]
 		tag, err := name.NewTag(repoTag)
 		if err != nil {
 			return fmt.Errorf("could not parse tag from docker archive manifest [%s]: %w", repoTag, err)

--- a/cmd/hauler/cli/store/sync.go
+++ b/cmd/hauler/cli/store/sync.go
@@ -84,7 +84,7 @@ func SyncCmd(ctx context.Context, o *flags.SyncOpts, s *store.Layout, rso *flags
 		l.Infof("processing completed successfully")
 	}
 
-	// If passed a local manifest, process it
+	// detect if archive is a local or remote
 	for _, fileName := range o.FileName {
 		l.Infof("processing manifest [%s] to store [%s]", fileName, o.StoreDir)
 

--- a/internal/mapper/filestore.go
+++ b/internal/mapper/filestore.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/containerd/remotes"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
+	"hauler.dev/go/hauler/pkg/consts"
 	"oras.land/oras-go/pkg/content"
 )
 
@@ -69,7 +70,7 @@ func (s *pusher) Push(ctx context.Context, desc ocispec.Descriptor) (ccontent.Wr
 
 	fullFileName := filepath.Join(s.store.ResolvePath(""), filename)
 	// TODO: Don't rewrite everytime, we can check the digest
-	f, err := os.OpenFile(fullFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+	f, err := os.OpenFile(fullFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, consts.DefaultFileMode)
 	if err != nil {
 		return nil, errors.Wrap(err, "pushing file")
 	}

--- a/pkg/artifacts/file/file_test.go
+++ b/pkg/artifacts/file/file_test.go
@@ -123,7 +123,7 @@ func Test_file_Layers(t *testing.T) {
 
 func setup() func() {
 	tfs = afero.NewMemMapFs()
-	afero.WriteFile(tfs, filename, data, 0644)
+	afero.WriteFile(tfs, filename, data, consts.DefaultFileMode)
 
 	mf := &mockFile{File: getter.NewFile(), fs: tfs}
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -12,6 +12,7 @@ const (
 	DockerUncompressedLayer   = "application/vnd.docker.image.rootfs.diff.tar"
 	OCILayer                  = "application/vnd.oci.image.layer.v1.tar+gzip"
 	OCIArtifact               = "application/vnd.oci.empty.v1+json"
+	OCIImageRefName           = "org.opencontainers.image.ref.name"
 
 	// helm chart media types
 	ChartConfigMediaType = "application/vnd.cncf.helm.config.v1+json"

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -42,13 +42,14 @@ const (
 	HaulerVendorPrefix = "vnd.hauler"
 
 	// annotation keys
-	KindAnnotationName      = "kind"
-	KindAnnotationImage     = "dev.cosignproject.cosign/image"
-	KindAnnotationIndex     = "dev.cosignproject.cosign/imageIndex"
-	ImageAnnotationKey      = "hauler.dev/key"
-	ImageAnnotationPlatform = "hauler.dev/platform"
-	ImageAnnotationRegistry = "hauler.dev/registry"
-	ImageAnnotationTlog     = "hauler.dev/use-tlog-verify"
+	ContainerdImageNameAnnotation = "io.containerd.image.name"
+	KindAnnotationName            = "kind"
+	KindAnnotationImage           = "dev.cosignproject.cosign/image"
+	KindAnnotationIndex           = "dev.cosignproject.cosign/imageIndex"
+	ImageAnnotationKey            = "hauler.dev/key"
+	ImageAnnotationPlatform       = "hauler.dev/platform"
+	ImageAnnotationRegistry       = "hauler.dev/registry"
+	ImageAnnotationTlog           = "hauler.dev/use-tlog-verify"
 
 	// cosign keyless validation options
 	ImageAnnotationCertIdentity                 = "hauler.dev/certificate-identity"

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -97,4 +97,5 @@ const (
 	DefaultRetries            = 3
 	RetriesInterval           = 5
 	CustomTimeFormat          = "2006-01-02 15:04:05"
+	DefaultFileMode           = 0644
 )

--- a/pkg/content/oci.go
+++ b/pkg/content/oci.go
@@ -121,8 +121,8 @@ func (o *OCI) SaveIndex() error {
 
 	// sort index to ensure that images come before any signatures and attestations.
 	sort.SliceStable(descs, func(i, j int) bool {
-		kindI := descs[i].Annotations["kind"]
-		kindJ := descs[j].Annotations["kind"]
+		kindI := descs[i].Annotations[consts.KindAnnotationName]
+		kindJ := descs[j].Annotations[consts.KindAnnotationName]
 
 		// Objects with the prefix of "dev.cosignproject.cosign/image" should be at the top.
 		if strings.HasPrefix(kindI, consts.KindAnnotationImage) && !strings.HasPrefix(kindJ, consts.KindAnnotationImage) {

--- a/pkg/content/oci.go
+++ b/pkg/content/oci.go
@@ -138,7 +138,7 @@ func (o *OCI) SaveIndex() error {
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(o.path(ocispec.ImageIndexFile), data, 0644)
+	return os.WriteFile(o.path(ocispec.ImageIndexFile), data, consts.DefaultFileMode)
 }
 
 // Resolve attempts to resolve the reference into a name and descriptor.
@@ -255,7 +255,7 @@ func (o *OCI) blobWriterAt(desc ocispec.Descriptor) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	return os.OpenFile(blobPath, os.O_WRONLY|os.O_CREATE, 0644)
+	return os.OpenFile(blobPath, os.O_WRONLY|os.O_CREATE, consts.DefaultFileMode)
 }
 
 func (o *OCI) ensureBlob(alg string, hex string) (string, error) {

--- a/pkg/getter/getter_test.go
+++ b/pkg/getter/getter_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"hauler.dev/go/hauler/pkg/consts"
 	"hauler.dev/go/hauler/pkg/getter"
 )
 
@@ -129,7 +130,7 @@ func setup(t *testing.T) func() {
 		t.Fatal(err)
 	}
 
-	if err := os.WriteFile(fileWithExt, []byte(""), 0644); err != nil {
+	if err := os.WriteFile(fileWithExt, []byte(""), consts.DefaultFileMode); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/store/oci_layout.go
+++ b/pkg/store/oci_layout.go
@@ -10,7 +10,7 @@ import (
 	"hauler.dev/go/hauler/pkg/consts"
 )
 
-// EnsureOCILayout patches index.json to inject cosign metadata and writes oci-layout to produce a valid layout
+// EnsureOCILayout patches index.json to inject cosign metadata and writes oci layout to produce a valid oci layout
 func EnsureOCILayout(dir string) error {
 	idxPath := filepath.Join(dir, ocispec.ImageIndexFile)
 	raw, err := os.ReadFile(idxPath)
@@ -47,14 +47,14 @@ func EnsureOCILayout(dir string) error {
 		return fmt.Errorf("write index.json: %w", err)
 	}
 
-	// add the oci-layout file
+	// add the oci layout file
 	layout := []byte(`{"imageLayoutVersion":"1.0.0"}`)
 	if err := os.WriteFile(
 		filepath.Join(dir, ocispec.ImageLayoutFile),
 		layout,
 		consts.DefaultFileMode,
 	); err != nil {
-		return fmt.Errorf("write oci-layout: %w", err)
+		return fmt.Errorf("write oci layout: %w", err)
 	}
 
 	return nil

--- a/pkg/store/oci_layout.go
+++ b/pkg/store/oci_layout.go
@@ -1,0 +1,61 @@
+package store
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"hauler.dev/go/hauler/pkg/consts"
+)
+
+// EnsureOCILayout patches index.json to inject cosign metadata and writes oci-layout to produce a valid layout
+func EnsureOCILayout(dir string) error {
+	idxPath := filepath.Join(dir, ocispec.ImageIndexFile)
+	raw, err := os.ReadFile(idxPath)
+	if err != nil {
+		return fmt.Errorf("read index.json: %w", err)
+	}
+
+	var idx ocispec.Index
+	if err := json.Unmarshal(raw, &idx); err != nil {
+		return fmt.Errorf("parse index.json: %w", err)
+	}
+
+	// only mutate the annotations
+	for i, desc := range idx.Manifests {
+		if desc.Annotations == nil {
+			desc.Annotations = make(map[string]string)
+		}
+		if full, ok := desc.Annotations[consts.ContainerdImageNameAnnotation]; ok {
+			desc.Annotations[ocispec.AnnotationRefName] = full
+		}
+		kind := consts.KindAnnotationImage
+		if desc.MediaType == consts.OCIImageIndexSchema {
+			kind = consts.KindAnnotationIndex
+		}
+		desc.Annotations[consts.KindAnnotationName] = kind
+		idx.Manifests[i] = desc
+	}
+
+	out, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal index.json: %w", err)
+	}
+	if err := os.WriteFile(idxPath, out, 0644); err != nil {
+		return fmt.Errorf("write index.json: %w", err)
+	}
+
+	// add the oci-layout file
+	layout := []byte(`{"imageLayoutVersion":"1.0.0"}`)
+	if err := os.WriteFile(
+		filepath.Join(dir, ocispec.ImageLayoutFile),
+		layout,
+		0644,
+	); err != nil {
+		return fmt.Errorf("write oci-layout: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/store/oci_layout.go
+++ b/pkg/store/oci_layout.go
@@ -43,7 +43,7 @@ func EnsureOCILayout(dir string) error {
 	if err != nil {
 		return fmt.Errorf("marshal index.json: %w", err)
 	}
-	if err := os.WriteFile(idxPath, out, 0644); err != nil {
+	if err := os.WriteFile(idxPath, out, consts.DefaultFileMode); err != nil {
 		return fmt.Errorf("write index.json: %w", err)
 	}
 
@@ -52,7 +52,7 @@ func EnsureOCILayout(dir string) error {
 	if err := os.WriteFile(
 		filepath.Join(dir, ocispec.ImageLayoutFile),
 		layout,
-		0644,
+		consts.DefaultFileMode,
 	); err != nil {
 		return fmt.Errorf("write oci-layout: %w", err)
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -126,7 +126,7 @@ func (l *Layout) AddOCI(ctx context.Context, oci artifacts.OCI, ref string) (oci
 		Platform: nil,
 	}
 
-	// write into index.json and ensure full oci-layout
+	// write into index.json and ensure full oci layout
 	if err := l.OCI.AddIndex(idx); err != nil {
 		return ocispec.Descriptor{}, err
 	}
@@ -155,10 +155,10 @@ func (l *Layout) AddOCICollection(ctx context.Context, collection artifacts.OCIC
 	return descs, nil
 }
 
-// Flush is a fancy name for delete-all-the-things, in this case it's as trivial as deleting oci-layout content
+// Flush is a fancy name for delete-all-the-things, in this case it's as trivial as deleting oci layout content
 //
 //	This can be a highly destructive operation if the store's directory happens to be inline with other non-store contents
-//	To reduce the blast radius and likelihood of deleting things we don't own, Flush explicitly deletes oci-layout content only
+//	To reduce the blast radius and likelihood of deleting things we don't own, Flush explicitly deletes oci layout content only
 func (l *Layout) Flush(ctx context.Context) error {
 	blobs := filepath.Join(l.Root, ocispec.ImageBlobsDir)
 	if err := os.RemoveAll(blobs); err != nil {


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- N/A

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix/Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Allow for `hauler` to be able to use and `hauler store load` any `tarball` into the `store
- examples: any `docker save` tarball or the `rke2-images` tarball or using `skopeo copy`

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

***docker save tarball:***
```bash
zackbradys@Zacks-MacBook-Pro test % docker pull rancher/rancher:v2.11.3
v2.11.3: Pulling from rancher/rancher
Digest: sha256:62ddf1d5357c08bda7c080b5c0909dc4d16d53995b34d6c245812b1307dd1969
Status: Image is up to date for rancher/rancher:v2.11.3
docker.io/rancher/rancher:v2.11.3
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test % docker save rancher/rancher:v2.11.3 -o rancher.tgz
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % ls -lh
total 5880712
-rwxr-xr-x  1 zackbradys  staff    89M Aug  7 22:39 hauler
-rw-------  1 zackbradys  staff   995M Aug  7 22:34 rancher.tgz
drwxr-xr-x  5 zackbradys  staff   160B Aug  7 22:06 store
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test % ./hauler store load -l debug -f rancher.tgz       
2025-08-07 22:39:16 DBG running cli command [hauler store load]
2025-08-07 22:39:16 DBG using store at [/Users/zackbradys/Downloads/test/store]
2025-08-07 22:39:16 DBG using temporary directory at [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler973207332]
2025-08-07 22:39:16 INF loading haul [rancher.tgz] to [/Users/zackbradys/Downloads/test/store]
2025-08-07 22:39:16 DBG attempt to inspect [rancher.tgz] as a docker archive tarball
2025-08-07 22:39:16 DBG detected docker archive formatted tarball in [rancher.tgz]
2025-08-07 22:39:16 INF converting docker archive to oci layout...
2025-08-07 22:39:17 INF successfully converted docker archive to oci layout [rancher/rancher:v2.11.3]
2025-08-07 22:39:17 DBG patching metadata in the oci layout in [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler973207332]
2025-08-07 22:39:17 DBG updating oci layout in store at [/Users/zackbradys/Downloads/test/store]
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % ./hauler store info
+-------------------------+-------+-------------+----------+--------+
| REFERENCE               | TYPE  | PLATFORM    | # LAYERS | SIZE   |
+-------------------------+-------+-------------+----------+--------+
| hauler/busybox:latest   | image | linux/arm64 |        1 | 1.8 MB |
| rancher/rancher:v2.11.3 | image | linux/arm64 |       22 | 1.0 GB |
+-------------------------+-------+-------------+----------+--------+
|                                                  TOTAL   | 1.0 GB |
+-------------------------+-------+-------------+----------+--------+
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test % tree store 
store
├── blobs
│   └── sha256
│       ├── 022a1e2dd837423f584febeac91d2c2f026850dbf16803f5440e807b99d42feb
│       ├── 02f6c55ca10fe150a98919b6701b400bd6f12f4dafae7cb1c08b6e12f4c65bd2
│       ├── 06d1fe503ba07bb88ab06897fa235ff7d50df757f633c62e14dd2dfac20f3b53
│       ├── 12206bc3d19f5e8aad08e0fd2e7953088b42368d3822e0a8931510d4036a90fb
│       ├── 15ef5d75322273cb76e72977ba0677ca9626daf77397228cf3e719c2be91f200
│       ├── 189fdd1508372905e80cc3edcdb56cdc4fa216aebef6f332dd3cba6e300238ea
│       ├── 3b64d2a770d9c7e8d7d79188817ea2194a8512ea8487d18baccbd20c86e3eb19
│       ├── 46d11fdf6e4b23eb1d3548c4aa2b861d1a2ff8ea459f572a2eaa8cf5f90562a4
│       ├── 4852e09198e9f1ee1866f0db9c1b015612a1acc8fe63a7da05d6bc3cec8fe45f
│       ├── 4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1
│       ├── 6b884a50c070e3d099f7176d051922b0250a84d2aae4ba34e7e2b89b1895830b
│       ├── 6d89f030ab68185e723455f003914f4b3f5cf0d201a0c162cc686984d7f89276
│       ├── 6feaa0691bd3da5718c37e5f1312b29cc65cf22939f35aa0544d9fffce0bf715
│       ├── 7b4721e214600044496305a20ca3902677e572127d4d976ed0e54da0137c243a
│       ├── 960607670f47d1528aa88b101a40c89f67f2289f20ea184bbbd51a396a3d0aa8
│       ├── 96f22228b2162e1de4901c7cdadd5257235671fbe21064296cec0a9d8adbd460
│       ├── c13f87075ddb7afea6a334f0a3a7e17ae16180bb7f8625286497fb3b90a5bc6e
│       ├── d30826cfc73860007459d4a1fed366bc5a8cd3ba8ccf21ff765512bf122eee99
│       ├── d467f934c8d8427ba215c0eac9bbc2a2189bd337f75ea3344f4f4e61ca653179
│       ├── d511221b8bf9d8ed96cf4ce0c79883330557f071d6616452bb3398656edc2dd5
│       ├── d6d23b8627248709ab7ff2db683212a63488069e2342feb58724e5214467f59e
│       ├── e97f1c5e1d0b290e99d9d22ea5a5ccd9b218f0bcc8852bf3082a0c0b49f48cda
│       ├── ed6a4c2466b37e6d9f22b2b04b3755e5633a77119cc43f77de36ec44541c6142
│       ├── f696c9f5d4200f6036b3d96a54991c012795e4c665539338c8a579d3e84abae4
│       └── fccf9559d5eca284927d21adc6d08b9cc0ba9161c1f330ad60b594a157cbc7c7
├── index.json
└── oci-layout

3 directories, 27 files
```

***rke2 images tarball:***
```bash
zackbradys@Zacks-MacBook-Pro test % curl -L https://github.com/rancher/rke2/releases/download/v1.32.4%2Brke2r1/rke2-images.linux-amd64.tar.zst -o rke2-images.tar.zst
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test % ./hauler store load -f rke2-images.tar.zst -l debug
2025-08-07 18:12:37 DBG running cli command [hauler store load]
2025-08-07 18:12:37 DBG using store at [/Users/zackbradys/Downloads/test/store]
2025-08-07 18:12:37 DBG using temporary directory at [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler906395617]
2025-08-07 18:12:37 INF loading haul [rke2-images.tar.zst] to [/Users/zackbradys/Downloads/test/store]
2025-08-07 18:12:37 DBG unarchiving temporary archive [rke2-images.tar.zst] to temporary store [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler906395617]
2025-08-07 18:12:37 DBG creating directory [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler906395617]
2025-08-07 18:12:42 INF unarchiving completed successfully
2025-08-07 18:12:42 DBG patching metadata in the oci layout in [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler906395617]
2025-08-07 18:12:45 DBG updating oci layout in store at [/Users/zackbradys/Downloads/test/store]
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test % ./hauler store add image busybox:latest -l debug   
2025-08-07 18:12:51 DBG running cli command [hauler store add image]
2025-08-07 18:12:51 DBG using store at [/Users/zackbradys/Downloads/test/store]
2025-08-07 18:12:51 INF adding image [busybox:latest] to the store
2025-08-07 18:12:51 DBG multi-arch image [true]
2025-08-07 18:12:56 INF successfully added image [index.docker.io/library/busybox:latest]
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test % ./hauler store info                                
+-----------------------------------------------------------------------------------------------------+-------+-----------------+----------+----------+
| REFERENCE                                                                                           | TYPE  | PLATFORM        | # LAYERS | SIZE     |
+-----------------------------------------------------------------------------------------------------+-------+-----------------+----------+----------+
| index.docker.io/library/busybox:latest                                                              | image | linux/386       |        1 | 2.2 MB   |
|                                                                                                     | image | linux/amd64     |        1 | 2.1 MB   |
|                                                                                                     | image | linux/arm       |        1 | 951.3 kB |
|                                                                                                     | image | linux/arm       |        1 | 1.6 MB   |
|                                                                                                     | image | linux/arm       |        1 | 1.8 MB   |
|                                                                                                     | image | linux/arm64     |        1 | 1.8 MB   |
|                                                                                                     | image | linux/mips64le  |        1 | 2.1 MB   |
|                                                                                                     | image | linux/ppc64le   |        1 | 2.5 MB   |
|                                                                                                     | image | linux/riscv64   |        1 | 923.4 kB |
|                                                                                                     | image | linux/s390x     |        1 | 1.9 MB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
| index.docker.io/rancher/hardened-addon-resizer:1.8.22-build20250110                                 | image | linux/amd64     |        1 | 40.3 MB  |
| index.docker.io/rancher/hardened-calico:v3.29.3-build20250408                                       | image | linux/amd64     |        4 | 600.6 MB |
| index.docker.io/rancher/hardened-cluster-autoscaler:v1.9.0-build20241203                            | image | linux/amd64     |        1 | 47.0 MB  |
| index.docker.io/rancher/hardened-coredns:v1.12.1-build20250401                                      | image | linux/amd64     |        2 | 89.4 MB  |
| index.docker.io/rancher/hardened-dns-node-cache:1.25.0-build20250127                                | image | linux/amd64     |        3 | 59.5 MB  |
| index.docker.io/rancher/hardened-etcd:v3.5.21-k3s1-build20250411                                    | image | linux/amd64     |        1 | 47.0 MB  |
| index.docker.io/rancher/hardened-flannel:v0.26.6-build20250414                                      | image | linux/amd64     |        4 | 225.4 MB |
| index.docker.io/rancher/hardened-k8s-metrics-server:v0.7.2-build20250110                            | image | linux/amd64     |        1 | 59.3 MB  |
| index.docker.io/rancher/hardened-kubernetes:v1.32.4-rke2r1-build20250423                            | image | linux/amd64     |        5 | 666.7 MB |
| index.docker.io/rancher/klipper-helm:v0.9.5-build20250306                                           | image | linux/amd64     |        5 | 192.0 MB |
| index.docker.io/rancher/klipper-lb:v0.4.13                                                          | image | linux/amd64     |        3 | 12.7 MB  |
| index.docker.io/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.2                          | image | linux/amd64     |       12 | 68.2 MB  |
| index.docker.io/rancher/mirrored-pause:3.6                                                          | image | linux/amd64     |        1 | 684.5 kB |
| index.docker.io/rancher/mirrored-sig-storage-snapshot-controller:v8.2.0                             | image | linux/amd64     |       12 | 71.9 MB  |
| index.docker.io/rancher/nginx-ingress-controller:v1.12.1-hardened3                                  | image | linux/amd64     |       21 | 764.8 MB |
| index.docker.io/rancher/rke2-cloud-provider:v1.32.0-rc3.0.20241220224140-68fbd1a6b543-build20250101 | image | linux/amd64     |        1 | 74.5 MB  |
| index.docker.io/rancher/rke2-runtime:v1.32.4-rke2r1                                                 | image | linux/amd64     |        1 | 288.6 MB |
+-----------------------------------------------------------------------------------------------------+-------+-----------------+----------+----------+
|                                                                                                                                  TOTAL   |  3.3 GB  |
+-----------------------------------------------------------------------------------------------------+-------+-----------------+----------+----------+
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % 
zackbradys@Zacks-MacBook-Pro test % ./hauler store save -l debug                       
2025-08-07 18:13:22 DBG running cli command [hauler store save]
2025-08-07 18:13:22 DBG using store at [/Users/zackbradys/Downloads/test/store]
2025-08-07 18:13:22 DBG descriptor [sha256:2200d39905f53b26bd76201a7958aa75ad1bec8f22bcd8d1a58db87b12e1b4a6] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/hardened-k8s-metrics-server@sha256:2200d39905f53b26bd76201a7958aa75ad1bec8f22bcd8d1a58db87b12e1b4a6]: type=application/vnd.oci.image.manifest.v1+json, size=401
2025-08-07 18:13:22 DBG descriptor [sha256:f9d0d0883db16841e5e77dcc6bb78a637431863ddca825b6644979d418762013] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/hardened-dns-node-cache@sha256:f9d0d0883db16841e5e77dcc6bb78a637431863ddca825b6644979d418762013]: type=application/vnd.oci.image.manifest.v1+json, size=709
2025-08-07 18:13:22 DBG descriptor [sha256:9e0601e524a484420b3c72b17470e3f725d2825312c84e89fe2bc89066b0b2bc] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/rke2-runtime@sha256:9e0601e524a484420b3c72b17470e3f725d2825312c84e89fe2bc89066b0b2bc]: type=application/vnd.oci.image.manifest.v1+json, size=402
2025-08-07 18:13:22 DBG descriptor [sha256:fe742c861c6c8f1c1e13426573147dd5cec3c3ceaeff980c598a56e0927d8d55] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/mirrored-sig-storage-snapshot-controller@sha256:fe742c861c6c8f1c1e13426573147dd5cec3c3ceaeff980c598a56e0927d8d55]: type=application/vnd.oci.image.manifest.v1+json, size=2061
2025-08-07 18:13:22 DBG descriptor [sha256:eee44c723ade10cbdcc6ff35425bf3042f157eda1af90412c2cf3800cc768567] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/hardened-flannel@sha256:eee44c723ade10cbdcc6ff35425bf3042f157eda1af90412c2cf3800cc768567]: type=application/vnd.oci.image.manifest.v1+json, size=864
2025-08-07 18:13:22 DBG descriptor [sha256:91ea27e2309b0fcf0d6231e3ce0d4027e1fc3a0915e64265322bb5174203e83b] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/mirrored-ingress-nginx-kube-webhook-certgen@sha256:91ea27e2309b0fcf0d6231e3ce0d4027e1fc3a0915e64265322bb5174203e83b]: type=application/vnd.oci.image.manifest.v1+json, size=2061
2025-08-07 18:13:22 DBG descriptor [sha256:36d545df2cf0f95db74e2857bdc39503acff9a2317d98b0a84acbef611d143b8] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/hardened-cluster-autoscaler@sha256:36d545df2cf0f95db74e2857bdc39503acff9a2317d98b0a84acbef611d143b8]: type=application/vnd.oci.image.manifest.v1+json, size=401
2025-08-07 18:13:22 DBG descriptor [sha256:89a128a64d0f07434abddf496ce78d20208accc263414668bb6d7a978c220226] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/klipper-lb@sha256:89a128a64d0f07434abddf496ce78d20208accc263414668bb6d7a978c220226]: type=application/vnd.oci.image.manifest.v1+json, size=704
2025-08-07 18:13:22 DBG descriptor [sha256:e845c2c2df5e7b4f4ea21a1023f95e095d8b6643d4a269f6428b0a9a1c7fc42b] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/rke2-cloud-provider@sha256:e845c2c2df5e7b4f4ea21a1023f95e095d8b6643d4a269f6428b0a9a1c7fc42b]: type=application/vnd.oci.image.manifest.v1+json, size=401
2025-08-07 18:13:22 DBG descriptor [sha256:cf6ba2edcab4b2143b95012cce9379158736a8659ce65bed20dbdad2f44fd9fd] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/klipper-helm@sha256:cf6ba2edcab4b2143b95012cce9379158736a8659ce65bed20dbdad2f44fd9fd]: type=application/vnd.oci.image.manifest.v1+json, size=1013
2025-08-07 18:13:22 DBG descriptor [sha256:dec7ddd14e3556be33072ad62e37171b58668f0d76ee666873f13e4e93a67675] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/hardened-calico@sha256:dec7ddd14e3556be33072ad62e37171b58668f0d76ee666873f13e4e93a67675]: type=application/vnd.oci.image.manifest.v1+json, size=862
2025-08-07 18:13:22 DBG descriptor [sha256:39aa04033d5ef5dcbd9df8ffe890362fbdd703947a235b8b16d9045ecc9f0fbe] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/hardened-addon-resizer@sha256:39aa04033d5ef5dcbd9df8ffe890362fbdd703947a235b8b16d9045ecc9f0fbe]: type=application/vnd.oci.image.manifest.v1+json, size=401
2025-08-07 18:13:22 DBG descriptor [sha256:a22eaa37cacb7fea1dd4b462648d3dd84a1a0aa4dfa62319f1e9fd24846f4f6e] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/hardened-coredns@sha256:a22eaa37cacb7fea1dd4b462648d3dd84a1a0aa4dfa62319f1e9fd24846f4f6e]: type=application/vnd.oci.image.manifest.v1+json, size=556
2025-08-07 18:13:22 DBG descriptor [sha256:7935939d2973fe4eacc71970f21375f9d9ef7004d6b24d713bc39c3954305b6e] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/hardened-kubernetes@sha256:7935939d2973fe4eacc71970f21375f9d9ef7004d6b24d713bc39c3954305b6e]: type=application/vnd.oci.image.manifest.v1+json, size=1017
2025-08-07 18:13:22 DBG descriptor [sha256:b71c51b7b6f523be9d69991f6f84e9b5be286406014a30a3961a730aa2ab857f] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/nginx-ingress-controller@sha256:b71c51b7b6f523be9d69991f6f84e9b5be286406014a30a3961a730aa2ab857f]: type=application/vnd.oci.image.manifest.v1+json, size=3446
2025-08-07 18:13:22 DBG descriptor [sha256:772d6c6bf6ac3757ae2f6aa55634475490383f972f87387b7e3a4eb6ceded602] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/hardened-etcd@sha256:772d6c6bf6ac3757ae2f6aa55634475490383f972f87387b7e3a4eb6ceded602]: type=application/vnd.oci.image.manifest.v1+json, size=402
2025-08-07 18:13:22 DBG descriptor [sha256:16974531848218d24822bf606be022d030ab8c9b05b2ecf11076c4c1c6885c95] = [application/vnd.oci.image.manifest.v1+json]
2025-08-07 18:13:22 DBG image [index.docker.io/rancher/mirrored-pause@sha256:16974531848218d24822bf606be022d030ab8c9b05b2ecf11076c4c1c6885c95]: type=application/vnd.oci.image.manifest.v1+json, size=399
2025-08-07 18:13:22 DBG descriptor [sha256:f9a104fddb33220ec80fc45a4e606c74aadf1ef7a3832eb0b05be9e90cd61f5f] = [application/vnd.oci.image.index.v1+json]
2025-08-07 18:13:22 DBG index [docker.io/library/busybox:latest]: digest=[sha256:f9a104fddb33220ec80fc45a4e606c74aadf1ef7a3832eb0b05be9e90cd61f5f]... type=[application/vnd.oci.image.index.v1+json]... size=[10200]
2025-08-07 18:13:22 WRN specify an export platform to prevent potential platform mismatch on import of index [docker.io/library/busybox:latest]
2025-08-07 18:13:22 DBG image [index.docker.io/library/busybox@sha256:7c0ffe5751238c8479f952f3fbc3b719d47bccac0e9bf0a21c77a27cba9ef12d]: type=application/vnd.oci.image.manifest.v1+json, size=610
2025-08-07 18:13:22 DBG index [docker.io/library/busybox:latest]: digest=[sha256:f9a104fddb33220ec80fc45a4e606c74aadf1ef7a3832eb0b05be9e90cd61f5f], platform=[unknown/unknown]: matches unknown platform... skipping...
2025-08-07 18:13:22 DBG image [index.docker.io/library/busybox@sha256:94d9880e2e0e243fa061c570b4dcf6b1059e9447ef4fe21f8526c67483cee6ad]: type=application/vnd.oci.image.manifest.v1+json, size=610
2025-08-07 18:13:22 DBG index [docker.io/library/busybox:latest]: digest=[sha256:f9a104fddb33220ec80fc45a4e606c74aadf1ef7a3832eb0b05be9e90cd61f5f], platform=[unknown/unknown]: matches unknown platform... skipping...
2025-08-07 18:13:22 DBG image [index.docker.io/library/busybox@sha256:6be497a98f91dd69a4265943283cd996e756c8c94784578a1b0b4573d039c64b]: type=application/vnd.oci.image.manifest.v1+json, size=608
2025-08-07 18:13:22 DBG image [index.docker.io/library/busybox@sha256:c859036e179b71840fe935083b39399ae7fb8c2fd023b70a28b101446e036631]: type=application/vnd.oci.image.manifest.v1+json, size=610
2025-08-07 18:13:22 DBG index [docker.io/library/busybox:latest]: digest=[sha256:f9a104fddb33220ec80fc45a4e606c74aadf1ef7a3832eb0b05be9e90cd61f5f], platform=[unknown/unknown]: matches unknown platform... skipping...
2025-08-07 18:13:22 DBG image [index.docker.io/library/busybox@sha256:68a0d55a75c935e1101d16ded1c748babb7f96a9af43f7533ba83b87e2508b82]: type=application/vnd.oci.image.manifest.v1+json, size=610
2025-08-07 18:13:22 DBG index [docker.io/library/busybox:latest]: digest=[sha256:f9a104fddb33220ec80fc45a4e606c74aadf1ef7a3832eb0b05be9e90cd61f5f], platform=[unknown/unknown]: matches unknown platform... skipping...
2025-08-07 18:13:22 DBG image [index.docker.io/library/busybox@sha256:18ac7a6883a86416ade8178063c26deff577cd831445f5c5ac5c7a931cb60983]: type=application/vnd.oci.image.manifest.v1+json, size=610
2025-08-07 18:13:22 DBG index [docker.io/library/busybox:latest]: digest=[sha256:f9a104fddb33220ec80fc45a4e606c74aadf1ef7a3832eb0b05be9e90cd61f5f], platform=[unknown/unknown]: matches unknown platform... skipping...
2025-08-07 18:13:22 DBG image [index.docker.io/library/busybox@sha256:ddac8b22852783747c1b61a9354e72279edb0926f4c825f6b5e9724057148249]: type=application/vnd.oci.image.manifest.v1+json, size=610
2025-08-07 18:13:22 DBG image [index.docker.io/library/busybox@sha256:8412c80c59e2720a095d18c00b982330fe12f9630cb7fca658ff2a4352228f5f]: type=application/vnd.oci.image.manifest.v1+json, size=610
2025-08-07 18:13:22 DBG index [docker.io/library/busybox:latest]: digest=[sha256:f9a104fddb33220ec80fc45a4e606c74aadf1ef7a3832eb0b05be9e90cd61f5f], platform=[unknown/unknown]: matches unknown platform... skipping...
2025-08-07 18:13:22 DBG image [index.docker.io/library/busybox@sha256:a730bc9f9367b59798adeb8f020420ad886d065040f27d312f967ca798903dd0]: type=application/vnd.oci.image.manifest.v1+json, size=608
2025-08-07 18:13:22 DBG index [docker.io/library/busybox:latest]: digest=[sha256:f9a104fddb33220ec80fc45a4e606c74aadf1ef7a3832eb0b05be9e90cd61f5f], platform=[unknown/unknown]: matches unknown platform... skipping...
2025-08-07 18:13:22 DBG image [index.docker.io/library/busybox@sha256:fec56dcf5c3b8c3635489b39b1096b7d8ba62c701675ab8c7e0ee74be458b8d0]: type=application/vnd.oci.image.manifest.v1+json, size=610
2025-08-07 18:13:22 DBG index [docker.io/library/busybox:latest]: digest=[sha256:f9a104fddb33220ec80fc45a4e606c74aadf1ef7a3832eb0b05be9e90cd61f5f], platform=[unknown/unknown]: matches unknown platform... skipping...
2025-08-07 18:13:22 DBG starting the archival process for [.]
2025-08-07 18:13:22 DBG removing existing output file: [/Users/zackbradys/Downloads/test/haul.tar.zst]
2025-08-07 18:13:22 DBG mapping files in directory [.]
2025-08-07 18:13:22 DBG successfully mapped files for directory [.]
2025-08-07 18:13:22 DBG creating output file [/Users/zackbradys/Downloads/test/haul.tar.zst]
2025-08-07 18:13:22 DBG defining the archive format: [archives.Tar]/[archives.Zstd]
2025-08-07 18:13:22 DBG starting archive for [/Users/zackbradys/Downloads/test/haul.tar.zst]
2025-08-07 18:13:28 DBG archive created successfully [/Users/zackbradys/Downloads/test/haul.tar.zst]
2025-08-07 18:13:28 DBG closing output file [/Users/zackbradys/Downloads/test/haul.tar.zst]
2025-08-07 18:13:28 INF saving store [/Users/zackbradys/Downloads/test/store] to archive [haul.tar.zst]
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test % rm -rf registry store 
```

```bash
zackbradys@Zacks-MacBook-Pro test % ./hauler store load -l debug                       
2025-08-07 18:13:48 DBG running cli command [hauler store load]
2025-08-07 18:13:48 DBG using store at [/Users/zackbradys/Downloads/test/store]
2025-08-07 18:13:48 DBG using temporary directory at [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler1178457098]
2025-08-07 18:13:48 INF loading haul [haul.tar.zst] to [/Users/zackbradys/Downloads/test/store]
2025-08-07 18:13:48 DBG unarchiving temporary archive [haul.tar.zst] to temporary store [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler1178457098]
2025-08-07 18:13:48 DBG creating directory [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler1178457098]
2025-08-07 18:13:51 INF unarchiving completed successfully
2025-08-07 18:13:51 DBG patching metadata in the oci layout in [/var/folders/5f/lyy8pc6s62dbckp8sy31ft5r0000gn/T/hauler1178457098]
2025-08-07 18:13:54 DBG updating oci layout in store at [/Users/zackbradys/Downloads/test/store]
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test % ./hauler store info                  
+-----------------------------------------------------------------------------------------------------+-------+-----------------+----------+----------+
| REFERENCE                                                                                           | TYPE  | PLATFORM        | # LAYERS | SIZE     |
+-----------------------------------------------------------------------------------------------------+-------+-----------------+----------+----------+
| index.docker.io/library/busybox:latest                                                              | image | linux/386       |        1 | 2.2 MB   |
|                                                                                                     | image | linux/amd64     |        1 | 2.1 MB   |
|                                                                                                     | image | linux/arm       |        1 | 951.3 kB |
|                                                                                                     | image | linux/arm       |        1 | 1.6 MB   |
|                                                                                                     | image | linux/arm       |        1 | 1.8 MB   |
|                                                                                                     | image | linux/arm64     |        1 | 1.8 MB   |
|                                                                                                     | image | linux/mips64le  |        1 | 2.1 MB   |
|                                                                                                     | image | linux/ppc64le   |        1 | 2.5 MB   |
|                                                                                                     | image | linux/riscv64   |        1 | 923.4 kB |
|                                                                                                     | image | linux/s390x     |        1 | 1.9 MB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
|                                                                                                     | image | unknown/unknown |        1 | 2.0 kB   |
| index.docker.io/rancher/hardened-addon-resizer:1.8.22-build20250110                                 | image | linux/amd64     |        1 | 40.3 MB  |
| index.docker.io/rancher/hardened-calico:v3.29.3-build20250408                                       | image | linux/amd64     |        4 | 600.6 MB |
| index.docker.io/rancher/hardened-cluster-autoscaler:v1.9.0-build20241203                            | image | linux/amd64     |        1 | 47.0 MB  |
| index.docker.io/rancher/hardened-coredns:v1.12.1-build20250401                                      | image | linux/amd64     |        2 | 89.4 MB  |
| index.docker.io/rancher/hardened-dns-node-cache:1.25.0-build20250127                                | image | linux/amd64     |        3 | 59.5 MB  |
| index.docker.io/rancher/hardened-etcd:v3.5.21-k3s1-build20250411                                    | image | linux/amd64     |        1 | 47.0 MB  |
| index.docker.io/rancher/hardened-flannel:v0.26.6-build20250414                                      | image | linux/amd64     |        4 | 225.4 MB |
| index.docker.io/rancher/hardened-k8s-metrics-server:v0.7.2-build20250110                            | image | linux/amd64     |        1 | 59.3 MB  |
| index.docker.io/rancher/hardened-kubernetes:v1.32.4-rke2r1-build20250423                            | image | linux/amd64     |        5 | 666.7 MB |
| index.docker.io/rancher/klipper-helm:v0.9.5-build20250306                                           | image | linux/amd64     |        5 | 192.0 MB |
| index.docker.io/rancher/klipper-lb:v0.4.13                                                          | image | linux/amd64     |        3 | 12.7 MB  |
| index.docker.io/rancher/mirrored-ingress-nginx-kube-webhook-certgen:v1.5.2                          | image | linux/amd64     |       12 | 68.2 MB  |
| index.docker.io/rancher/mirrored-pause:3.6                                                          | image | linux/amd64     |        1 | 684.5 kB |
| index.docker.io/rancher/mirrored-sig-storage-snapshot-controller:v8.2.0                             | image | linux/amd64     |       12 | 71.9 MB  |
| index.docker.io/rancher/nginx-ingress-controller:v1.12.1-hardened3                                  | image | linux/amd64     |       21 | 764.8 MB |
| index.docker.io/rancher/rke2-cloud-provider:v1.32.0-rc3.0.20241220224140-68fbd1a6b543-build20250101 | image | linux/amd64     |        1 | 74.5 MB  |
| index.docker.io/rancher/rke2-runtime:v1.32.4-rke2r1                                                 | image | linux/amd64     |        1 | 288.6 MB |
+-----------------------------------------------------------------------------------------------------+-------+-----------------+----------+----------+
|                                                                                                                                  TOTAL   |  3.3 GB  |
+-----------------------------------------------------------------------------------------------------+-------+-----------------+----------+----------+
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test %
zackbradys@Zacks-MacBook-Pro test % ls -lh store 
total 32
drwxr-xr-x  3 zackbradys  staff    96B Aug  7 18:13 blobs
-rw-r--r--  1 zackbradys  staff   8.3K Aug  7 18:13 index.json
-rw-r--r--  1 zackbradys  staff    30B Aug  7 18:13 oci-layout
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
