### PR TITLE
Add registry logout command

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,16 +117,6 @@ jobs:
           hauler login docker.io --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_TOKEN }}
           echo ${{ secrets.GITHUB_TOKEN }} | hauler login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
-      - name: Verify - hauler logout
-        run: |
-          hauler logout --help
-          hauler logout docker.io
-          hauler logout ghcr.io
-
-      - name: Remove Hauler Store Credentials
-        run: |
-          rm -rf ~/.docker/config.json
-
       - name: Verify - hauler store
         run: |
           hauler store --help
@@ -341,3 +331,13 @@ jobs:
         with:
           name: hauler-report
           path: hauler-report.txt
+
+      - name: Verify - hauler logout
+        run: |
+          hauler logout --help
+          hauler logout docker.io
+          hauler logout ghcr.io
+
+      - name: Remove Hauler Store Credentials
+        run: |
+          rm -rf ~/.docker/config.json

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,6 +117,12 @@ jobs:
           hauler login docker.io --username ${{ secrets.DOCKERHUB_USERNAME }} --password ${{ secrets.DOCKERHUB_TOKEN }}
           echo ${{ secrets.GITHUB_TOKEN }} | hauler login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
+      - name: Verify - hauler logout
+        run: |
+          hauler logout --help
+          hauler logout docker.io
+          hauler logout ghcr.io
+
       - name: Remove Hauler Store Credentials
         run: |
           rm -rf ~/.docker/config.json

--- a/cmd/hauler/cli/cli.go
+++ b/cmd/hauler/cli/cli.go
@@ -30,6 +30,7 @@ func New(ctx context.Context, ro *flags.CliRootOpts) *cobra.Command {
 	flags.AddRootFlags(cmd, ro)
 
 	cmd.AddCommand(cranecmd.NewCmdAuthLogin("hauler"))
+	cmd.AddCommand(cranecmd.NewCmdAuthLogout("hauler"))
 	addStore(cmd, ro)
 	addVersion(cmd, ro)
 	addCompletion(cmd, ro)


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [x] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

- Implements #459 

**Types of Changes:**

- Feature

**Proposed Changes:**

- Just adds Logout the same way Login is implemented, and a test to tests.yaml in the same way

**Verification/Testing of Changes:**

```
hauler/dist/hauler_linux_amd64_v1$ ./hauler login bogus-registry.com:5000 -u test -p test
logged in via /home/garret/.docker/config.json

hauler/dist/hauler_linux_amd64_v1$ grep bogus-registry.com:5000 /home/garret/.docker/config.json
		"bogus-registry.com:5000": {
		
hauler/dist/hauler_linux_amd64_v1$ ./hauler logout bogus-registry.com:5000
logged out via /home/garret/.docker/config.json

hauler/dist/hauler_linux_amd64_v1$ grep bogus-registry.com:5000 /home/garret/.docker/config.json
hauler/dist/hauler_linux_amd64_v1$
```

**Additional Context:**

- N/A
