### PR TITLE
adjust hauler's kind annotation to not reflect cosign

### DIFF
--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -107,6 +107,9 @@ func unarchiveLayoutTo(ctx context.Context, haulPath string, dest string, tempDi
 		if _, exists := idx.Manifests[i].Annotations[consts.KindAnnotationName]; !exists {
 			idx.Manifests[i].Annotations[consts.KindAnnotationName] = consts.KindAnnotationImage
 		}
+		// Translate legacy dev.cosignproject.cosign values to dev.hauler equivalents.
+		kind := idx.Manifests[i].Annotations[consts.KindAnnotationName]
+		idx.Manifests[i].Annotations[consts.KindAnnotationName] = consts.NormalizeLegacyKind(kind)
 		if ref, ok := idx.Manifests[i].Annotations[consts.ContainerdImageNameKey]; ok {
 			if slash := strings.Index(ref, "/"); slash != -1 {
 				ref = ref[slash+1:]

--- a/cmd/hauler/cli/store/load_test.go
+++ b/cmd/hauler/cli/store/load_test.go
@@ -288,6 +288,99 @@ func TestUnarchiveLayoutTo_AnnotationBackfill(t *testing.T) {
 }
 
 // --------------------------------------------------------------------------
+// TestUnarchiveLayoutTo_LegacyKindMigration
+// --------------------------------------------------------------------------
+
+// TestUnarchiveLayoutTo_LegacyKindMigration crafts a haul archive whose
+// index.json contains old dev.cosignproject.cosign kind values, then verifies
+// that unarchiveLayoutTo translates them to dev.hauler equivalents.
+func TestUnarchiveLayoutTo_LegacyKindMigration(t *testing.T) {
+	ctx := newTestContext(t)
+
+	// Step 1: Extract the real test archive to obtain a valid OCI layout on disk.
+	extractDir := t.TempDir()
+	if err := archives.Unarchive(ctx, testHaulArchive, extractDir); err != nil {
+		t.Fatalf("Unarchive: %v", err)
+	}
+
+	// Step 2: Read index.json and inject old dev.cosignproject.cosign kind values.
+	indexPath := filepath.Join(extractDir, "index.json")
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read index.json: %v", err)
+	}
+
+	var idx ocispec.Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatalf("unmarshal index.json: %v", err)
+	}
+	if len(idx.Manifests) == 0 {
+		t.Skip("testdata/haul.tar.zst has no top-level manifests — cannot test legacy kind migration")
+	}
+
+	// Replace all kind annotations with old-prefix equivalents so we can verify
+	// that unarchiveLayoutTo normalizes them to the new dev.hauler prefix.
+	const legacyPrefix = "dev.cosignproject.cosign"
+	const newPrefix = "dev.hauler"
+	for i := range idx.Manifests {
+		if idx.Manifests[i].Annotations == nil {
+			idx.Manifests[i].Annotations = make(map[string]string)
+		}
+		kind := idx.Manifests[i].Annotations[consts.KindAnnotationName]
+		if kind == "" {
+			kind = consts.KindAnnotationImage
+		}
+		// Rewrite dev.hauler/* → dev.cosignproject.cosign/* to simulate legacy archive.
+		if strings.HasPrefix(kind, newPrefix) {
+			kind = legacyPrefix + kind[len(newPrefix):]
+		}
+		idx.Manifests[i].Annotations[consts.KindAnnotationName] = kind
+	}
+
+	out, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal legacy index.json: %v", err)
+	}
+	if err := os.WriteFile(indexPath, out, 0644); err != nil {
+		t.Fatalf("write legacy index.json: %v", err)
+	}
+
+	// Step 3: Re-archive with files at the archive root (no subdir prefix).
+	legacyArchive := filepath.Join(t.TempDir(), "legacy.tar.zst")
+	if err := createRootLevelArchive(extractDir, legacyArchive); err != nil {
+		t.Fatalf("createRootLevelArchive: %v", err)
+	}
+
+	// Step 4: Load the legacy archive.
+	destDir := t.TempDir()
+	tempDir := t.TempDir()
+	if err := unarchiveLayoutTo(ctx, legacyArchive, destDir, tempDir); err != nil {
+		t.Fatalf("unarchiveLayoutTo legacy: %v", err)
+	}
+
+	// Step 5: Every descriptor in the dest store must now have a dev.hauler kind.
+	s, err := store.NewLayout(destDir)
+	if err != nil {
+		t.Fatalf("store.NewLayout(destDir): %v", err)
+	}
+
+	if err := s.OCI.Walk(func(_ string, desc ocispec.Descriptor) error {
+		kind := desc.Annotations[consts.KindAnnotationName]
+		if strings.HasPrefix(kind, legacyPrefix) {
+			t.Errorf("descriptor %s still has legacy kind %q; expected dev.hauler prefix",
+				desc.Digest, kind)
+		}
+		if !strings.HasPrefix(kind, newPrefix) {
+			t.Errorf("descriptor %s has unexpected kind %q; expected dev.hauler prefix",
+				desc.Digest, kind)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+}
+
+// --------------------------------------------------------------------------
 // TestClearDir
 // --------------------------------------------------------------------------
 

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -44,16 +44,16 @@ const (
 	// annotation keys
 	ContainerdImageNameKey = "io.containerd.image.name"
 	KindAnnotationName     = "kind"
-	KindAnnotationImage    = "dev.cosignproject.cosign/image"
-	KindAnnotationIndex    = "dev.cosignproject.cosign/imageIndex"
-	KindAnnotationSigs     = "dev.cosignproject.cosign/sigs"
-	KindAnnotationAtts     = "dev.cosignproject.cosign/atts"
-	KindAnnotationSboms    = "dev.cosignproject.cosign/sboms"
+	KindAnnotationImage    = "dev.hauler/image"
+	KindAnnotationIndex    = "dev.hauler/imageIndex"
+	KindAnnotationSigs     = "dev.hauler/sigs"
+	KindAnnotationAtts     = "dev.hauler/atts"
+	KindAnnotationSboms    = "dev.hauler/sboms"
 	// KindAnnotationReferrers is the kind prefix for OCI 1.1 referrer manifests (cosign v3
 	// new-bundle-format). Each referrer gets a unique kind with the referrer manifest digest
-	// appended (e.g. "dev.cosignproject.cosign/referrers/sha256hex") so multiple referrers
-	// for the same base image coexist in the OCI index.
-	KindAnnotationReferrers = "dev.cosignproject.cosign/referrers"
+	// appended (e.g. "dev.hauler/referrers/sha256hex") so multiple referrers for the same
+	// base image coexist in the OCI index.
+	KindAnnotationReferrers = "dev.hauler/referrers"
 
 	// Sigstore / OCI 1.1 artifact media types used by cosign v3 new-bundle-format.
 	SigstoreBundleMediaType = "application/vnd.dev.sigstore.bundle.v0.3+json"

--- a/pkg/consts/migrate.go
+++ b/pkg/consts/migrate.go
@@ -1,0 +1,19 @@
+package consts
+
+import "strings"
+
+// NormalizeLegacyKind translates old dev.cosignproject.cosign kind annotation
+// values to their dev.hauler equivalents. Returns the input unchanged if it is
+// already a current value or empty.
+//
+// This handles all cases including the dynamic referrer suffix:
+//
+//	dev.cosignproject.cosign/referrers/<sha256hex> → dev.hauler/referrers/<sha256hex>
+func NormalizeLegacyKind(kind string) string {
+	const oldPrefix = "dev.cosignproject.cosign"
+	const newPrefix = "dev.hauler"
+	if strings.HasPrefix(kind, oldPrefix) {
+		return newPrefix + kind[len(oldPrefix):]
+	}
+	return kind
+}

--- a/pkg/consts/migrate_test.go
+++ b/pkg/consts/migrate_test.go
@@ -1,0 +1,30 @@
+package consts
+
+import "testing"
+
+func TestNormalizeLegacyKind(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		// Old dev.cosignproject.cosign values → new dev.hauler equivalents
+		{"dev.cosignproject.cosign/image", "dev.hauler/image"},
+		{"dev.cosignproject.cosign/imageIndex", "dev.hauler/imageIndex"},
+		{"dev.cosignproject.cosign/sigs", "dev.hauler/sigs"},
+		{"dev.cosignproject.cosign/atts", "dev.hauler/atts"},
+		{"dev.cosignproject.cosign/sboms", "dev.hauler/sboms"},
+		{"dev.cosignproject.cosign/referrers/abc123def456", "dev.hauler/referrers/abc123def456"},
+		// Already-new values pass through unchanged
+		{"dev.hauler/image", "dev.hauler/image"},
+		{"dev.hauler/imageIndex", "dev.hauler/imageIndex"},
+		{"dev.hauler/referrers/abc123", "dev.hauler/referrers/abc123"},
+		// Empty string passes through unchanged
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := NormalizeLegacyKind(tt.input)
+		if got != tt.want {
+			t.Errorf("NormalizeLegacyKind(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/pkg/content/oci.go
+++ b/pkg/content/oci.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
 	"sort"
@@ -91,11 +92,20 @@ func (o *OCI) LoadIndex() error {
 			continue
 		}
 
-		// Set default kind if missing
+		// Set default kind if missing; normalize legacy dev.cosignproject.cosign values.
 		kind := desc.Annotations[consts.KindAnnotationName]
+		kind = consts.NormalizeLegacyKind(kind)
 		if kind == "" {
 			kind = consts.KindAnnotationImage
 		}
+
+		// Write the normalized kind back into a copy of the annotations map so
+		// that Walk() callers receive descriptors with dev.hauler/... values.
+		// We copy the map to avoid mutating the slice element's shared map.
+		normalized := make(map[string]string, len(desc.Annotations)+1)
+		maps.Copy(normalized, desc.Annotations)
+		normalized[consts.KindAnnotationName] = kind
+		desc.Annotations = normalized
 
 		if strings.TrimSpace(key.String()) != "--" {
 			switch key.(type) {
@@ -130,7 +140,7 @@ func (o *OCI) SaveIndex() error {
 		kindI := descs[i].Annotations["kind"]
 		kindJ := descs[j].Annotations["kind"]
 
-		// Objects with the prefix of "dev.cosignproject.cosign/image" should be at the top.
+		// Objects with the prefix of KindAnnotationImage should be at the top.
 		if strings.HasPrefix(kindI, consts.KindAnnotationImage) && !strings.HasPrefix(kindJ, consts.KindAnnotationImage) {
 			return true
 		} else if !strings.HasPrefix(kindI, consts.KindAnnotationImage) && strings.HasPrefix(kindJ, consts.KindAnnotationImage) {
@@ -299,11 +309,18 @@ func (p *ociPusher) Push(ctx context.Context, d ocispec.Descriptor) (ccontent.Wr
 			if err := p.oci.LoadIndex(); err != nil {
 				return nil, err
 			}
-			// Use compound key format: "reference-kind"
+			// Use compound key format: "reference-kind"; normalize legacy values.
 			kind := d.Annotations[consts.KindAnnotationName]
+			kind = consts.NormalizeLegacyKind(kind)
 			if kind == "" {
 				kind = consts.KindAnnotationImage
 			}
+			// Copy annotations map to avoid mutating the caller's descriptor,
+			// then write the normalized kind so Walk() callers see dev.hauler/... values.
+			normalizedAnnotations := make(map[string]string, len(d.Annotations)+1)
+			maps.Copy(normalizedAnnotations, d.Annotations)
+			normalizedAnnotations[consts.KindAnnotationName] = kind
+			d.Annotations = normalizedAnnotations
 			key := fmt.Sprintf("%s-%s", p.ref, kind)
 			p.oci.nameMap.Store(key, d)
 			if err := p.oci.SaveIndex(); err != nil {

--- a/pkg/content/oci_test.go
+++ b/pkg/content/oci_test.go
@@ -1,0 +1,281 @@
+package content
+
+// oci_test.go covers the annotation-normalization correctness of LoadIndex()
+// and ociPusher.Push(). Specifically, it verifies that descriptors returned
+// by Walk() carry the normalized dev.hauler/... kind annotation value, not the
+// legacy dev.cosignproject.cosign/... value that may be present on disk.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"hauler.dev/go/hauler/pkg/consts"
+)
+
+// buildMinimalOCILayout writes the smallest valid OCI layout (oci-layout marker
+// + index.json with the supplied descriptors) into dir. No blobs are written;
+// this is sufficient for testing LoadIndex/Walk without a full store.
+func buildMinimalOCILayout(t *testing.T, dir string, manifests []ocispec.Descriptor) {
+	t.Helper()
+
+	// oci-layout marker
+	layoutMarker := map[string]string{"imageLayoutVersion": "1.0.0"}
+	markerData, err := json.Marshal(layoutMarker)
+	if err != nil {
+		t.Fatalf("marshal oci-layout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ocispec.ImageLayoutFile), markerData, 0644); err != nil {
+		t.Fatalf("write oci-layout: %v", err)
+	}
+
+	// index.json
+	idx := ocispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageIndex,
+		Manifests: manifests,
+	}
+	data, err := json.MarshalIndent(idx, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal index.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ocispec.ImageIndexFile), data, 0644); err != nil {
+		t.Fatalf("write index.json: %v", err)
+	}
+}
+
+// fakeDigest returns a syntactically valid digest string that can be used in
+// test descriptors without any real blob.
+func fakeDigest(hex string) digest.Digest {
+	// pad hex to 64 chars
+	for len(hex) < 64 {
+		hex += "0"
+	}
+	return digest.Digest("sha256:" + hex)
+}
+
+// --------------------------------------------------------------------------
+// TestLoadIndex_NormalizesLegacyKindInDescriptorAnnotations
+// --------------------------------------------------------------------------
+
+// TestLoadIndex_NormalizesLegacyKindInDescriptorAnnotations verifies that
+// after LoadIndex() (called implicitly by Walk()), every descriptor returned
+// by Walk carries a normalized dev.hauler/... kind annotation, not the legacy
+// dev.cosignproject.cosign/... value stored on disk.
+func TestLoadIndex_NormalizesLegacyKindInDescriptorAnnotations(t *testing.T) {
+	dir := t.TempDir()
+
+	legacyKinds := []string{
+		"dev.cosignproject.cosign/image",
+		"dev.cosignproject.cosign/imageIndex",
+		"dev.cosignproject.cosign/sigs",
+		"dev.cosignproject.cosign/atts",
+		"dev.cosignproject.cosign/sboms",
+	}
+
+	var manifests []ocispec.Descriptor
+	for i, legacyKind := range legacyKinds {
+		d := ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageManifest,
+			Digest:    fakeDigest(strings.Repeat(string(rune('a'+i)), 1)),
+			Size:      100,
+			Annotations: map[string]string{
+				ocispec.AnnotationRefName: "example.com/repo:tag" + strings.Repeat(string(rune('a'+i)), 1),
+				consts.KindAnnotationName: legacyKind,
+			},
+		}
+		manifests = append(manifests, d)
+	}
+
+	buildMinimalOCILayout(t, dir, manifests)
+
+	o, err := NewOCI(dir)
+	if err != nil {
+		t.Fatalf("NewOCI: %v", err)
+	}
+
+	var walked []ocispec.Descriptor
+	if err := o.Walk(func(_ string, desc ocispec.Descriptor) error {
+		walked = append(walked, desc)
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	if len(walked) == 0 {
+		t.Fatal("Walk returned no descriptors")
+	}
+
+	const legacyPrefix = "dev.cosignproject.cosign"
+	const newPrefix = "dev.hauler"
+	for _, desc := range walked {
+		kind := desc.Annotations[consts.KindAnnotationName]
+		if strings.HasPrefix(kind, legacyPrefix) {
+			t.Errorf("descriptor %s: Walk returned legacy kind %q; want normalized dev.hauler/... value",
+				desc.Digest, kind)
+		}
+		if !strings.HasPrefix(kind, newPrefix) {
+			t.Errorf("descriptor %s: Walk returned unexpected kind %q; want dev.hauler/... prefix",
+				desc.Digest, kind)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestLoadIndex_DoesNotMutateOnDiskAnnotations
+// --------------------------------------------------------------------------
+
+// TestLoadIndex_DoesNotMutateOnDiskAnnotations verifies that the normalization
+// performed by LoadIndex() is in-memory only: the index.json on disk must
+// still carry the original (legacy) annotation values after a Walk() call.
+func TestLoadIndex_DoesNotMutateOnDiskAnnotations(t *testing.T) {
+	dir := t.TempDir()
+
+	legacyKind := "dev.cosignproject.cosign/image"
+	manifests := []ocispec.Descriptor{
+		{
+			MediaType: ocispec.MediaTypeImageManifest,
+			Digest:    fakeDigest("b"),
+			Size:      100,
+			Annotations: map[string]string{
+				ocispec.AnnotationRefName: "example.com/repo:tagb",
+				consts.KindAnnotationName: legacyKind,
+			},
+		},
+	}
+	buildMinimalOCILayout(t, dir, manifests)
+
+	o, err := NewOCI(dir)
+	if err != nil {
+		t.Fatalf("NewOCI: %v", err)
+	}
+	// Trigger LoadIndex via Walk.
+	if err := o.Walk(func(_ string, _ ocispec.Descriptor) error { return nil }); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	// Re-read index.json from disk and verify the annotation is unchanged.
+	data, err := os.ReadFile(filepath.Join(dir, ocispec.ImageIndexFile))
+	if err != nil {
+		t.Fatalf("read index.json: %v", err)
+	}
+	var idx ocispec.Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatalf("unmarshal index.json: %v", err)
+	}
+	for _, desc := range idx.Manifests {
+		got := desc.Annotations[consts.KindAnnotationName]
+		if got != legacyKind {
+			t.Errorf("on-disk kind was mutated: got %q, want %q", got, legacyKind)
+		}
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestPush_NormalizesLegacyKindInStoredDescriptor
+// --------------------------------------------------------------------------
+
+// TestPush_NormalizesLegacyKindInStoredDescriptor verifies that after a Push()
+// that matches the root digest, the descriptor stored in nameMap (and therefore
+// returned by subsequent Walk() calls) carries the normalized dev.hauler/...
+// kind annotation rather than the legacy value.
+func TestPush_NormalizesLegacyKindInStoredDescriptor(t *testing.T) {
+	dir := t.TempDir()
+	buildMinimalOCILayout(t, dir, nil) // start with empty index
+
+	o, err := NewOCI(dir)
+	if err != nil {
+		t.Fatalf("NewOCI: %v", err)
+	}
+
+	// Build a minimal manifest blob so Push() can write it to disk.
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config: ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageConfig,
+			Digest:    fakeDigest("config0"),
+			Size:      2,
+		},
+	}
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	manifestDigest := digest.FromBytes(manifestData)
+
+	// Ensure the blobs directory exists so Push can write.
+	blobsDir := filepath.Join(dir, ocispec.ImageBlobsDir, "sha256")
+	if err := os.MkdirAll(blobsDir, 0755); err != nil {
+		t.Fatalf("mkdir blobs: %v", err)
+	}
+
+	legacyKind := "dev.cosignproject.cosign/sigs"
+	baseRef := "example.com/repo:tagsig"
+
+	pusher, err := o.Pusher(context.Background(), baseRef+"@"+manifestDigest.String())
+	if err != nil {
+		t.Fatalf("Pusher: %v", err)
+	}
+
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    manifestDigest,
+		Size:      int64(len(manifestData)),
+		Annotations: map[string]string{
+			ocispec.AnnotationRefName: baseRef,
+			consts.KindAnnotationName: legacyKind,
+		},
+	}
+
+	w, err := pusher.Push(context.Background(), desc)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if _, err := w.Write(manifestData); err != nil {
+		t.Fatalf("Write manifest: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	// Now Walk and verify the descriptor in nameMap has the normalized kind.
+	// We need a fresh OCI instance so Walk calls LoadIndex (which reads SaveIndex output).
+	o2, err := NewOCI(dir)
+	if err != nil {
+		t.Fatalf("NewOCI second: %v", err)
+	}
+
+	const legacyPrefix = "dev.cosignproject.cosign"
+	const newPrefix = "dev.hauler"
+	var found bool
+	if err := o2.Walk(func(_ string, d ocispec.Descriptor) error {
+		found = true
+		kind := d.Annotations[consts.KindAnnotationName]
+		if strings.HasPrefix(kind, legacyPrefix) {
+			t.Errorf("Push stored descriptor with legacy kind %q; want normalized dev.hauler/... value", kind)
+		}
+		if !strings.HasPrefix(kind, newPrefix) {
+			t.Errorf("Push stored descriptor with unexpected kind %q; want dev.hauler/... prefix", kind)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if !found {
+		t.Fatal("Walk returned no descriptors after Push")
+	}
+
+	// Also verify the caller's original descriptor map was NOT mutated.
+	if desc.Annotations[consts.KindAnnotationName] != legacyKind {
+		t.Errorf("Push mutated caller's descriptor annotations: got %q, want %q",
+			desc.Annotations[consts.KindAnnotationName], legacyKind)
+	}
+}


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Breaking Change

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Within the hauler OCI layout, the index.json uses a `kind` annotation that we inherited from sigstore/cosign.  Now that v2 hauler no longer has cosign as a dependency other than sig verification, using these annotations as is (`dev.cosignproject.cosign/<thing>`) feels a bit wrong.  This PR will adjust the `kind` annotations to be `dev.hauler/<thing>`.

- This also includes a small migration function to handle loading and converting a v1 hauler `haul.tar.zst` into v2 hauler.

- The breaking change is that v2 hauls would not be able to be loaded into v1 hauler.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- normal v2 workflow
```
❯ hauler store add image rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1
2026-03-18 13:55:46 INF adding image [rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1] to the store
2026-03-18 13:56:15 INF successfully added image [rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1]

❯ cat store/index.json | jq .
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:8a41e0bd2d9ddb6d4cc4a4ee4be61509aac263b13668b2a7270f07772586790c",
      "size": 936,
      "annotations": {
        "io.containerd.image.name": "rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1",
        "kind": "dev.hauler/imageIndex",
        "org.opencontainers.image.ref.name": "rancher/rke2/rke2-binary:v1.32.3-rke2r1"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:2a586756073042fd3b2ac94986a796fefbadc7ea10272dd449f4430a31b4fb08",
      "size": 1622,
      "annotations": {
        "io.containerd.image.name": "rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1",
        "kind": "dev.hauler/sigs",
        "org.opencontainers.image.ref.name": "rancher/rke2/rke2-binary:v1.32.3-rke2r1"
      }
    }
  ]
}
```

- v1 haul load into v2 workflow
```
❯ hauler store add image rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1
2026-03-18 14:20:33 INF adding image [rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1] to the store
2026-03-18 14:21:05 INF successfully added image [rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1]

❯ cat store/index.json | jq .
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "size": 936,
      "digest": "sha256:8a41e0bd2d9ddb6d4cc4a4ee4be61509aac263b13668b2a7270f07772586790c",
      "annotations": {
        "io.containerd.image.name": "rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1",
        "kind": "dev.cosignproject.cosign/imageIndex",
        "org.opencontainers.image.ref.name": "rancher/rke2/rke2-binary:v1.32.3-rke2r1"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 1622,
      "digest": "sha256:2a586756073042fd3b2ac94986a796fefbadc7ea10272dd449f4430a31b4fb08",
      "annotations": {
        "io.containerd.image.name": "rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1",
        "kind": "dev.cosignproject.cosign/sigs",
        "org.opencontainers.image.ref.name": "rancher/rke2/rke2-binary:v1.32.3-rke2r1"
      }
    }
  ]
}

❯ hauler store save
2026-03-18 14:22:12 INF saving store [/Users/amartin/projects/hauler/store] to archive [haul.tar.zst]

##### swap to v2 hauler #####

❯ hauler store load 
2026-03-18 14:23:01 INF loading haul [haul.tar.zst] to [/Users/amartin/projects/hauler/store]
2026-03-18 14:23:01 INF unarchiving completed successfully

❯ cat store/index.json | jq .
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.index.v1+json",
      "digest": "sha256:8a41e0bd2d9ddb6d4cc4a4ee4be61509aac263b13668b2a7270f07772586790c",
      "size": 936,
      "annotations": {
        "io.containerd.image.name": "rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1",
        "kind": "dev.hauler/imageIndex",
        "org.opencontainers.image.ref.name": "rancher/rke2/rke2-binary:v1.32.3-rke2r1"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:2a586756073042fd3b2ac94986a796fefbadc7ea10272dd449f4430a31b4fb08",
      "size": 1622,
      "annotations": {
        "io.containerd.image.name": "rgcrprod.azurecr.us/rancher/rke2/rke2-binary:v1.32.3-rke2r1",
        "kind": "dev.hauler/sigs",
        "org.opencontainers.image.ref.name": "rancher/rke2/rke2-binary:v1.32.3-rke2r1"
      }
    }
  ]
}
```


**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- more test code than actual code.  🤓
