### PR TITLE
added digests view to info

### DIFF
--- a/internal/flags/info.go
+++ b/internal/flags/info.go
@@ -9,6 +9,7 @@ type InfoOpts struct {
 	TypeFilter   string
 	SizeUnit     string
 	ListRepos    bool
+	ShowDigests  bool
 }
 
 func (o *InfoOpts) AddFlags(cmd *cobra.Command) {
@@ -17,4 +18,5 @@ func (o *InfoOpts) AddFlags(cmd *cobra.Command) {
 	f.StringVarP(&o.OutputFormat, "output", "o", "table", "(Optional) Specify the output format (table | json)")
 	f.StringVarP(&o.TypeFilter, "type", "t", "all", "(Optional) Filter on content type (image | chart | file | sigs | atts | sbom)")
 	f.BoolVar(&o.ListRepos, "list-repos", false, "(Optional) List all repository names")
+	f.BoolVar(&o.ShowDigests, "digests", false, "(Optional) Show digests of each artifact in the output table")
 }


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- N/A

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Added the flag of `--digests` to show the image digests for each item in the `store`
- Truncated the current `reference` for images in the `store` since the full `digest` is now viewable via the flag

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

```bash
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store info
+-------------------------------------------------------+-------+-----------------+----------+----------+
| REFERENCE                                             | TYPE  | PLATFORM        | # LAYERS | SIZE     |
+-------------------------------------------------------+-------+-----------------+----------+----------+
| gcr.io/distroless/base@sha256:7fa7445dfbeb…           | image | linux/amd64     |        2 | 8.0 MB   |
| hauler/hauler-helm:2.1.0                              | chart | -               |        1 | 8.9 kB   |
| hauler/hauler-manifest.yaml:latest                    | file  | -               |        1 | 1.7 kB   |
| hauler/install.sh:latest                              | file  | -               |        1 | 25.3 kB  |
| hauler/rancher:2.8.5                                  | chart | -               |        1 | 15.1 kB  |
| index.docker.io/library/busybox:latest                | image | linux/386       |        1 | 2.3 MB   |
|                                                       | image | linux/amd64     |        1 | 2.2 MB   |
|                                                       | image | linux/arm       |        1 | 1.8 MB   |
|                                                       | image | linux/arm       |        1 | 951.3 kB |
|                                                       | image | linux/arm       |        1 | 1.6 MB   |
|                                                       | image | linux/arm64     |        1 | 1.9 MB   |
|                                                       | image | linux/ppc64le   |        1 | 2.5 MB   |
|                                                       | image | linux/riscv64   |        1 | 1.9 MB   |
|                                                       | image | linux/s390x     |        1 | 2.0 MB   |
|                                                       | image | unknown/unknown |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown |        1 | 3.2 kB   |
|                                                       | image | unknown/unknown |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown |        1 | 2.0 kB   |
| index.docker.io/library/busybox:stable                | image | linux/amd64     |        1 | 2.2 MB   |
| rgcrprod.azurecr.us/backing-image-manager:v3_20220609 | image | linux/amd64     |        6 | 121.4 MB |
|                                                       | atts  | -               |        2 | 1.5 MB   |
|                                                       | sbom  | -               |        1 | 4.8 MB   |
|                                                       | sigs  | -               |       52 | 13.4 kB  |
+-------------------------------------------------------+-------+-----------------+----------+----------+
|                                                                                    TOTAL   | 155.2 MB |
+-------------------------------------------------------+-------+-----------------+----------+----------+
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store info --digests
+-------------------------------------------------------+-------+-----------------+-------------------------------------------------------------------------+----------+----------+
| REFERENCE                                             | TYPE  | PLATFORM        | DIGEST                                                                  | # LAYERS | SIZE     |
+-------------------------------------------------------+-------+-----------------+-------------------------------------------------------------------------+----------+----------+
| gcr.io/distroless/base@sha256:7fa7445dfbeb…           | image | linux/amd64     | sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5 |        2 | 8.0 MB   |
| hauler/hauler-helm:2.1.0                              | chart | -               | sha256:4853d03d930a93695270a4b122f79bb53663462089346089d59f123ff5066387 |        1 | 8.9 kB   |
| hauler/hauler-manifest.yaml:latest                    | file  | -               | sha256:941ef3f2c5e76f2a4f35b8fc6a07649f47eff667c2c2e4bb81199932133b4dde |        1 | 1.7 kB   |
| hauler/install.sh:latest                              | file  | -               | sha256:56296939dad10716dc03913d54c14ab003f9dbfe49e91150d006671966bafd7e |        1 | 25.3 kB  |
| hauler/rancher:2.8.5                                  | chart | -               | sha256:fe07eb6fec5e42ab3f5316287db8be5ac050e6f0090683b6ce2dfd855c5d90c3 |        1 | 15.1 kB  |
| index.docker.io/library/busybox:latest                | image | linux/386       | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.3 MB   |
|                                                       | image | linux/amd64     | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.2 MB   |
|                                                       | image | linux/arm       | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 1.8 MB   |
|                                                       | image | linux/arm       | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 951.3 kB |
|                                                       | image | linux/arm       | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 1.6 MB   |
|                                                       | image | linux/arm64     | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 1.9 MB   |
|                                                       | image | linux/ppc64le   | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.5 MB   |
|                                                       | image | linux/riscv64   | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 1.9 MB   |
|                                                       | image | linux/s390x     | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.0 MB   |
|                                                       | image | unknown/unknown | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 3.2 kB   |
|                                                       | image | unknown/unknown | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.0 kB   |
|                                                       | image | unknown/unknown | sha256:2f590fc602ce325cbff2ccfc39499014d039546dc400ef8bbf5c6ffb860632e7 |        1 | 2.0 kB   |
| index.docker.io/library/busybox:stable                | image | linux/amd64     | sha256:4a35a7836fe08f340a42e25c4ac5eef4439585bbbb817b7bd28b2cd87c742642 |        1 | 2.2 MB   |
| rgcrprod.azurecr.us/backing-image-manager:v3_20220609 | image | linux/amd64     | sha256:ab2aeb7091511c6c9a4675dd0f96eb4d378c19998457fa755b4dfb8bcfbfb3e7 |        6 | 121.4 MB |
|                                                       | atts  | -               | sha256:491d9b8db2064cd74dec9c5a1ca8afcdcc6c3479c5db672ca93ede90a628dc80 |        2 | 1.5 MB   |
|                                                       | sbom  | -               | sha256:e1b546a9a58668bbe56de399ffa3f9198aa5eb255e790c2745f1f00a918e0bbd |        1 | 4.8 MB   |
|                                                       | sigs  | -               | sha256:5991edea14131990984cc665ac6e5ec23fca083dcb9701d39ae49ee966d6b318 |       52 | 13.4 kB  |
+-------------------------------------------------------+-------+-----------------+-------------------------------------------------------------------------+----------+----------+
|                                                                                                                                                              TOTAL   | 155.2 MB |
+-------------------------------------------------------+-------+-----------------+-------------------------------------------------------------------------+----------+----------+
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
