### PR TITLE
fix dockerhub default host bug

### DIFF
--- a/pkg/content/registry.go
+++ b/pkg/content/registry.go
@@ -47,6 +47,10 @@ func NewRegistryTarget(host string, opts RegistryOptions) *RegistryTarget {
 	)
 
 	hosts := func(h string) ([]cdocker.RegistryHost, error) {
+		host, err := cdocker.DefaultHost(h)
+		if err != nil {
+			return nil, err
+		}
 		scheme := "https"
 		if opts.PlainHTTP || opts.Insecure {
 			scheme = "http"
@@ -55,7 +59,7 @@ func NewRegistryTarget(host string, opts RegistryOptions) *RegistryTarget {
 			Client:       http.DefaultClient,
 			Authorizer:   authorizer,
 			Scheme:       scheme,
-			Host:         h,
+			Host:         host,
 			Path:         "/v2",
 			Capabilities: cdocker.HostCapabilityPull | cdocker.HostCapabilityResolve | cdocker.HostCapabilityPush,
 		}}, nil


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix for v2 codebase

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

Call cdocker.DefaultHost(h) to normalize the hostname before building the RegistryHost struct. Without this, short-form hosts like docker.io wouldn't be resolved to their actual registry hostname (registry-1.docker.io). Previously the raw host string h was passed directly, which could cause resolution failures for well-known registries with aliases.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

before:
```
> hauler store --store /tmp/forager-oci-store add chart releases/forager-easymode-1.1.1.tgz --repo . --rewrite amartin120/forager-easymode:1.1.1
2026-03-17 11:13:26 INF adding chart [forager-easymode-1.1.1.tgz] to the store
2026-03-17 11:13:26 INF successfully added chart [forager-easymode:1.1.1]
> hauler store --store /tmp/forager-oci-store copy registry://docker.io
2026-03-17 11:13:26 INF amartin120/forager-easymode:1.1.1
2026-03-17 11:13:26 ERR error (attempt 1/3)... failed to push manifest: invalid content digest in response: invalid checksum digest format
2026-03-17 11:13:32 ERR error (attempt 2/3)... failed to push manifest: invalid content digest in response: invalid checksum digest format
2026-03-17 11:13:37 ERR error (attempt 3/3)... failed to push manifest: invalid content digest in response: invalid checksum digest format
Error: operation unsuccessful after 3 attempts
```

after:
```
> hauler store --store /tmp/forager-oci-store add chart releases/forager-easymode-1.1.1.tgz --repo . --rewrite amartin120/forager-easymode:1.1.1
2026-03-17 11:14:17 INF adding chart [forager-easymode-1.1.1.tgz] to the store
2026-03-17 11:14:17 INF successfully added chart [forager-easymode:1.1.1]
> hauler store --store /tmp/forager-oci-store copy registry://docker.io
2026-03-17 11:14:17 INF amartin120/forager-easymode:1.1.1
2026-03-17 11:14:20 INF docker.io/amartin120/forager-easymode:1.1.1: digest: sha256:dab37b40cd5e56ed094ebb7d29378e7c8a80e5efe020718e4a45c1d53988c8b5 size: 488
2026-03-17 11:14:20 INF copied artifacts to [docker.io]
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- I admit to only testing with Harbor.  Lesson learned.  Thanks dockerhub. 
