### PR TITLE
Fix platform filter

### DIFF
--- a/cmd/hauler/cli/store/info.go
+++ b/cmd/hauler/cli/store/info.go
@@ -315,6 +315,9 @@ func newItem(s *store.Layout, desc ocispec.Descriptor, m ocispec.Manifest, plat 
 	if o.TypeFilter != "all" && ctype != o.TypeFilter {
 		return item{}
 	}
+	if (ctype == "sigs" || ctype == "atts" || ctype == "sbom") && len(m.Layers) == 0 {
+		return item{}
+	}
 
 	return item{
 		Reference: ref.Name(),

--- a/pkg/cosign/cosign.go
+++ b/pkg/cosign/cosign.go
@@ -7,9 +7,18 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	v1layout "github.com/google/go-containerregistry/pkg/v1/layout"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v3/cmd/cosign/cli/verify"
+	"github.com/sigstore/cosign/v3/pkg/oci"
+	ocilayout "github.com/sigstore/cosign/v3/pkg/oci/layout"
+	ociremote "github.com/sigstore/cosign/v3/pkg/oci/remote"
 	"hauler.dev/go/hauler/internal/flags"
 	"hauler.dev/go/hauler/pkg/artifacts/image"
 	"hauler.dev/go/hauler/pkg/consts"
@@ -118,11 +127,95 @@ func SaveImage(ctx context.Context, s *store.Layout, ref string, platform string
 			return err
 		}
 
+		if platform != "" && isMultiArch {
+			if err := saveIndexAttachments(ctx, s.Root, ref); err != nil {
+				return err
+			}
+		}
+
 		return nil
 
 	}
 
 	return RetryOperation(ctx, rso, ro, operation)
+}
+
+func saveIndexAttachments(ctx context.Context, dir string, ref string) error {
+	parsedRef, err := name.ParseReference(ref)
+	if err != nil {
+		return err
+	}
+
+	remoteOpts := []remote.Option{
+		remote.WithContext(ctx),
+		remote.WithUserAgent(options.UserAgent()),
+		remote.WithAuthFromKeychain(authn.DefaultKeychain),
+	}
+	se, err := ociremote.SignedEntity(parsedRef, ociremote.WithRemoteOptions(remoteOpts...))
+	if err != nil {
+		return err
+	}
+
+	sii, ok := se.(oci.SignedImageIndex)
+	if !ok {
+		return nil
+	}
+
+	lp, err := v1layout.FromPath(dir)
+	if os.IsNotExist(err) {
+		lp, err = v1layout.Write(dir, empty.Index)
+	}
+	if err != nil {
+		return err
+	}
+
+	imageRef := strings.TrimPrefix(parsedRef.Name(), parsedRef.Context().RegistryStr()+"/")
+	containerdName := strings.Replace(parsedRef.Name(), "index.docker.io/", "docker.io/", 1)
+
+	sigs, err := sii.Signatures()
+	if err != nil {
+		return err
+	}
+	if sigs != nil {
+		if err := lp.AppendImage(sigs, v1layout.WithAnnotations(map[string]string{
+			ocilayout.KindAnnotation:           ocilayout.SigsAnnotation,
+			ocilayout.ImageRefAnnotation:       imageRef,
+			ocilayout.ContainerdNameAnnotation: containerdName,
+		})); err != nil {
+			return err
+		}
+	}
+
+	atts, err := sii.Attestations()
+	if err != nil {
+		return err
+	}
+	if atts != nil {
+		if err := lp.AppendImage(atts, v1layout.WithAnnotations(map[string]string{
+			ocilayout.KindAnnotation:           ocilayout.AttsAnnotation,
+			ocilayout.ImageRefAnnotation:       imageRef,
+			ocilayout.ContainerdNameAnnotation: containerdName,
+		})); err != nil {
+			return err
+		}
+	}
+
+	sbom, err := sii.Attachment("sbom")
+	if err == nil && sbom != nil {
+		sbomImg, ok := sbom.(v1.Image)
+		if !ok {
+			return fmt.Errorf("sbom attachment does not implement v1.Image")
+		}
+		if err := lp.AppendImage(sbomImg, v1layout.WithAnnotations(map[string]string{
+			ocilayout.KindAnnotation:           ocilayout.SbomsAnnotation,
+			ocilayout.ImageRefAnnotation:       imageRef,
+			ocilayout.ContainerdNameAnnotation: containerdName,
+		})); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // LoadImage loads store to a remote registry.


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

**Associated Links:**

```
nathanielchurchill@Nathaniels-MacBook-Pro hauler-src % vi test.yaml
nathanielchurchill@Nathaniels-MacBook-Pro hauler-src % rm -rf store; cat test.yaml;  hauler store sync -f test.yaml && hauler store info
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: hauler-content-images-example
  annotations:
    hauler.dev/platform: linux/amd64
spec:
  images:
    - name: ghcr.io/americancode/gitlab-cicd-k8s:v0.3.9
2026-02-02 19:26:13 INF processing manifest [test.yaml] to store [/Users/nathanielchurchill/source/hauler-src/store]
2026-02-02 19:26:13 INF syncing content [content.hauler.cattle.io/v1] with [kind=Images] to store [/Users/nathanielchurchill/source/hauler-src/store]
2026-02-02 19:26:13 INF adding image [ghcr.io/americancode/gitlab-cicd-k8s:v0.3.9] to the store
vi test	2026-02-02 19:26:21 INF successfully added image [ghcr.io/americancode/gitlab-cicd-k8s:v0.3.9]
2026-02-02 19:26:21 INF processing completed successfully
+---------------------------------------------+-------+-------------+----------+---------+
| REFERENCE                                   | TYPE  | PLATFORM    | # LAYERS | SIZE    |
+---------------------------------------------+-------+-------------+----------+---------+
| ghcr.io/americancode/gitlab-cicd-k8s:v0.3.9 | image | linux/amd64 |       11 | 93.7 MB |
+---------------------------------------------+-------+-------------+----------+---------+
|                                                                      TOTAL   | 93.7 MB |
+---------------------------------------------+-------+-------------+----------+---------+
nathanielchurchill@Nathaniels-MacBook-Pro hauler-src % vi test.yaml
nathanielchurchill@Nathaniels-MacBook-Pro hauler-src % rm -rf store; cat test.yaml;  hauler store sync -f test.yaml && hauler store info
apiVersion: content.hauler.cattle.io/v1
kind: Images
metadata:
  name: hauler-content-images-example
#  annotations:
#    hauler.dev/platform: linux/amd64
spec:
  images:
    - name: ghcr.io/americancode/gitlab-cicd-k8s:v0.3.9
2026-02-02 19:26:34 INF processing manifest [test.yaml] to store [/Users/nathanielchurchill/source/hauler-src/store]
2026-02-02 19:26:34 INF syncing content [content.hauler.cattle.io/v1] with [kind=Images] to store [/Users/nathanielchurchill/source/hauler-src/store]
2026-02-02 19:26:34 INF adding image [ghcr.io/americancode/gitlab-cicd-k8s:v0.3.9] to the store
2026-02-02 19:26:43 INF successfully added image [ghcr.io/americancode/gitlab-cicd-k8s:v0.3.9]
2026-02-02 19:26:43 INF processing completed successfully
+---------------------------------------------+-------+-----------------+----------+---------+
| REFERENCE                                   | TYPE  | PLATFORM        | # LAYERS | SIZE    |
+---------------------------------------------+-------+-----------------+----------+---------+
| ghcr.io/americancode/gitlab-cicd-k8s:v0.3.9 | image | linux/amd64     |       11 | 93.7 MB |
|                                             | image | unknown/unknown |        1 | 9.9 kB  |
|                                             | sigs  | -               |        2 | 504 B   |
+---------------------------------------------+-------+-----------------+----------+---------+
|                                                                          TOTAL   | 93.7 MB |
+---------------------------------------------+-------+-----------------+----------+---------+
```
**Additional Context:**

- When `platform` is set in the v1 manifest, cosign saved only the platform image and omitted index-level signatures/attestations. The fix restores those artifacts so the store contains the same security metadata as non-platform syncs.
