### PR TITLE
adjust logging for extracting oci artifacts with cosign bits

### DIFF
--- a/cmd/hauler/cli/store/extract.go
+++ b/cmd/hauler/cli/store/extract.go
@@ -99,6 +99,21 @@ func ExtractCmd(ctx context.Context, o *flags.ExtractOpts, s *store.Layout, ref 
 		if !strings.Contains(reference, repo) {
 			return nil
 		}
+
+		// Cosign sig/att/sbom/referrer descriptors are registry-only metadata —
+		// they are never extractable to disk. Skip them silently at debug level,
+		// mirroring the same guard in copy.go (directory-target path).
+		kind := desc.Annotations[consts.KindAnnotationName]
+		switch kind {
+		case consts.KindAnnotationSigs, consts.KindAnnotationAtts, consts.KindAnnotationSboms:
+			l.Debugf("skipping cosign artifact [%s] for extract", reference)
+			return nil
+		}
+		if strings.HasPrefix(kind, consts.KindAnnotationReferrers) {
+			l.Debugf("skipping OCI referrer [%s] for extract", reference)
+			return nil
+		}
+
 		found = true
 
 		rc, err := s.Fetch(ctx, desc)

--- a/cmd/hauler/cli/store/extract_test.go
+++ b/cmd/hauler/cli/store/extract_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"bytes"
+	"context"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	gvtypes "github.com/google/go-containerregistry/pkg/v1/types"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/rs/zerolog"
 
 	"hauler.dev/go/hauler/internal/flags"
 	v1 "hauler.dev/go/hauler/pkg/apis/hauler.cattle.io/v1"
@@ -546,6 +549,77 @@ func TestExtractCmd_SubstringMatch(t *testing.T) {
 	}
 
 	outPath := filepath.Join(destDir, "extract-sub.txt")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("expected extracted file at %s: %v", outPath, err)
+	}
+	if string(data) != fileContent {
+		t.Errorf("content mismatch: got %q, want %q", string(data), fileContent)
+	}
+}
+
+// newLogCaptureContext returns a context backed by a zerolog logger that writes
+// JSON log lines to buf. Use buf.String() after the call to inspect log output.
+func newLogCaptureContext(buf *bytes.Buffer) context.Context {
+	zl := zerolog.New(buf).With().Timestamp().Logger()
+	return zl.WithContext(context.Background())
+}
+
+func TestExtractCmd_CosignArtifactsProduceNoContainerImageWarning(t *testing.T) {
+	// Regression test: extracting a file ref whose store also contains cosign
+	// sig/att/sbom/referrer descriptors with the same repo prefix must not emit
+	// the "container images cannot be extracted" warning for those cosign descriptors.
+	//
+	// Before the fix, cosign manifests tripped isContainerImageManifest() and caused
+	// a misleading WRN line. The fix is a kind-annotation early-return in the Walk
+	// callback that mirrors the pattern in copy.go:49-58.
+
+	var logBuf bytes.Buffer
+	ctx := newLogCaptureContext(&logBuf)
+	s := newTestStore(t)
+
+	// Seed a real file artifact so ExtractCmd finds something to extract.
+	fileContent := "cosign-filter test file content"
+	url := seedFileInHTTPServer(t, "sigtest.txt", fileContent)
+	if err := storeFile(ctx, s, v1.File{Path: url}); err != nil {
+		t.Fatalf("storeFile: %v", err)
+	}
+
+	// The file is stored under "hauler/sigtest.txt:latest". Inject fake cosign
+	// sig/att/sbom/referrer descriptors sharing the same AnnotationRefName so the
+	// Walk callback's strings.Contains(reference, repo) filter matches them too.
+	baseRef := "hauler/sigtest.txt:latest"
+	for _, kind := range []string{
+		consts.KindAnnotationSigs,
+		consts.KindAnnotationAtts,
+		consts.KindAnnotationSboms,
+		consts.KindAnnotationReferrers + "/sha256" + strings.Repeat("a", 64),
+	} {
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName:     baseRef,
+			consts.KindAnnotationName:     kind,
+			consts.ContainerdImageNameKey: "registry.example.com/" + baseRef,
+		})
+	}
+
+	destDir := t.TempDir()
+	eo := &flags.ExtractOpts{
+		StoreRootOpts:  defaultRootOpts(s.Root),
+		DestinationDir: destDir,
+	}
+
+	if err := ExtractCmd(ctx, eo, s, baseRef); err != nil {
+		t.Fatalf("ExtractCmd: %v", err)
+	}
+
+	// The "container images cannot be extracted" warning must NOT appear for
+	// the cosign descriptors — they must be silently skipped at debug level.
+	if strings.Contains(logBuf.String(), "container images cannot be extracted") {
+		t.Errorf("unexpected warning in log output for cosign descriptors:\n%s", logBuf.String())
+	}
+
+	// The file artifact must still be extracted to the destination directory.
+	outPath := filepath.Join(destDir, "sigtest.txt")
 	data, err := os.ReadFile(outPath)
 	if err != nil {
 		t.Fatalf("expected extracted file at %s: %v", outPath, err)


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->
                                                                                                                                                                                                                                                                                                   
  `hauler store extract` walks every descriptor in the store's index whose reference contains the target repo prefix. Cosign sig/att/sbom/referrer descriptors share that prefix, so they get decoded as manifests and fed into the container-image heuristic (`isContainerImageManifest`), which trips on their config media type and produces:                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                    
```  
WRN skipping [/sigs]: container images cannot be extracted (use hauler store copy to push to a registry)
```
                                                                                                                                                                                                                                                                                                    
  That warning is both **wrong** (the artifact is a signature, not an image) and  **noise** (signatures are registry-only metadata — not extractable by design, and not something the user asked for).                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                                    
  This change adds a `kind`-annotation early-return at the top of the extract walk callback, mirroring the existing pattern in `cmd/hauler/cli/store/copy.go` for directory targets. Sig/att/sbom/referrer descriptors are now skipped silently                                                                                                                                                                                                                     
  (logged at debug level). The `container images cannot be extracted` warning is unchanged and still fires for legitimate container-image refs.                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     
  - `cmd/hauler/cli/store/extract.go` — skip descriptors whose `kind` annotation is`dev.hauler/sigs`, `/atts`, `/sboms`, or has the `dev.hauler/referrers/` prefix, before the container-image heuristic runs.                                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                   

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- Before:
```
$ hauler store extract registry.ranchercarbide.dev/carbide/harvester/harvester-v1.7.1-govt.2-amd64.iso:v1.7.1-govt.2
2026-04-22 10:35:54 WRN skipping [carbide/harvester/harvester-v1.7.1-govt.2-amd64.iso:v1.7.1-govt.2-dev.hauler/sigs]: container images cannot be extracted (use `hauler store copy` to push to a registry)
```

- After:
```
$ hauler store extract registry.ranchercarbide.dev/carbide/harvester/harvester-v1.7.1-govt.2-amd64.iso:v1.7.1-govt.2                                                                                                                                             
2026-04-22 09:48:59 INF extracted [application/vnd.oci.image.manifest.v1+json] from store with digest [sha256:15aea92e9496f54a8f9c068d0796ef0480414f5a1795de0efc46b10d17cbab48]
```

- After (with debug logging):
```
hauler store extract registry.ranchercarbide.dev/carbide/harvester/harvester-v1.7.1-govt.2-amd64.iso:v1.7.1-govt.2 -l debug 
2026-04-22 09:49:30 INF extracted [application/vnd.oci.image.manifest.v1+json] from store with digest [sha256:15aea92e9496f54a8f9c068d0796ef0480414f5a1795de0efc46b10d17cbab48]
2026-04-22 09:49:30 DBG skipping cosign artifact [carbide/harvester/harvester-v1.7.1-govt.2-amd64.iso:v1.7.1-govt.2-dev.hauler/sigs] for extract
```


**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
