### PR TITLE
digest only regression fix

### DIFF
--- a/cmd/hauler/cli/store/lifecycle_test.go
+++ b/cmd/hauler/cli/store/lifecycle_test.go
@@ -241,6 +241,63 @@ func TestLifecycle_Chart_AddSaveLoadExtract(t *testing.T) {
 	}
 }
 
+// TestLifecycle_DigestOnlyImage_AddSaveLoad exercises the full save/load round-trip
+// for an image added by digest only (no tag). Before fix #642, the image disappeared
+// from index.json after LoadCmd because CopyAll appended a double-@ digest.
+func TestLifecycle_DigestOnlyImage_AddSaveLoad(t *testing.T) {
+	ctx := newTestContext(t)
+
+	// Step 1: seed a tagged image so we can get its digest
+	srcHost, srcOpts := newLocalhostRegistry(t)
+	srcImg := seedImage(t, srcHost, "lifecycle/digestonly", "v1", srcOpts...)
+	hash, err := srcImg.Digest()
+	if err != nil {
+		t.Fatalf("srcImg.Digest: %v", err)
+	}
+
+	// Step 2: add BY DIGEST (not tag) into store A
+	storeA := newTestStore(t)
+	rso := defaultRootOpts(storeA.Root)
+	ro := defaultCliOpts()
+	digestRef := srcHost + "/lifecycle/digestonly@" + hash.String()
+	if err := storeImage(ctx, storeA, v1.Image{Name: digestRef}, "", false, rso, ro, ""); err != nil {
+		t.Fatalf("storeImage by digest: %v", err)
+	}
+	// The image should be findable by its digest hex
+	assertArtifactInStore(t, storeA, hash.Hex)
+
+	// Flush index.json for SaveCmd
+	if err := storeA.SaveIndex(); err != nil {
+		t.Fatalf("SaveIndex: %v", err)
+	}
+
+	// Step 3: SaveCmd -> archive
+	archivePath := filepath.Join(t.TempDir(), "lifecycle-digestonly.tar.zst")
+	saveOpts := newSaveOpts(storeA.Root, archivePath)
+	if err := SaveCmd(ctx, saveOpts, defaultRootOpts(storeA.Root), defaultCliOpts()); err != nil {
+		t.Fatalf("SaveCmd: %v", err)
+	}
+
+	// Step 4: LoadCmd -> fresh store B
+	storeBDir := t.TempDir()
+	loadOpts := &flags.LoadOpts{
+		StoreRootOpts: defaultRootOpts(storeBDir),
+		FileName:      []string{archivePath},
+	}
+	if err := LoadCmd(ctx, loadOpts, defaultRootOpts(storeBDir), defaultCliOpts()); err != nil {
+		t.Fatalf("LoadCmd: %v", err)
+	}
+
+	storeB, err := store.NewLayout(storeBDir)
+	if err != nil {
+		t.Fatalf("store.NewLayout(storeB): %v", err)
+	}
+
+	// Regression assertion: the digest-only image must survive the save/load round-trip.
+	// Before fix 1, the image disappears from the loaded store's index.json.
+	assertArtifactInStore(t, storeB, hash.Hex)
+}
+
 // TestLifecycle_Remove_ThenSave verifies that removing one artifact from a store
 // with two file artifacts, then saving/loading, results in only the retained
 // artifact being present.

--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -322,6 +322,20 @@ func (x *exports) record(ctx context.Context, index libv1.ImageIndex, desc libv1
 		slices.Sort(xd.RepoTags)
 		xd.RepoTags = slices.Compact(xd.RepoTags)
 		ref = tag.Digest(digest)
+	case name.Digest:
+		// For digest-only refs, derive a deterministic, docker-valid tag from
+		// the manifest digest so ctr/docker can import the image (#642).
+		// Convention mirrors copy.go:229: "sha256-<hex>".
+		named, err := referencev3.ParseNormalizedNamed(tag.Repository.Name())
+		if err != nil {
+			return err
+		}
+		familiarRepo := referencev3.FamiliarName(named)
+		digestTag := strings.ReplaceAll(digest, ":", "-") // e.g. "sha256-498a..."
+		repotag := familiarRepo + ":" + digestTag
+		xd.RepoTags = append(xd.RepoTags[:], repotag)
+		slices.Sort(xd.RepoTags)
+		xd.RepoTags = slices.Compact(xd.RepoTags)
 	}
 
 	l.Debugf("image [%s]: type=%s, size=%d", ref.Name(), desc.MediaType, desc.Size)

--- a/cmd/hauler/cli/store/save_test.go
+++ b/cmd/hauler/cli/store/save_test.go
@@ -113,6 +113,37 @@ func TestWriteExportsManifest(t *testing.T) {
 	})
 }
 
+func TestWriteExportsManifest_DigestOnlyImageHasRepoTag(t *testing.T) {
+	ctx := newTestContext(t)
+
+	// Seed a tagged image so we can reference it by digest
+	host, srcOpts := newLocalhostRegistry(t)
+	img := seedImage(t, host, "test/digestonly", "v1", srcOpts...)
+	hash, err := img.Digest()
+	if err != nil {
+		t.Fatalf("img.Digest: %v", err)
+	}
+
+	// Add the image BY DIGEST
+	s := newTestStore(t)
+	if err := s.AddImage(ctx, host+"/test/digestonly@"+hash.String(), "", false); err != nil {
+		t.Fatalf("AddImage by digest: %v", err)
+	}
+
+	if err := writeExportsManifest(ctx, s.Root, ""); err != nil {
+		t.Fatalf("writeExportsManifest: %v", err)
+	}
+
+	entries := readManifestJSON(t, s.Root)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 manifest entry, got %d", len(entries))
+	}
+	// Before fix 2, digest-only refs fall through the switch without setting RepoTags.
+	if len(entries[0].RepoTags) == 0 {
+		t.Errorf("expected at least one RepoTag for digest-only image, got none")
+	}
+}
+
 func TestWriteExportsManifest_SkipsNonImages(t *testing.T) {
 	ctx := newTestContext(t)
 

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -753,9 +753,15 @@ func (l *Layout) CopyAll(ctx context.Context, to content.Target, toMapper func(s
 			toRef = tr
 		}
 
-		// Append the digest to help the target pusher identify the root descriptor
-		// Format: "reference@digest" allows the pusher to update its index.json
+		// Append the digest to help the target pusher identify the root descriptor.
+		// AnnotationRefName for digest-only images already ends in "@sha256:...".
+		// Strip any existing digest before appending the authoritative descriptor
+		// digest so the destination pusher can match the root manifest. A double "@"
+		// yields a digest the pusher never matches, leaving the image unindexed (#642).
 		if desc.Digest.Validate() == nil {
+			if at := strings.Index(toRef, "@"); at != -1 {
+				toRef = toRef[:at]
+			}
 			toRef = fmt.Sprintf("%s@%s", toRef, desc.Digest)
 		}
 


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- https://github.com/hauler-dev/hauler/issues/642

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Bugfix

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- The bug: hauler store load rebuilds the destination store via `Layout.CopyAll (pkg/store/store.go:737)`, which unconditionally appends `@<digest>` to the destination ref. For digest-only images, the ref annotation (org.opencontainers.image.ref.name) already ends in `@sha256:`..., so `CopyAll` produces a malformed double-@ ref like `library/busybox@sha256:AAA@sha256:BBB`.

- The destination pusher (`pkg/content/oci.go`) splits on the first `@`, so its "root digest" becomes the garbage `sha256:AAA@sha256:BBB`, which never matches the actual manifest digest — so the manifest's blobs get written but no index.json entry is created. The image vanishes after load. Tagged refs have no `@`, so they round-trip fine.

- Why it's a regression: the `v2.0.0` containerd rewrite (#515) introduced this digest-appending logic; v1 (#250/#259) didn't have it.

- The fix:

    - Core: strip any existing `@digest` in `CopyAll` before appending the authoritative descriptor digest.
    - Containerd compat: populate manifest.json RepoTags for digest-only images (so ctr images import stops skipping them), reusing the existing sha256-<hex> tag convention.
    - Regression test (digest-only sync→save→load round-trip) + a manifest.json RepoTags test.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- Verification (`make fmt`, `make vet clean`; `go test ./pkg/store/... ./cmd/hauler/cli/store/...` -race passes) was confirmed by the implementing agent and the diff matches the approved plan exactly.

- Using the script provided by the issue, the new output is...
```
============================================
SUMMARY
============================================

  Digest-only WITHOUT platform             PASS
  Digest-only WITH platform                PASS
  Tagged reference (control)               PASS

All tests passed. The bug may have been fixed in this version.
```
