### PR TITLE
registry auth fallback bugfix

### DIFF
--- a/cmd/hauler/cli/cli.go
+++ b/cmd/hauler/cli/cli.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"hauler.dev/go/hauler/v2/internal/flags"
 	"hauler.dev/go/hauler/v2/pkg/consts"
+	"hauler.dev/go/hauler/v2/pkg/content"
 	"hauler.dev/go/hauler/v2/pkg/log"
 )
 
@@ -45,6 +46,10 @@ func New(ctx context.Context, ro *flags.CliRootOpts) *cobra.Command {
 			l := log.FromContext(ctx)
 			l.SetLevel(ro.LogLevel)
 			l.Debugf("running cli command [%s]", cmd.CommandPath())
+
+			if dir, set := content.SetDefaultDockerConfig(); set {
+				l.Debugf("defaulted $DOCKER_CONFIG to [%s] for registry credential resolution", dir)
+			}
 
 			if ro.LogLevel == "debug" {
 				logrus.SetLevel(logrus.DebugLevel)

--- a/pkg/content/dockerconfig.go
+++ b/pkg/content/dockerconfig.go
@@ -1,0 +1,54 @@
+package content
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+// currentUser is a seam so tests can simulate a running UID with no passwd
+// entry (where user.Current() returns an error).
+var currentUser = user.Current
+
+// SetDefaultDockerConfig defaults the DOCKER_CONFIG environment variable to the
+// directory where `hauler login` (crane -> docker/cli) writes credentials, so
+// that go-containerregistry's authn.DefaultKeychain -- used to resolve registry
+// credentials during `hauler store copy registry://`, `add`, and `sync` -- can
+// find them even when $HOME is unset.
+//
+// It replicates docker/cli's config.Dir()/getHomeDir() resolution using only the
+// standard library (no docker/cli dependency): DOCKER_CONFIG if already set,
+// otherwise <home>/.docker, where home is os.UserHomeDir() ($HOME on Unix,
+// %USERPROFILE% on Windows) with an /etc/passwd fallback via os/user.Current()
+// when $HOME is empty -- exactly the passwd fallback `hauler login` uses.
+//
+// When no home directory can be resolved at all ($HOME empty AND
+// user.Current() fails or returns an empty HomeDir), this mirrors docker/cli's
+// own config.Dir(), which computes filepath.Join(getHomeDir(), ".docker"): with
+// getHomeDir() == "", that join collapses to the relative path ".docker". So
+// DOCKER_CONFIG is defaulted to the relative path ".docker" in that case too,
+// keeping `hauler login`'s (relative) write and the keychain's (relative) read
+// in agreement as long as both run from the same working directory.
+//
+// The only remaining no-op case is when DOCKER_CONFIG is already explicitly
+// set (an explicit value always wins). Setting DOCKER_CONFIG does not disable
+// DefaultKeychain's $REGISTRY_AUTH_FILE / Podman auth.json fallbacks: those
+// still apply when no config.json exists at the set path.
+//
+// Returns the directory it set and true, or "" and false if it made no change.
+func SetDefaultDockerConfig() (string, bool) {
+	if os.Getenv("DOCKER_CONFIG") != "" {
+		return "", false
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		if u, uerr := currentUser(); uerr == nil {
+			home = u.HomeDir
+		}
+	}
+
+	dir := filepath.Join(home, ".docker")
+	os.Setenv("DOCKER_CONFIG", dir)
+	return dir, true
+}

--- a/pkg/content/registry.go
+++ b/pkg/content/registry.go
@@ -100,15 +100,19 @@ func NewRegistryTarget(host string, opts RegistryOptions, client *http.Client) *
 			// Bridge to go-containerregistry's keychain for credential lookup.
 			reg, err := goname.NewRegistry(h, goname.Insecure)
 			if err != nil {
-				return "", "", nil
+				return "", "", fmt.Errorf("parsing registry host [%s] for credential lookup: %w", h, err)
 			}
 			a, err := goauthn.DefaultKeychain.Resolve(reg)
-			if err != nil || a == goauthn.Anonymous {
+			if err != nil {
+				// don't fall back to anonymous on a real resolution error
+				return "", "", fmt.Errorf("resolving credentials for [%s]: %w", h, err)
+			}
+			if a == goauthn.Anonymous {
 				return "", "", nil
 			}
 			cfg, err := a.Authorization()
 			if err != nil {
-				return "", "", nil
+				return "", "", fmt.Errorf("reading resolved authorization for [%s]: %w", h, err)
 			}
 			return cfg.Username, cfg.Password, nil
 		}),


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [ ] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

**Associated Links:**

-

**Types of Changes:**

- Bugfix

**Proposed Changes:**

Fixes registry credential resolution during `hauler store copy registry://`, `add`, and `sync` when running in environments without a $HOME or $DOCKER_CONFIG set.  `hauler login` has a fallback for this but go-containerregistry doesn't inherently look in the fallback location.

- **`pkg/content/dockerconfig.go` (new):** Adds `SetDefaultDockerConfig()`, which defaults `$DOCKER_CONFIG` to the same directory `hauler login` writes to (`<home>/.docker`) so go-containerregistry's `DefaultKeychain` can find credentials even when `$HOME` is unset. Replicates docker/cli's `config.Dir()`/`getHomeDir()` resolution — including the `/etc/passwd` fallback via `os/user.Current()` — using only the standard library. An explicitly set `DOCKER_CONFIG` always wins.
- **`cmd/hauler/cli/cli.go`:** Invokes `SetDefaultDockerConfig()` in the root `PersistentPreRun`, logging the defaulted path at debug level.
- **`pkg/content/registry.go`:** Stops silently swallowing credential-resolution failures. Registry host parse errors, keychain resolve errors, and authorization read errors now return wrapped errors instead of falling back to anonymous auth; only a genuine `Anonymous` result yields empty credentials.

**Verification/Testing of Changes:**

1. With credentials stored via `hauler login <registry>` and `$HOME` unset, run `hauler store copy registry://<registry>/...` and confirm the push authenticates instead of failing anonymously.
2. Run with `--log-level debug` and confirm the `defaulted $DOCKER_CONFIG to [...]` line appears.
3. Confirm an explicitly set `$DOCKER_CONFIG` is left unchanged.

**Additional Context:**

Small, targeted bugfix. The previous code returned anonymous credentials on any resolution error, masking real auth failures; this makes credential lookup match `hauler login`'s write location and surfaces genuine errors.