### PR TITLE
fix: correct file:// dependency chart path resolution

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -521,7 +521,7 @@ func storeChart(ctx context.Context, s *store.Layout, cfg v1.Chart, opts *flags.
 
 			if strings.HasPrefix(dep.Repository, "file://") {
 				depPath := strings.TrimPrefix(dep.Repository, "file://")
-				subchartPath := filepath.Join(chartPath, depPath)
+				subchartPath := filepath.Join(chartPath, "charts", dep.Name)
 
 				depCfg = v1.Chart{Name: subchartPath, RepoURL: "", Version: ""}
 				depOpts.ChartOpts.RepoURL = ""


### PR DESCRIPTION
## Summary

When handling file:// dependencies with relative paths like ../libcoder, the previous code used:
```go
subchartPath := filepath.Join(chartPath, depPath)
```

This caused incorrect path resolution because depPath would traverse up from the parent directory, resulting in paths like /tmp/hauler149441757/libcoder instead of looking in the expected charts/ subdirectory.

## Fix

Changed to:
```go
subchartPath := filepath.Join(chartPath, "charts", dep.Name)
```

This correctly:
1. Locates dependency charts in the charts/ subdirectory per Helm convention
2. Uses dep.Name directly to avoid path traversal issues
3. Follows Helm standard dependency chart structure

## Related Issue

Fixes #500