### PR TITLE
added/updated logging for `serve` and `remove`

### DIFF
--- a/cmd/hauler/cli/store/remove.go
+++ b/cmd/hauler/cli/store/remove.go
@@ -1,8 +1,12 @@
 package store
 
 import (
+	"bufio"
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -67,24 +71,30 @@ func RemoveCmd(ctx context.Context, o *flags.RemoveOpts, s *store.Layout, ref st
 	if len(matches) >= 1 {
 		l.Infof("found %d matching references:", len(matches))
 		for _, m := range matches {
-			l.Infof("  - %s", formatReference(m.reference))
+			l.Infof("  - [%s]", formatReference(m.reference))
 		}
 	}
 
 	if !o.Force {
 		fmt.Printf("  ↳ are you sure you want to remove [%d] artifact(s) from the store? (yes/no) ", len(matches))
 
-		var response string
-		_, err := fmt.Scanln(&response)
-		if err != nil {
-			return fmt.Errorf("failed to read response: %w", err)
+		reader := bufio.NewReader(os.Stdin)
+
+		line, err := reader.ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return fmt.Errorf("failed to read response: [%w]... please answer 'yes' or 'no'", err)
 		}
+
+		response := strings.ToLower(strings.TrimSpace(line))
+
 		switch response {
 		case "yes", "y":
 			l.Infof("starting to remove artifacts from store...")
 		case "no", "n":
 			l.Infof("successfully cancelled removal of artifacts from store")
 			return nil
+		case "":
+			return fmt.Errorf("failed to read response... please answer 'yes' or 'no'")
 		default:
 			return fmt.Errorf("invalid response [%s]... please answer 'yes' or 'no'", response)
 		}
@@ -100,10 +110,10 @@ func RemoveCmd(ctx context.Context, o *flags.RemoveOpts, s *store.Layout, ref st
 	}
 
 	// clean up unreferenced blobs
-	l.Infof("cleaning up unreferenced blobs...")
+	l.Infof("cleaning up all unreferenced blobs...")
 	removedCount, removedSize, err := s.CleanUp(ctx)
 	if err != nil {
-		l.Warnf("garbage collection failed: %v", err)
+		l.Warnf("garbage collection failed: [%v]", err)
 	} else if removedCount > 0 {
 		l.Infof("successfully removed [%d] unreferenced blobs [freed %d bytes]", removedCount, removedSize)
 	}

--- a/cmd/hauler/cli/store/remove.go
+++ b/cmd/hauler/cli/store/remove.go
@@ -67,12 +67,12 @@ func RemoveCmd(ctx context.Context, o *flags.RemoveOpts, s *store.Layout, ref st
 	if len(matches) >= 1 {
 		l.Infof("found %d matching references:", len(matches))
 		for _, m := range matches {
-			l.Infof(" - %s", formatReference(m.reference))
+			l.Infof("  - %s", formatReference(m.reference))
 		}
 	}
 
 	if !o.Force {
-		fmt.Printf("are you sure you want to remove [%d] artifact(s) from the store? (yes/no) ", len(matches))
+		fmt.Printf("  ↳ are you sure you want to remove [%d] artifact(s) from the store? (yes/no) ", len(matches))
 
 		var response string
 		_, err := fmt.Scanln(&response)
@@ -86,14 +86,14 @@ func RemoveCmd(ctx context.Context, o *flags.RemoveOpts, s *store.Layout, ref st
 			l.Infof("successfully cancelled removal of artifacts from store")
 			return nil
 		default:
-			return fmt.Errorf("invalid response '%s' - please answer 'yes' or 'no'", response)
+			return fmt.Errorf("invalid response [%s]... please answer 'yes' or 'no'", response)
 		}
 	}
 
 	// remove artifact(s)
 	for _, m := range matches {
 		if err := s.RemoveArtifact(ctx, m.reference, m.desc); err != nil {
-			return fmt.Errorf("failed to remove artifact %s: %w", formatReference(m.reference), err)
+			return fmt.Errorf("failed to remove artifact [%s]: %w", formatReference(m.reference), err)
 		}
 
 		l.Infof("successfully removed [%s] of type [%s] with digest [%s]", formatReference(m.reference), m.desc.MediaType, m.desc.Digest.String())


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- closes https://github.com/hauler-dev/hauler/issues/461

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Updated `hauler store serve registry`/`hauler store serve fileserver` to check for the `store` before starting to serve their respective processes and error out with a useful error message
- Updated `hauler store remove` input logs to match the indents, lines, and arrows of the other `hauler` commands that start a new line in the same log message
- Added more error catching and logging for user inputs (such as newlines or others) to `hauler store remove`

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

`hauler store serve registry`/`hauler store serve fileserver`...

```bash
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store info
+-----------+------+----------+----------+------+
| REFERENCE | TYPE | PLATFORM | # LAYERS | SIZE |
+-----------+------+----------+----------+------+
+-----------+------+----------+----------+------+
|                                TOTAL   | 0 B  |
+-----------+------+----------+----------+------+
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store serve registry
Error: no store found at [/Users/zackbradys/Documents/Coding/GitHub/hauler/store]
  ↳ does the hauler store exist? (verify with `hauler store info`)
Usage:
  hauler store serve registry [flags]

Flags:
  -c, --config string      (Optional) Location of config file (overrides all flags)
      --directory string   (Optional) Directory to use for backend. Defaults to $PWD/registry (default "registry")
  -h, --help               help for registry
  -p, --port int           (Optional) Set the port to use for incoming connections (default 5000)
      --readonly           (Optional) Run the registry as readonly (default true)
      --tls-cert string    (Optional) Location of the TLS Certificate to use for server authenication
      --tls-key string     (Optional) Location of the TLS Key to use for server authenication

Global Flags:
  -d, --haulerdir string   Set the location of the hauler directory (default $HOME/.hauler)
      --ignore-errors      Ignore/Bypass errors (i.e. warn on error) (defaults false)
  -l, --log-level string   Set the logging level (i.e. info, debug, warn) (default "info")
  -r, --retries int        Set the number of retries for operations (default 3)
  -s, --store string       Set the directory to use for the content store
  -t, --tempdir string     (Optional) Override the default temporary directory determined by the OS

2026-01-10 19:45:43 ERR no store found at [/Users/zackbradys/Documents/Coding/GitHub/hauler/store]
  ↳ does the hauler store exist? (verify with `hauler store info`)
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store serve fileserver 
Error: no store found at [/Users/zackbradys/Documents/Coding/GitHub/hauler/store]
  ↳ does the hauler store exist? (verify with `hauler store info`)
Usage:
  hauler store serve fileserver [flags]

Flags:
      --directory string   (Optional) Directory to use for backend. Defaults to $PWD/fileserver (default "fileserver")
  -h, --help               help for fileserver
  -p, --port int           (Optional) Set the port to use for incoming connections (default 8080)
      --timeout int        (Optional) Timeout duration for HTTP Requests in seconds for both reads/writes (default 60)
      --tls-cert string    (Optional) Location of the TLS Certificate to use for server authenication
      --tls-key string     (Optional) Location of the TLS Key to use for server authenication

Global Flags:
  -d, --haulerdir string   Set the location of the hauler directory (default $HOME/.hauler)
      --ignore-errors      Ignore/Bypass errors (i.e. warn on error) (defaults false)
  -l, --log-level string   Set the logging level (i.e. info, debug, warn) (default "info")
  -r, --retries int        Set the number of retries for operations (default 3)
  -s, --store string       Set the directory to use for the content store
  -t, --tempdir string     (Optional) Override the default temporary directory determined by the OS

2026-01-10 19:45:55 ERR no store found at [/Users/zackbradys/Documents/Coding/GitHub/hauler/store]
  ↳ does the hauler store exist? (verify with `hauler store info`)
```

---

`hauler store remove`...

```bash
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store info                                     
+-------------------------------------+------+----------+----------+--------+
| REFERENCE                           | TYPE | PLATFORM | # LAYERS | SIZE   |
+-------------------------------------+------+----------+----------+--------+
| hauler/certificate-script.sh:latest | file | -        |        1 | 5.7 kB |
+-------------------------------------+------+----------+----------+--------+
|                                                          TOTAL   | 5.7 KB |
+-------------------------------------+------+----------+----------+--------+
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store remove script                            
2026-01-10 20:01:14 INF found 1 matching references:
2026-01-10 20:01:14 INF   - [hauler/certificate-script.sh:latest [dev.cosignproject.cosign/image]]
  ↳ are you sure you want to remove [1] artifact(s) from the store? (yes/no) 
Error: failed to read response... please answer 'yes' or 'no'
Usage:
  hauler store remove <artifact-ref> [flags]

Examples:
# remove an image using full store reference
hauler store info
hauler store remove index.docker.io/library/busybox:stable

# remove a chart using full store reference
hauler store info
hauler store remove hauler/rancher:2.8.4

# remove a file using full store reference
hauler store info
hauler store remove hauler/rke2-install.sh

# remove any artifact with the latest tag
hauler store remove :latest

# remove any artifact with 'busybox' in the reference
hauler store remove busybox

# force remove without verification
hauler store remove busybox:latest --force

Flags:
  -f, --force   (Optional) Remove artifact(s) without confirmation
  -h, --help    help for remove

Global Flags:
  -d, --haulerdir string   Set the location of the hauler directory (default $HOME/.hauler)
      --ignore-errors      Ignore/Bypass errors (i.e. warn on error) (defaults false)
  -l, --log-level string   Set the logging level (i.e. info, debug, warn) (default "info")
  -r, --retries int        Set the number of retries for operations (default 3)
  -s, --store string       Set the directory to use for the content store
  -t, --tempdir string     (Optional) Override the default temporary directory determined by the OS

2026-01-10 20:01:15 ERR failed to read response... please answer 'yes' or 'no'
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store remove script
2026-01-10 20:01:19 INF found 1 matching references:
2026-01-10 20:01:19 INF   - [hauler/certificate-script.sh:latest [dev.cosignproject.cosign/image]]
  ↳ are you sure you want to remove [1] artifact(s) from the store? (yes/no) HECK YAH 
Error: invalid response [heck yah]... please answer 'yes' or 'no'
Usage:
  hauler store remove <artifact-ref> [flags]

Examples:
# remove an image using full store reference
hauler store info
hauler store remove index.docker.io/library/busybox:stable

# remove a chart using full store reference
hauler store info
hauler store remove hauler/rancher:2.8.4

# remove a file using full store reference
hauler store info
hauler store remove hauler/rke2-install.sh

# remove any artifact with the latest tag
hauler store remove :latest

# remove any artifact with 'busybox' in the reference
hauler store remove busybox

# force remove without verification
hauler store remove busybox:latest --force

Flags:
  -f, --force   (Optional) Remove artifact(s) without confirmation
  -h, --help    help for remove

Global Flags:
  -d, --haulerdir string   Set the location of the hauler directory (default $HOME/.hauler)
      --ignore-errors      Ignore/Bypass errors (i.e. warn on error) (defaults false)
  -l, --log-level string   Set the logging level (i.e. info, debug, warn) (default "info")
  -r, --retries int        Set the number of retries for operations (default 3)
  -s, --store string       Set the directory to use for the content store
  -t, --tempdir string     (Optional) Override the default temporary directory determined by the OS

2026-01-10 20:01:23 ERR invalid response [heck yah]... please answer 'yes' or 'no'
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store remove script
2026-01-10 20:01:26 INF found 1 matching references:
2026-01-10 20:01:26 INF   - [hauler/certificate-script.sh:latest [dev.cosignproject.cosign/image]]
  ↳ are you sure you want to remove [1] artifact(s) from the store? (yes/no) yes
2026-01-10 20:01:28 INF starting to remove artifacts from store...
2026-01-10 20:01:28 INF successfully removed [hauler/certificate-script.sh:latest [dev.cosignproject.cosign/image]] of type [application/vnd.oci.image.manifest.v1+json] with digest [sha256:6c669fdaee7ff0b8173fa0bc2afa854b312d73953eb8559e3f4e8c15f1218c60]
2026-01-10 20:01:28 INF cleaning up all unreferenced blobs...
2026-01-10 20:01:28 INF successfully removed [3] unreferenced blobs [freed 6244 bytes]
```


**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
