### PR TITLE
adjust extract to handle an image index appropriately

### DIFF
--- a/cmd/hauler/cli/store/extract.go
+++ b/cmd/hauler/cli/store/extract.go
@@ -10,10 +10,28 @@ import (
 
 	"hauler.dev/go/hauler/internal/flags"
 	"hauler.dev/go/hauler/internal/mapper"
+	"hauler.dev/go/hauler/pkg/consts"
 	"hauler.dev/go/hauler/pkg/log"
 	"hauler.dev/go/hauler/pkg/reference"
 	"hauler.dev/go/hauler/pkg/store"
 )
+
+// isContainerImageManifest returns true when the manifest describes a real
+// container image — i.e. an OCI/Docker image config with no AnnotationTitle on
+// any layer. File artifacts distributed as OCI images always carry AnnotationTitle
+// on their layers, so they are NOT considered container images by this check.
+func isContainerImageManifest(m ocispec.Manifest) bool {
+	switch m.Config.MediaType {
+	case consts.DockerConfigJSON, ocispec.MediaTypeImageConfig:
+		for _, layer := range m.Layers {
+			if _, ok := layer.Annotations[ocispec.AnnotationTitle]; ok {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
 
 func ExtractCmd(ctx context.Context, o *flags.ExtractOpts, s *store.Layout, ref string) error {
 	l := log.FromContext(ctx)
@@ -39,9 +57,36 @@ func ExtractCmd(ctx context.Context, o *flags.ExtractOpts, s *store.Layout, ref 
 		}
 		defer rc.Close()
 
+		// For image indexes, decoding the index JSON as ocispec.Manifest produces
+		// an empty Config.MediaType and nil Layers — causing FromManifest to fall
+		// back to Default() mapper, which writes config blobs as sha256:<digest>.bin.
+		// Instead, peek at the first child manifest to get real config/layer info.
 		var m ocispec.Manifest
-		if err := json.NewDecoder(rc).Decode(&m); err != nil {
-			return err
+		if desc.MediaType == ocispec.MediaTypeImageIndex || desc.MediaType == consts.DockerManifestListSchema2 {
+			var idx ocispec.Index
+			if err := json.NewDecoder(rc).Decode(&idx); err != nil {
+				return err
+			}
+			if len(idx.Manifests) > 0 {
+				childRC, err := s.Fetch(ctx, idx.Manifests[0])
+				if err != nil {
+					return err
+				}
+				defer childRC.Close()
+				// ignore decode error — FromManifest handles an empty manifest gracefully
+				json.NewDecoder(childRC).Decode(&m) //nolint:errcheck
+			}
+		} else {
+			if err := json.NewDecoder(rc).Decode(&m); err != nil {
+				return err
+			}
+		}
+
+		// Container images (no AnnotationTitle on any layer) are not extractable
+		// to disk in a meaningful way — use `hauler store copy` to push to a registry.
+		if isContainerImageManifest(m) {
+			l.Warnf("skipping [%s]: container images cannot be extracted (use `hauler store copy` to push to a registry)", reference)
+			return nil
 		}
 
 		mapperStore, err := mapper.FromManifest(m, o.DestinationDir)

--- a/cmd/hauler/cli/store/extract.go
+++ b/cmd/hauler/cli/store/extract.go
@@ -16,6 +16,56 @@ import (
 	"hauler.dev/go/hauler/pkg/store"
 )
 
+// isIndexMediaType returns true for OCI and Docker manifest list media types.
+func isIndexMediaType(mt string) bool {
+	return mt == ocispec.MediaTypeImageIndex || mt == consts.DockerManifestListSchema2
+}
+
+// firstLeafManifest walks a (potentially nested) OCI index and returns the
+// decoded manifest of the first non-index child. It prefers non-index children
+// at each level; if all children are indexes it descends into the first one.
+// Returns an error if any nested index or manifest cannot be decoded.
+func firstLeafManifest(ctx context.Context, s *store.Layout, idx ocispec.Index) (ocispec.Manifest, error) {
+	for {
+		if len(idx.Manifests) == 0 {
+			return ocispec.Manifest{}, fmt.Errorf("image index has no child manifests")
+		}
+
+		// Prefer the first non-index child; fall back to the first child (an index) if all are indexes.
+		desc := idx.Manifests[0]
+		for _, d := range idx.Manifests {
+			if !isIndexMediaType(d.MediaType) {
+				desc = d
+				break
+			}
+		}
+
+		rc, err := s.Fetch(ctx, desc)
+		if err != nil {
+			return ocispec.Manifest{}, err
+		}
+
+		if isIndexMediaType(desc.MediaType) {
+			var nested ocispec.Index
+			err = json.NewDecoder(rc).Decode(&nested)
+			rc.Close()
+			if err != nil {
+				return ocispec.Manifest{}, fmt.Errorf("decoding nested index: %w", err)
+			}
+			idx = nested
+			continue
+		}
+
+		var m ocispec.Manifest
+		err = json.NewDecoder(rc).Decode(&m)
+		rc.Close()
+		if err != nil {
+			return ocispec.Manifest{}, fmt.Errorf("decoding child manifest: %w", err)
+		}
+		return m, nil
+	}
+}
+
 // isContainerImageManifest returns true when the manifest describes a real
 // container image — i.e. an OCI/Docker image config with no AnnotationTitle on
 // any layer. File artifacts distributed as OCI images always carry AnnotationTitle
@@ -67,14 +117,14 @@ func ExtractCmd(ctx context.Context, o *flags.ExtractOpts, s *store.Layout, ref 
 			if err := json.NewDecoder(rc).Decode(&idx); err != nil {
 				return err
 			}
-			if len(idx.Manifests) > 0 {
-				childRC, err := s.Fetch(ctx, idx.Manifests[0])
-				if err != nil {
-					return err
-				}
-				defer childRC.Close()
-				// ignore decode error — FromManifest handles an empty manifest gracefully
-				json.NewDecoder(childRC).Decode(&m) //nolint:errcheck
+			if len(idx.Manifests) == 0 {
+				l.Warnf("skipping [%s]: image index has no child manifests", reference)
+				return nil
+			}
+			var err error
+			m, err = firstLeafManifest(ctx, s, idx)
+			if err != nil {
+				return err
 			}
 		} else {
 			if err := json.NewDecoder(rc).Decode(&m); err != nil {

--- a/cmd/hauler/cli/store/extract_test.go
+++ b/cmd/hauler/cli/store/extract_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
@@ -186,6 +187,226 @@ func TestExtractCmd_OciArtifactKindImage(t *testing.T) {
 	}
 	if string(data) != string(fileContent) {
 		t.Errorf("content mismatch: got %q, want %q", string(data), string(fileContent))
+	}
+}
+
+func TestExtractCmd_OciImageIndex_NoBinFiles(t *testing.T) {
+	// Regression test: extracting an OCI image index whose platform manifests
+	// carry binary layers with AnnotationTitle must yield only the named binary
+	// files — no sha256:<digest>.bin metadata files.
+	// Before the fix, decoding the index as an ocispec.Manifest produced an
+	// empty Config.MediaType, causing FromManifest to select Default() mapper
+	// which wrote config blobs and child manifests as sha256:<digest>.bin.
+	ctx := newTestContext(t)
+	host, rOpts := newLocalhostRegistry(t)
+
+	buildPlatformImg := func(content []byte, title string) gcrv1.Image {
+		layer := static.NewLayer(content, gvtypes.OCILayer)
+		img, err := mutate.Append(empty.Image, mutate.Addendum{
+			Layer: layer,
+			Annotations: map[string]string{
+				ocispec.AnnotationTitle: title,
+			},
+		})
+		if err != nil {
+			t.Fatalf("mutate.Append: %v", err)
+		}
+		img = mutate.MediaType(img, gvtypes.OCIManifestSchema1)
+		img = mutate.ConfigMediaType(img, gvtypes.MediaType(ocispec.MediaTypeImageConfig))
+		return img
+	}
+
+	amd64Img := buildPlatformImg([]byte("amd64 binary content"), "mybinary.linux-amd64")
+	arm64Img := buildPlatformImg([]byte("arm64 binary content"), "mybinary.linux-arm64")
+
+	idx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{
+			Add: amd64Img,
+			Descriptor: gcrv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gcrv1.Platform{OS: "linux", Architecture: "amd64"},
+			},
+		},
+		mutate.IndexAddendum{
+			Add: arm64Img,
+			Descriptor: gcrv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gcrv1.Platform{OS: "linux", Architecture: "arm64"},
+			},
+		},
+	)
+
+	ref := host + "/binaries/mybinary:v1"
+	tag, err := name.NewTag(ref, name.Insecure)
+	if err != nil {
+		t.Fatalf("name.NewTag: %v", err)
+	}
+	if err := remote.WriteIndex(tag, idx, rOpts...); err != nil {
+		t.Fatalf("remote.WriteIndex: %v", err)
+	}
+
+	s := newTestStore(t)
+	if err := s.AddImage(ctx, ref, "", rOpts...); err != nil {
+		t.Fatalf("AddImage: %v", err)
+	}
+
+	destDir := t.TempDir()
+	eo := &flags.ExtractOpts{
+		StoreRootOpts:  defaultRootOpts(s.Root),
+		DestinationDir: destDir,
+	}
+	if err := ExtractCmd(ctx, eo, s, "binaries/mybinary:v1"); err != nil {
+		t.Fatalf("ExtractCmd: %v", err)
+	}
+
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+
+	// No sha256: digest-named files should be extracted
+	for _, n := range names {
+		if strings.HasPrefix(n, "sha256:") {
+			t.Errorf("unexpected digest-named file %q extracted (all files: %v)", n, names)
+		}
+	}
+
+	// Both platform binaries must be present
+	for _, want := range []string{"mybinary.linux-amd64", "mybinary.linux-arm64"} {
+		found := false
+		for _, n := range names {
+			if n == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected binary %q not found; got: %v", want, names)
+		}
+	}
+}
+
+func TestExtractCmd_ContainerImage_Skipped(t *testing.T) {
+	// A real container image (no AnnotationTitle on any layer) should be skipped
+	// without error and without writing any files to the destination directory.
+	ctx := newTestContext(t)
+	host, rOpts := newLocalhostRegistry(t)
+
+	layer := static.NewLayer([]byte("layer content"), gvtypes.OCILayer)
+	img, err := mutate.Append(empty.Image, mutate.Addendum{Layer: layer})
+	if err != nil {
+		t.Fatalf("mutate.Append: %v", err)
+	}
+	img = mutate.MediaType(img, gvtypes.OCIManifestSchema1)
+	img = mutate.ConfigMediaType(img, gvtypes.MediaType(ocispec.MediaTypeImageConfig))
+
+	ref := host + "/myapp/myimage:v1"
+	tag, err := name.NewTag(ref, name.Insecure)
+	if err != nil {
+		t.Fatalf("name.NewTag: %v", err)
+	}
+	if err := remote.Write(tag, img, rOpts...); err != nil {
+		t.Fatalf("remote.Write: %v", err)
+	}
+
+	s := newTestStore(t)
+	if err := s.AddImage(ctx, ref, "", rOpts...); err != nil {
+		t.Fatalf("AddImage: %v", err)
+	}
+
+	destDir := t.TempDir()
+	eo := &flags.ExtractOpts{
+		StoreRootOpts:  defaultRootOpts(s.Root),
+		DestinationDir: destDir,
+	}
+	if err := ExtractCmd(ctx, eo, s, "myapp/myimage:v1"); err != nil {
+		t.Fatalf("ExtractCmd: %v", err)
+	}
+
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("expected no files extracted for container image, got: %v", names)
+	}
+}
+
+func TestExtractCmd_ContainerImageIndex_Skipped(t *testing.T) {
+	// A real multi-arch container image index (no AnnotationTitle on any layer)
+	// should be skipped without error and without writing any files.
+	ctx := newTestContext(t)
+	host, rOpts := newLocalhostRegistry(t)
+
+	buildPlatformImg := func(content []byte) gcrv1.Image {
+		layer := static.NewLayer(content, gvtypes.OCILayer)
+		img, err := mutate.Append(empty.Image, mutate.Addendum{Layer: layer})
+		if err != nil {
+			t.Fatalf("mutate.Append: %v", err)
+		}
+		img = mutate.MediaType(img, gvtypes.OCIManifestSchema1)
+		img = mutate.ConfigMediaType(img, gvtypes.MediaType(ocispec.MediaTypeImageConfig))
+		return img
+	}
+
+	idx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{
+			Add: buildPlatformImg([]byte("amd64 content")),
+			Descriptor: gcrv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gcrv1.Platform{OS: "linux", Architecture: "amd64"},
+			},
+		},
+		mutate.IndexAddendum{
+			Add: buildPlatformImg([]byte("arm64 content")),
+			Descriptor: gcrv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gcrv1.Platform{OS: "linux", Architecture: "arm64"},
+			},
+		},
+	)
+
+	ref := host + "/myapp/multiarch:v1"
+	tag, err := name.NewTag(ref, name.Insecure)
+	if err != nil {
+		t.Fatalf("name.NewTag: %v", err)
+	}
+	if err := remote.WriteIndex(tag, idx, rOpts...); err != nil {
+		t.Fatalf("remote.WriteIndex: %v", err)
+	}
+
+	s := newTestStore(t)
+	if err := s.AddImage(ctx, ref, "", rOpts...); err != nil {
+		t.Fatalf("AddImage: %v", err)
+	}
+
+	destDir := t.TempDir()
+	eo := &flags.ExtractOpts{
+		StoreRootOpts:  defaultRootOpts(s.Root),
+		DestinationDir: destDir,
+	}
+	if err := ExtractCmd(ctx, eo, s, "myapp/multiarch:v1"); err != nil {
+		t.Fatalf("ExtractCmd: %v", err)
+	}
+
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		t.Errorf("expected no files extracted for container image index, got: %v", names)
 	}
 }
 

--- a/cmd/hauler/cli/store/extract_test.go
+++ b/cmd/hauler/cli/store/extract_test.go
@@ -290,6 +290,116 @@ func TestExtractCmd_OciImageIndex_NoBinFiles(t *testing.T) {
 	}
 }
 
+func TestExtractCmd_NestedImageIndex_NoBinFiles(t *testing.T) {
+	// Regression test: extracting a nested OCI image index (outer index whose only
+	// children are inner indexes, which in turn contain the platform manifests) must
+	// yield only the named binary files — no sha256:<digest>.bin metadata files.
+	// firstLeafManifest must descend through the outer index into the inner index to
+	// find a leaf manifest so that FromManifest selects the correct Files() mapper.
+	ctx := newTestContext(t)
+	host, rOpts := newLocalhostRegistry(t)
+
+	buildPlatformImg := func(content []byte, title string) gcrv1.Image {
+		layer := static.NewLayer(content, gvtypes.OCILayer)
+		img, err := mutate.Append(empty.Image, mutate.Addendum{
+			Layer: layer,
+			Annotations: map[string]string{
+				ocispec.AnnotationTitle: title,
+			},
+		})
+		if err != nil {
+			t.Fatalf("mutate.Append: %v", err)
+		}
+		img = mutate.MediaType(img, gvtypes.OCIManifestSchema1)
+		img = mutate.ConfigMediaType(img, gvtypes.MediaType(ocispec.MediaTypeImageConfig))
+		return img
+	}
+
+	amd64Img := buildPlatformImg([]byte("amd64 binary content"), "mybinary.linux-amd64")
+	arm64Img := buildPlatformImg([]byte("arm64 binary content"), "mybinary.linux-arm64")
+
+	// Inner index contains the leaf platform manifests.
+	innerIdx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{
+			Add: amd64Img,
+			Descriptor: gcrv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gcrv1.Platform{OS: "linux", Architecture: "amd64"},
+			},
+		},
+		mutate.IndexAddendum{
+			Add: arm64Img,
+			Descriptor: gcrv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gcrv1.Platform{OS: "linux", Architecture: "arm64"},
+			},
+		},
+	)
+
+	// Outer index contains only the inner index — all children are indexes.
+	outerIdx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{
+			Add: innerIdx,
+			Descriptor: gcrv1.Descriptor{
+				MediaType: gvtypes.OCIImageIndex,
+			},
+		},
+	)
+
+	ref := host + "/binaries/nested:v1"
+	tag, err := name.NewTag(ref, name.Insecure)
+	if err != nil {
+		t.Fatalf("name.NewTag: %v", err)
+	}
+	if err := remote.WriteIndex(tag, outerIdx, rOpts...); err != nil {
+		t.Fatalf("remote.WriteIndex: %v", err)
+	}
+
+	s := newTestStore(t)
+	if err := s.AddImage(ctx, ref, "", rOpts...); err != nil {
+		t.Fatalf("AddImage: %v", err)
+	}
+
+	destDir := t.TempDir()
+	eo := &flags.ExtractOpts{
+		StoreRootOpts:  defaultRootOpts(s.Root),
+		DestinationDir: destDir,
+	}
+	if err := ExtractCmd(ctx, eo, s, "binaries/nested:v1"); err != nil {
+		t.Fatalf("ExtractCmd: %v", err)
+	}
+
+	entries, err := os.ReadDir(destDir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+
+	// No sha256: digest-named files should be extracted.
+	for _, n := range names {
+		if strings.HasPrefix(n, "sha256:") {
+			t.Errorf("unexpected digest-named file %q extracted (all files: %v)", n, names)
+		}
+	}
+
+	// Both platform binaries must be present.
+	for _, want := range []string{"mybinary.linux-amd64", "mybinary.linux-arm64"} {
+		found := false
+		for _, n := range names {
+			if n == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected binary %q not found; got: %v", want, names)
+		}
+	}
+}
+
 func TestExtractCmd_ContainerImage_Skipped(t *testing.T) {
 	// A real container image (no AnnotationTitle on any layer) should be skipped
 	// without error and without writing any files to the destination directory.


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- bugfix for v2 codebase.

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- if you have an image index and it's a container image there's nothing really meaningful to extract, warn and skip.
- if you have an image index of other mediaTypes, make sure that you extract each item of the index.


**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

trying to extract an image index containing a file...
```
> hauler store add image rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1
> hauler store info
┌─────────────────────────────────────────────────────────────┬───────┬─────────────┬───────────┬──────────┐
│ REFERENCE                                                   │ TYPE  │ PLATFORM    │ #  LAYERS │ SIZE     │
├─────────────────────────────────────────────────────────────┼───────┼─────────────┼───────────┼──────────┤
│ rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1 │ image │ linux/amd64 │ 1         │ 121.1 MB │
│                                                             │ image │ linux/arm64 │ 1         │ 116.8 MB │
│                                                             │ sigs  │ -           │ 1         │ 289 B    │
├─────────────────────────────────────────────────────────────┼───────┼─────────────┼───────────┼──────────┤
│                                                             │       │             │     Total │ 237.9 MB │
└─────────────────────────────────────────────────────────────┴───────┴─────────────┴───────────┴──────────┘

> hauler store extract rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1
> ls -l rke2.linux-*
-rw-r--r--@ 1 amartin  staff  121094504 Mar 11 15:59 rke2.linux-amd64
-rw-r--r--@ 1 amartin  staff  116809896 Mar 11 15:59 rke2.linux-arm64
```

trying to extract a container image...
```
hauler store add image rgcrprod.azurecr.us/containers/nats:2.12.5-5.2
2026-03-11 16:03:06 INF adding image [rgcrprod.azurecr.us/containers/nats:2.12.5-5.2] to the store
2026-03-11 16:03:16 INF successfully added image [rgcrprod.azurecr.us/containers/nats:2.12.5-5.2]

hauler store extract rgcrprod.azurecr.us/containers/nats:2.12.5-5.2
2026-03-11 16:03:33 WRN skipping [containers/nats:2.12.5-5.2-dev.cosignproject.cosign/imageIndex]: container images cannot be extracted (use `hauler store copy` to push to a registry)
2026-03-11 16:03:33 WRN skipping [containers/nats:2.12.5-5.2-dev.cosignproject.cosign/sigs]: container images cannot be extracted (use `hauler store copy` to push to a registry)
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
