### PR TITLE
fix and support containerd imports of `hauls`

### DIFF
--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -56,12 +56,14 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, rso *flags.StoreRootOpts, r
 
 	// strip out the oci-layout file from the haul
 	// required for containerd to be able to interpret the haul correctly for all mediatypes and artifactypes
-	if err := os.Remove(filepath.Join(".", ocispec.ImageLayoutFile)); err != nil {
-		if !os.IsNotExist(err) {
-			return err
+	if o.ContainerdCompatibility {
+		if err := os.Remove(filepath.Join(".", ocispec.ImageLayoutFile)); err != nil {
+			if !os.IsNotExist(err) {
+				return err
+			}
+		} else {
+			l.Warnf("compatibility warning... containerd... removing 'oci-layout' file to support containerd importing of images")
 		}
-
-		l.Debugf("compatibility warning... containerd... removing 'oci-layout' file to support containerd importing of images")
 	}
 
 	// create the archive
@@ -130,7 +132,7 @@ func writeExportsManifest(ctx context.Context, dir string, platformStr string) e
 						// when no platform is inputted... warn the user of potential mismatch on import for docker
 						// required for docker to be able to interpret and load the image correctly
 						if platform.String() == "" {
-							l.Warnf("compatibility warning... docker... please specify platform to prevent potential mismatch on import of index [%s]", refName)
+							l.Warnf("compatibility warning... docker... specify platform to prevent potential mismatch on import of index [%s]", refName)
 						}
 
 						iix, err := idx.ImageIndex(desc.Digest)

--- a/internal/flags/save.go
+++ b/internal/flags/save.go
@@ -7,8 +7,9 @@ import (
 
 type SaveOpts struct {
 	*StoreRootOpts
-	FileName string
-	Platform string
+	FileName                string
+	Platform                string
+	ContainerdCompatibility bool
 }
 
 func (o *SaveOpts) AddFlags(cmd *cobra.Command) {
@@ -16,4 +17,6 @@ func (o *SaveOpts) AddFlags(cmd *cobra.Command) {
 
 	f.StringVarP(&o.FileName, "filename", "f", consts.DefaultHaulerArchiveName, "(Optional) Specify the name of outputted haul")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform for runtime imports... i.e. linux/amd64 (unspecified implies all)")
+	cmd.Flags().BoolVar(&o.ContainerdCompatibility, "containerd", false, "(Optional) Enable import compatibility containerd... removes oci-layout from the haul")
+
 }


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [x] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- `containerd` associated import process... 
  - https://github.com/containerd/containerd/blob/main/core/images/archive/importer.go#L106
- `containerd` convert process for `docker` to `oci`... 
  - https://github.com/containerd/containerd/blob/main/core/images/converter/default.go#L422
- `oci` image spec... 
  - https://github.com/opencontainers/image-spec/blob/main/specs-go/v1/layout.go

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Updated `hauler store save` with a flag of `--containerd` to allow for `hauls` to be full compatibly with `containerd` in specific edge cases, such as when you have ` store` with `mediatypes` of `oci` and `docker`.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

```bash
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store add image nginx
2026-01-15 08:46:22 INF adding image [nginx] to the store
2026-01-15 08:47:02 INF successfully added image [index.docker.io/library/nginx:latest]
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store ls             
+--------------------------------------+-------+-----------------+----------+----------+
| REFERENCE                            | TYPE  | PLATFORM        | # LAYERS | SIZE     |
+--------------------------------------+-------+-----------------+----------+----------+
| index.docker.io/library/nginx:latest | image | linux/386       |        7 | 63.2 MB  |
|                                      | image | linux/amd64     |        7 | 62.8 MB  |
|                                      | image | linux/arm       |        7 | 52.3 MB  |
|                                      | image | linux/arm       |        7 | 54.1 MB  |
|                                      | image | linux/arm64     |        7 | 61.2 MB  |
|                                      | image | linux/ppc64le   |        7 | 67.0 MB  |
|                                      | image | linux/riscv64   |        7 | 57.5 MB  |
|                                      | image | linux/s390x     |        7 | 60.4 MB  |
|                                      | image | unknown/unknown |        2 | 2.9 MB   |
|                                      | image | unknown/unknown |        2 | 2.9 MB   |
|                                      | image | unknown/unknown |        2 | 2.9 MB   |
|                                      | image | unknown/unknown |        2 | 2.9 MB   |
|                                      | image | unknown/unknown |        2 | 2.9 MB   |
|                                      | image | unknown/unknown |        2 | 2.9 MB   |
|                                      | image | unknown/unknown |        2 | 2.9 MB   |
|                                      | image | unknown/unknown |        2 | 2.8 MB   |
+--------------------------------------+-------+-----------------+----------+----------+
|                                                                   TOTAL   | 501.4 MB |
+--------------------------------------+-------+-----------------+----------+----------+
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % ls -lh store 
total 16
drwxr-xr-x  3 zackbradys  staff    96B Jan 15 08:47 blobs
-rwxr-xr-x  1 zackbradys  staff   549B Jan 15 08:47 index.json
-rwxr-xr-x  1 zackbradys  staff    37B Jan 15 08:46 oci-layout
```

---

```bash
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store save 
2026-01-15 08:47:35 WRN compatibility warning... docker... specify platform to prevent potential mismatch on import of index [docker.io/library/nginx:latest]
2026-01-15 08:47:36 INF saving store [/Users/zackbradys/Documents/Coding/GitHub/hauler/store] to archive [haul.tar.zst]
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % tar tvf haul.tar.zst | grep oci-layout
-rwxr-xr-x  0 zackbradys staff       37 Jan 15 08:46 oci-layout
```

---

```bash
zackbradys@Zacks-MacBook-Pro hauler % ./dist/hauler_darwin_arm64_v8.0/hauler store save --containerd
2026-01-15 08:48:18 WRN compatibility warning... docker... specify platform to prevent potential mismatch on import of index [docker.io/library/nginx:latest]
2026-01-15 08:48:18 WRN compatibility warning... containerd... removing 'oci-layout' file to support containerd importing of images
2026-01-15 08:48:19 INF saving store [/Users/zackbradys/Documents/Coding/GitHub/hauler/store] to archive [haul.tar.zst]
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % 
zackbradys@Zacks-MacBook-Pro hauler % tar tvf haul.tar.zst | grep oci-layout 
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
