### PR TITLE
fix extract for oci files

### DIFF
--- a/internal/mapper/filestore.go
+++ b/internal/mapper/filestore.go
@@ -62,14 +62,23 @@ func (s *pusher) Push(ctx context.Context, desc ocispec.Descriptor) (ccontent.Wr
 	// Check if this descriptor has a mapper for its media type
 	mapperFn, hasMapper := s.mapper[desc.MediaType]
 	if !hasMapper {
+		// Fall back to catch-all sentinel, then discard
+		mapperFn, hasMapper = s.mapper[DefaultCatchAll]
+	}
+	if !hasMapper {
 		// No mapper for this media type, discard it (config blobs, etc.)
 		return content.NewIoContentWriter(&nopCloser{io.Discard}, content.WithOutputHash(desc.Digest.String())), nil
 	}
 
-	// Get the filename from the mapper function
+	// Get the filename from the mapper function.
+	// An empty filename means the mapper explicitly declined this descriptor (e.g. a
+	// config blob that has no title annotation); treat it the same as no mapper.
 	filename, err := mapperFn(desc)
 	if err != nil {
 		return nil, err
+	}
+	if filename == "" {
+		return content.NewIoContentWriter(&nopCloser{io.Discard}, content.WithOutputHash(desc.Digest.String())), nil
 	}
 
 	// Get the destination directory and create the full path

--- a/internal/mapper/filestore.go
+++ b/internal/mapper/filestore.go
@@ -81,9 +81,23 @@ func (s *pusher) Push(ctx context.Context, desc ocispec.Descriptor) (ccontent.Wr
 		return content.NewIoContentWriter(&nopCloser{io.Discard}, content.WithOutputHash(desc.Digest.String())), nil
 	}
 
-	// Get the destination directory and create the full path
-	destDir := s.store.ResolvePath("")
+	// Get the destination directory and create the full path.
+	// Use absolute paths so the traversal check works even when destDir is relative (e.g. ".").
+	destDir, err := filepath.Abs(s.store.ResolvePath(""))
+	if err != nil {
+		return nil, errors.Wrap(err, "resolving destination dir")
+	}
 	fullFileName := filepath.Join(destDir, filename)
+
+	// Guard against path traversal (e.g. filename containing "../")
+	if !strings.HasPrefix(fullFileName, destDir+string(filepath.Separator)) {
+		return nil, fmt.Errorf("path_traversal_disallowed: %q resolves outside destination dir", filename)
+	}
+
+	// Create parent directories (e.g. when filename is "subdir/file.txt")
+	if err := os.MkdirAll(filepath.Dir(fullFileName), 0755); err != nil {
+		return nil, errors.Wrap(err, fmt.Sprintf("creating directory for %s", fullFileName))
+	}
 
 	// Create the file
 	f, err := os.OpenFile(fullFileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)

--- a/internal/mapper/mappers.go
+++ b/internal/mapper/mappers.go
@@ -13,32 +13,35 @@ type Fn func(desc ocispec.Descriptor) (string, error)
 
 // FromManifest will return the appropriate content store given a reference and source type adequate for storing the results on disk
 func FromManifest(manifest ocispec.Manifest, root string) (content.Target, error) {
-	// First, switch on config mediatype to identify known types
+	// First, switch on config mediatype to identify known types.
 	switch manifest.Config.MediaType {
-	case consts.DockerConfigJSON, ocispec.MediaTypeImageConfig:
-		return NewMapperFileStore(root, Images())
-
 	case consts.ChartLayerMediaType, consts.ChartConfigMediaType:
 		return NewMapperFileStore(root, Chart())
 
 	case consts.FileLocalConfigMediaType, consts.FileDirectoryConfigMediaType, consts.FileHttpConfigMediaType:
 		return NewMapperFileStore(root, Files())
+
+	case consts.DockerConfigJSON, ocispec.MediaTypeImageConfig:
+		// Standard OCI/Docker image config. OCI artifacts that distribute files
+		// (e.g. rke2-binary) reuse this config type but set AnnotationTitle on their
+		// layers. When title annotations are present prefer Files() so the title is
+		// used as the output filename; otherwise treat as a container image.
+		for _, layer := range manifest.Layers {
+			if _, ok := layer.Annotations[ocispec.AnnotationTitle]; ok {
+				return NewMapperFileStore(root, Files())
+			}
+		}
+		return NewMapperFileStore(root, Images())
 	}
 
-	// For unknown config types, check if any layer has a title annotation, which indicates a file artifact
-	hasFileLayer := false
+	// Unknown config type: title annotation indicates a file artifact; otherwise use
+	// a catch-all mapper that writes blobs by digest.
 	for _, layer := range manifest.Layers {
 		if _, ok := layer.Annotations[ocispec.AnnotationTitle]; ok {
-			hasFileLayer = true
-			break
+			return NewMapperFileStore(root, Files())
 		}
 	}
-	if hasFileLayer {
-		return NewMapperFileStore(root, Files())
-	}
-
-	// Default fallback
-	return NewMapperFileStore(root, nil)
+	return NewMapperFileStore(root, Default())
 }
 
 func Images() map[string]Fn {
@@ -91,6 +94,24 @@ func Chart() map[string]Fn {
 	return m
 }
 
+// DefaultCatchAll is the sentinel key used in a mapper map to match any media type
+// not explicitly registered. Push checks for this key as a fallback.
+const DefaultCatchAll = ""
+
+// Default returns a catch-all mapper that extracts any layer blob using its title
+// annotation as the filename, falling back to a digest-based name. Used when the
+// manifest config media type is not a known hauler type.
+func Default() map[string]Fn {
+	m := make(map[string]Fn)
+	m[DefaultCatchAll] = Fn(func(desc ocispec.Descriptor) (string, error) {
+		if title, ok := desc.Annotations[ocispec.AnnotationTitle]; ok {
+			return title, nil
+		}
+		return fmt.Sprintf("%s.bin", desc.Digest.String()), nil
+	})
+	return m
+}
+
 func Files() map[string]Fn {
 	m := make(map[string]Fn)
 
@@ -108,6 +129,16 @@ func Files() map[string]Fn {
 	m[consts.FileLayerMediaType] = fileMapperFn
 	m[consts.OCILayer] = fileMapperFn                          // Also handle standard OCI layers that have title annotation
 	m["application/vnd.oci.image.layer.v1.tar"] = fileMapperFn // And the tar variant
+
+	// Catch-all for OCI artifacts that use custom layer media types (e.g. rke2-binary).
+	// Write the blob if it carries an AnnotationTitle; silently discard everything else
+	// (config blobs, metadata) by returning an empty filename.
+	m[DefaultCatchAll] = Fn(func(desc ocispec.Descriptor) (string, error) {
+		if title, ok := desc.Annotations[ocispec.AnnotationTitle]; ok {
+			return title, nil
+		}
+		return "", nil // No title → discard (config blob or unrecognised metadata)
+	})
 
 	return m
 }


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- bugfix for v2 codebase

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- v2 was not able to `hauler store extract` certain custom media-typed OCI artifacts pulled from a registry.  

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- pre change:  (showed success but the file didn't end up in local fs.
```
❯ hauler store extract rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1
2026-03-10 08:23:07 INF extracted [application/vnd.oci.image.manifest.v1+json] from store with digest [sha256:7fcf5c04edb68ca4f34ccc5eb23544eb57c8720e7bfafcc06fc00b78e3b2c911]
2026-03-10 08:23:07 INF extracted [application/vnd.oci.image.manifest.v1+json] from store with digest [sha256:5ac44c2ac0ad92295e46e8f93f1f2b3eb5976c000191f73c2bc494dc837583a3]

❯ ls -la rke2.linux-amd64                                                                                                                                                                                                   
ls: rke2.linux-amd64: No such file or directory
```

- post change: (properly extracted the file)
```
❯ ./dist/hauler_darwin_arm64_v8.0/hauler store extract rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1
2026-03-10 08:26:13 INF extracted [application/vnd.oci.image.manifest.v1+json] from store with digest [sha256:7fcf5c04edb68ca4f34ccc5eb23544eb57c8720e7bfafcc06fc00b78e3b2c911]
2026-03-10 08:26:13 INF extracted [application/vnd.oci.image.manifest.v1+json] from store with digest [sha256:5ac44c2ac0ad92295e46e8f93f1f2b3eb5976c000191f73c2bc494dc837583a3]

❯ ls -la rke2.linux-amd64
-rw-r--r--@ 1 amartin  staff  121094504 Mar 10 08:26 rke2.linux-amd64
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
