### PR TITLE
fix: preserve library/ and docker.io/index.docker.io exactly as typed for Docker Hub images #681

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -176,7 +176,7 @@ func storeLocalImage(ctx context.Context, s *store.Layout, i v1.Image, _ *flags.
 		return err
 	}
 
-	localDigest, err := s.AddLocalImage(ctx, r.Name())
+	localDigest, err := s.AddLocalImage(ctx, i.Name)
 	if err != nil {
 		if ro.IgnoreErrors {
 			l.Warnf("unable to add image [%s] from Docker daemon to store: %v... skipping...", r.Name(), err)
@@ -265,7 +265,7 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 	var imageDigest string
 	err = retry.Operation(ctx, rso, ro, func() error {
 		var addErr error
-		imageDigest, addErr = s.AddImage(ctx, r.Name(), platform, excludeExtras)
+		imageDigest, addErr = s.AddImage(ctx, i.Name, platform, excludeExtras)
 		return addErr
 	})
 	if err != nil {

--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -200,7 +200,7 @@ func storeLocalImage(ctx context.Context, s *store.Layout, i v1.Image, _ *flags.
 		if err != nil {
 			return fmt.Errorf("unable to parse rewrite name [%s]: %w", rewrite, err)
 		}
-		if err := rewriteReference(ctx, s, r, newRef, rawRewrite); err != nil {
+		if err := rewriteReference(ctx, s, r, newRef, rawRewrite, i.Name); err != nil {
 			return err
 		}
 	}
@@ -210,7 +210,7 @@ func storeLocalImage(ctx context.Context, s *store.Layout, i v1.Image, _ *flags.
 			StoreID:   s.StoreID,
 			Store:     s.Root,
 			Type:      "image",
-			Command:   "store add image",
+			Command:   "store add local image",
 			Args:      []string{i.Name},
 			Reference: r.Name(),
 			Digest:    localDigest,
@@ -293,7 +293,7 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 		if err != nil {
 			return fmt.Errorf("unable to parse rewrite name [%s]: %w", rewrite, err)
 		}
-		if err := rewriteReference(ctx, s, r, newRef, rawRewrite); err != nil {
+		if err := rewriteReference(ctx, s, r, newRef, rawRewrite, i.Name); err != nil {
 			return err
 		}
 	}
@@ -340,52 +340,43 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 	return nil
 }
 
-func rewriteReference(ctx context.Context, s *store.Layout, oldRef name.Reference, newRef name.Reference, rawRewrite string) error {
+func rewriteReference(ctx context.Context, s *store.Layout, oldRef name.Reference, newRef name.Reference, rawRewrite string, sourceRef string) error {
 	l := log.FromContext(ctx)
 
 	if err := s.OCI.LoadIndex(); err != nil {
 		return fmt.Errorf("failed to load index: %w", err)
 	}
 
-	//TODO: improve string manipulation
-	oldRefContext := oldRef.Context()
-	newRefContext := newRef.Context()
-	oldRepo := oldRefContext.RepositoryStr()
-	newRepo := newRefContext.RepositoryStr()
+	// Compute the annotation pair that was actually stored by writeImage/writeIndex.
+	// Using the same DockerHubAnnotationRef logic guarantees the lookup keys match,
+	// regardless of whether the user typed "nginx", "library/nginx", "docker.io/nginx", etc.
+	oldAnnotationRef, oldContainerdName := store.DockerHubAnnotationRef(oldRef, sourceRef)
 
-	oldTag := oldRef.Identifier()
-	if tag, ok := oldRef.(name.Tag); ok {
-		oldTag = tag.TagStr()
+	// The registry stored in ContainerdImageNameKey ("docker.io" or "index.docker.io").
+	// When the rewrite string has no explicit registry, we inherit this so that
+	// docker.io sources stay as docker.io after the rewrite.
+	storedRegistry := strings.SplitN(oldContainerdName, "/", 2)[0]
+
+	// Compute the new annotation pair from the rewrite target.
+	// DockerHubAnnotationRef handles library/ stripping based on rawRewrite:
+	//   "nginx"          → strip library/   ; "library/nginx" → keep library/
+	//   "docker.io/nginx"→ use docker.io registry, strip library/
+	newAnnotationRef, newContainerdName := store.DockerHubAnnotationRef(newRef, rawRewrite)
+
+	// If rawRewrite has no explicit registry (bare path or library/-prefixed path),
+	// inherit the source's stored registry instead of defaulting to index.docker.io.
+	if rewriteHasNoRegistry(rawRewrite) {
+		newContainerdName = storedRegistry + "/" + newAnnotationRef
 	}
-	newTag := newRef.Identifier()
-	if tag, ok := newRef.(name.Tag); ok {
-		newTag = tag.TagStr()
-	}
 
-	// ContainerdImageNameKey stores annotationRef.Name() verbatim, which includes the
-	// "index.docker.io" prefix for docker.io images. Do not strip "index." here or the
-	// comparison will never match images stored by writeImage/writeIndex.
-	oldRegistry := oldRefContext.RegistryStr()
-	newRegistry := newRefContext.RegistryStr()
-	// If user omitted a registry in the rewrite string, go-containerregistry defaults to
-	// index.docker.io. Preserve the original registry when the source is non-docker.
-	if newRegistry == "index.docker.io" && !strings.HasPrefix(rawRewrite, "docker.io") && !strings.HasPrefix(rawRewrite, "index.docker.io") {
-		newRegistry = oldRegistry
-		newRepo = strings.TrimPrefix(newRepo, "library/") //if rewrite has library/ prefix in path it is stripped off unless registry specified in rewrite
-	}
-	oldTotal := oldRepo + ":" + oldTag
-	newTotal := newRepo + ":" + newTag
-	oldTotalReg := oldRegistry + "/" + oldTotal
-	newTotalReg := newRegistry + "/" + newTotal
+	l.Infof("rewriting [%s] to [%s]", oldContainerdName, newContainerdName)
 
-	l.Infof("rewriting [%s] to [%s]", oldTotalReg, newTotalReg)
-
-	//find and update reference
 	found := false
 	if err := s.OCI.Walk(func(k string, d ocispec.Descriptor) error {
-		if d.Annotations[ocispec.AnnotationRefName] == oldTotal && d.Annotations[consts.ContainerdImageNameKey] == oldTotalReg {
-			d.Annotations[ocispec.AnnotationRefName] = newTotal
-			d.Annotations[consts.ContainerdImageNameKey] = newTotalReg
+		if d.Annotations[ocispec.AnnotationRefName] == oldAnnotationRef &&
+			d.Annotations[consts.ContainerdImageNameKey] == oldContainerdName {
+			d.Annotations[ocispec.AnnotationRefName] = newAnnotationRef
+			d.Annotations[consts.ContainerdImageNameKey] = newContainerdName
 			found = true
 		}
 		return nil
@@ -398,7 +389,19 @@ func rewriteReference(ctx context.Context, s *store.Layout, oldRef name.Referenc
 	}
 
 	return s.OCI.SaveIndex()
+}
 
+// rewriteHasNoRegistry reports whether rawRewrite is a bare path that does not
+// include an explicit registry host (e.g. "nginx", "library/nginx", "myorg/myimage")
+// as opposed to a fully qualified reference like "docker.io/nginx".
+func rewriteHasNoRegistry(rawRewrite string) bool {
+	slash := strings.Index(rawRewrite, "/")
+	if slash == -1 {
+		return true // bare name
+	}
+	prefix := rawRewrite[:slash]
+	// A registry host contains a dot or a colon (port), or is "localhost".
+	return !strings.ContainsAny(prefix, ".:") && prefix != "localhost"
 }
 
 func AddChartCmd(ctx context.Context, o *flags.AddChartOpts, s *store.Layout, chartName string, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {

--- a/cmd/hauler/cli/store/add_test.go
+++ b/cmd/hauler/cli/store/add_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"net"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -632,6 +633,74 @@ func TestStoreImage_Rewrite(t *testing.T) {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
+}
+
+// dockerHubRedirectTransport rewrites any outgoing request whose host is
+// "index.docker.io" to point at a local stand-in registry, letting tests
+// exercise code paths gated on registry=="index.docker.io" (e.g. Docker Hub
+// library/ normalisation) without making real network calls to Docker Hub.
+type dockerHubRedirectTransport struct {
+	inner  http.RoundTripper
+	toHost string
+}
+
+func (rt *dockerHubRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host == "index.docker.io" {
+		req = req.Clone(req.Context())
+		req.URL.Scheme = "http"
+		req.URL.Host = rt.toHost
+		req.Host = rt.toHost
+	}
+	return rt.inner.RoundTrip(req)
+}
+
+// TestStoreImage_DockerHubReferenceWiring is a regression test for a bug where
+// storeImage called s.AddImage(ctx, r.Name(), ...) using the
+// go-containerregistry-*normalized* reference instead of the raw string the
+// user typed on the CLI. AddImage uses that same string both to parse the
+// reference and (via store.DockerHubAnnotationRef) to decide whether to keep
+// or strip the Docker Hub "library/" prefix -- so passing the normalized form
+// silently defeated library/ preservation for every Docker Hub image add.
+//
+// This exercises storeImage itself (the real production caller), not just the
+// lower-level helper, by temporarily redirecting requests bound for
+// "index.docker.io" to a local stand-in registry via remote.DefaultTransport
+// (the fallback transport go-containerregistry's remote package uses when no
+// per-call remote.Option is supplied, which is exactly storeImage's case).
+func TestStoreImage_DockerHubReferenceWiring(t *testing.T) {
+	ctx := newTestContext(t)
+
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+	srcHost := strings.TrimPrefix(srv.URL, "http://")
+	seedImage(t, srcHost, "library/nginx", "latest", remote.WithTransport(srv.Client().Transport))
+
+	original := remote.DefaultTransport
+	remote.DefaultTransport = &dockerHubRedirectTransport{inner: original, toHost: srcHost}
+	t.Cleanup(func() { remote.DefaultTransport = original })
+
+	tests := []struct {
+		imageName          string
+		wantAnnotationRef  string
+		wantContainerdName string
+	}{
+		{"nginx:latest", "nginx:latest", "index.docker.io/nginx:latest"},
+		{"library/nginx:latest", "library/nginx:latest", "index.docker.io/library/nginx:latest"},
+		{"docker.io/nginx:latest", "nginx:latest", "docker.io/nginx:latest"},
+		{"docker.io/library/nginx:latest", "library/nginx:latest", "docker.io/library/nginx:latest"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.imageName, func(t *testing.T) {
+			s := newTestStore(t)
+			rso := defaultRootOpts(s.Root)
+			ro := defaultCliOpts()
+
+			if err := storeImage(ctx, s, v1.Image{Name: tc.imageName}, "", true, rso, ro, ""); err != nil {
+				t.Fatalf("storeImage(%q): %v", tc.imageName, err)
+			}
+			assertAnnotationsInStore(t, s, tc.wantAnnotationRef, tc.wantContainerdName)
+		})
+	}
 }
 
 func TestStoreImage_MultiArch(t *testing.T) {

--- a/cmd/hauler/cli/store/add_test.go
+++ b/cmd/hauler/cli/store/add_test.go
@@ -252,7 +252,7 @@ func TestRewriteReference(t *testing.T) {
 
 		rawRewrite := newRef.String()
 
-		if err := rewriteReference(ctx, s, oldRef, newRef, rawRewrite); err != nil {
+		if err := rewriteReference(ctx, s, oldRef, newRef, rawRewrite, host+"/src/repo:v1"); err != nil {
 			t.Fatalf("rewriteReference: %v", err)
 		}
 
@@ -265,7 +265,7 @@ func TestRewriteReference(t *testing.T) {
 		newRef, _ := name.NewTag("docker.io/new/repo:v2")
 		rawRewrite := newRef.String()
 
-		err := rewriteReference(ctx, s, oldRef, newRef, rawRewrite)
+		err := rewriteReference(ctx, s, oldRef, newRef, rawRewrite, "docker.io/missing/repo:v1")
 		if err == nil {
 			t.Fatal("expected error, got nil")
 		}
@@ -274,65 +274,170 @@ func TestRewriteReference(t *testing.T) {
 		}
 	})
 
-	// Tests for the registry-preservation / library/-stripping logic (lines 188-191).
-	// go-containerregistry normalises bare single-name Docker Hub refs (e.g. "nginx:latest")
-	// to "index.docker.io/library/nginx:latest". When the rewrite string omits a registry,
-	// rewriteReference must (a) preserve the source registry and (b) strip the injected
-	// "library/" prefix so that the stored ref looks like "nginx:v2", not "library/nginx:v2".
+	// Tests for the registry-preservation / library/-stripping logic.
+	// These cover the full 12-combination matrix: 4 source forms × 3 rewrite forms.
+	// The "sourceRef" passed to rewriteReference must match what the user originally
+	// typed (or what came from a chart annotation), so the lookup keys produced by
+	// DockerHubAnnotationRef match what writeImage actually stored.
 
-	t.Run("path-only rewrite strips library/ prefix from docker hub official image", func(t *testing.T) {
+	// ── Source: nginx:latest (no registry, no library/) ──────────────────────────
+
+	t.Run("nginx:latest / no rewrite", func(t *testing.T) {
+		// verify storage; rewriteReference not called
 		s := newTestStore(t)
 		seedStoreDescriptor(t, s, map[string]string{
-			ocispec.AnnotationRefName:     "library/nginx:latest",
-			consts.ContainerdImageNameKey: "index.docker.io/library/nginx:latest",
+			ocispec.AnnotationRefName:     "nginx:latest",
+			consts.ContainerdImageNameKey: "index.docker.io/nginx:latest",
 		})
+		assertAnnotationsInStore(t, s, "nginx:latest", "index.docker.io/nginx:latest")
+	})
 
-		oldRef, _ := name.NewTag("nginx:latest") // → index.docker.io/library/nginx:latest
-		newRef, _ := name.NewTag("nginx:v2")     // → index.docker.io/library/nginx:v2
-		rawRewrite := "nginx:v2"
-
-		if err := rewriteReference(ctx, s, oldRef, newRef, rawRewrite); err != nil {
+	t.Run("nginx:latest / rewrite library/nginx", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName:     "nginx:latest",
+			consts.ContainerdImageNameKey: "index.docker.io/nginx:latest",
+		})
+		oldRef, _ := name.NewTag("nginx:latest")
+		newRef, _ := name.NewTag("library/nginx:latest")
+		if err := rewriteReference(ctx, s, oldRef, newRef, "library/nginx", "nginx:latest"); err != nil {
 			t.Fatalf("rewriteReference: %v", err)
 		}
-		// library/ must be stripped... registry stays index.docker.io
+		assertAnnotationsInStore(t, s, "library/nginx:latest", "index.docker.io/library/nginx:latest")
+	})
+
+	t.Run("nginx:latest / rewrite nginx", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName:     "nginx:latest",
+			consts.ContainerdImageNameKey: "index.docker.io/nginx:latest",
+		})
+		oldRef, _ := name.NewTag("nginx:latest")
+		newRef, _ := name.NewTag("nginx:v2")
+		if err := rewriteReference(ctx, s, oldRef, newRef, "nginx", "nginx:latest"); err != nil {
+			t.Fatalf("rewriteReference: %v", err)
+		}
 		assertAnnotationsInStore(t, s, "nginx:v2", "index.docker.io/nginx:v2")
 	})
 
-	t.Run("explicit docker.io rewrite preserves library/ prefix", func(t *testing.T) {
+	// ── Source: library/nginx:latest (explicit library/) ─────────────────────────
+
+	t.Run("library/nginx:latest / no rewrite", func(t *testing.T) {
 		s := newTestStore(t)
 		seedStoreDescriptor(t, s, map[string]string{
 			ocispec.AnnotationRefName:     "library/nginx:latest",
 			consts.ContainerdImageNameKey: "index.docker.io/library/nginx:latest",
 		})
-
-		oldRef, _ := name.NewTag("nginx:latest")
-		newRef, _ := name.NewTag("docker.io/nginx:v2") // → index.docker.io/library/nginx:v2
-		rawRewrite := "docker.io/nginx:v2"
-
-		if err := rewriteReference(ctx, s, oldRef, newRef, rawRewrite); err != nil {
-			t.Fatalf("rewriteReference: %v", err)
-		}
-		// rawRewrite starts with "docker.io" → condition must NOT fire → library/ preserved
-		assertAnnotationsInStore(t, s, "library/nginx:v2", "index.docker.io/library/nginx:v2")
+		assertAnnotationsInStore(t, s, "library/nginx:latest", "index.docker.io/library/nginx:latest")
 	})
 
-	t.Run("explicit index.docker.io rewrite preserves library/ prefix", func(t *testing.T) {
+	t.Run("library/nginx:latest / rewrite library/nginx", func(t *testing.T) {
 		s := newTestStore(t)
 		seedStoreDescriptor(t, s, map[string]string{
 			ocispec.AnnotationRefName:     "library/nginx:latest",
 			consts.ContainerdImageNameKey: "index.docker.io/library/nginx:latest",
 		})
-
-		oldRef, _ := name.NewTag("nginx:latest")
-		newRef, _ := name.NewTag("index.docker.io/nginx:v2") // → index.docker.io/library/nginx:v2
-		rawRewrite := "index.docker.io/nginx:v2"
-
-		if err := rewriteReference(ctx, s, oldRef, newRef, rawRewrite); err != nil {
+		oldRef, _ := name.NewTag("library/nginx:latest")
+		newRef, _ := name.NewTag("library/nginx:v2")
+		if err := rewriteReference(ctx, s, oldRef, newRef, "library/nginx", "library/nginx:latest"); err != nil {
 			t.Fatalf("rewriteReference: %v", err)
 		}
-		// rawRewrite starts with "index.docker.io" → condition must NOT fire → library/ preserved
 		assertAnnotationsInStore(t, s, "library/nginx:v2", "index.docker.io/library/nginx:v2")
 	})
+
+	t.Run("library/nginx:latest / rewrite nginx", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName:     "library/nginx:latest",
+			consts.ContainerdImageNameKey: "index.docker.io/library/nginx:latest",
+		})
+		oldRef, _ := name.NewTag("library/nginx:latest")
+		newRef, _ := name.NewTag("nginx:v2")
+		if err := rewriteReference(ctx, s, oldRef, newRef, "nginx", "library/nginx:latest"); err != nil {
+			t.Fatalf("rewriteReference: %v", err)
+		}
+		assertAnnotationsInStore(t, s, "nginx:v2", "index.docker.io/nginx:v2")
+	})
+
+	// ── Source: docker.io/nginx:latest (explicit docker.io, no library/) ─────────
+
+	t.Run("docker.io/nginx:latest / no rewrite", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName:     "nginx:latest",
+			consts.ContainerdImageNameKey: "docker.io/nginx:latest",
+		})
+		assertAnnotationsInStore(t, s, "nginx:latest", "docker.io/nginx:latest")
+	})
+
+	t.Run("docker.io/nginx:latest / rewrite library/nginx", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName:     "nginx:latest",
+			consts.ContainerdImageNameKey: "docker.io/nginx:latest",
+		})
+		oldRef, _ := name.NewTag("docker.io/nginx:latest")
+		newRef, _ := name.NewTag("library/nginx:latest")
+		if err := rewriteReference(ctx, s, oldRef, newRef, "library/nginx", "docker.io/nginx:latest"); err != nil {
+			t.Fatalf("rewriteReference: %v", err)
+		}
+		assertAnnotationsInStore(t, s, "library/nginx:latest", "docker.io/library/nginx:latest")
+	})
+
+	t.Run("docker.io/nginx:latest / rewrite nginx", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName:     "nginx:latest",
+			consts.ContainerdImageNameKey: "docker.io/nginx:latest",
+		})
+		oldRef, _ := name.NewTag("docker.io/nginx:latest")
+		newRef, _ := name.NewTag("nginx:v2")
+		if err := rewriteReference(ctx, s, oldRef, newRef, "nginx", "docker.io/nginx:latest"); err != nil {
+			t.Fatalf("rewriteReference: %v", err)
+		}
+		assertAnnotationsInStore(t, s, "nginx:v2", "docker.io/nginx:v2")
+	})
+
+	// ── Source: docker.io/library/nginx:latest (explicit docker.io + library/) ───
+
+	t.Run("docker.io/library/nginx:latest / no rewrite", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName:     "library/nginx:latest",
+			consts.ContainerdImageNameKey: "docker.io/library/nginx:latest",
+		})
+		assertAnnotationsInStore(t, s, "library/nginx:latest", "docker.io/library/nginx:latest")
+	})
+
+	t.Run("docker.io/library/nginx:latest / rewrite library/nginx", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName:     "library/nginx:latest",
+			consts.ContainerdImageNameKey: "docker.io/library/nginx:latest",
+		})
+		oldRef, _ := name.NewTag("docker.io/library/nginx:latest")
+		newRef, _ := name.NewTag("library/nginx:v2")
+		if err := rewriteReference(ctx, s, oldRef, newRef, "library/nginx", "docker.io/library/nginx:latest"); err != nil {
+			t.Fatalf("rewriteReference: %v", err)
+		}
+		assertAnnotationsInStore(t, s, "library/nginx:v2", "docker.io/library/nginx:v2")
+	})
+
+	t.Run("docker.io/library/nginx:latest / rewrite nginx", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName:     "library/nginx:latest",
+			consts.ContainerdImageNameKey: "docker.io/library/nginx:latest",
+		})
+		oldRef, _ := name.NewTag("docker.io/library/nginx:latest")
+		newRef, _ := name.NewTag("nginx:v2")
+		if err := rewriteReference(ctx, s, oldRef, newRef, "nginx", "docker.io/library/nginx:latest"); err != nil {
+			t.Fatalf("rewriteReference: %v", err)
+		}
+		assertAnnotationsInStore(t, s, "nginx:v2", "docker.io/nginx:v2")
+	})
+
+	// ── Non-Docker Hub: path-only rewrite inherits source registry ────────────────
 
 	t.Run("non-docker source with path-only rewrite preserves original registry", func(t *testing.T) {
 		host, rOpts := newTestRegistry(t)
@@ -344,13 +449,10 @@ func TestRewriteReference(t *testing.T) {
 		}
 
 		oldRef, _ := name.NewTag(host+"/src/repo:v1", name.Insecure)
-		newRef, _ := name.NewTag("newrepo/img:v2") // defaults to index.docker.io
-		rawRewrite := "newrepo/img:v2"
-
-		if err := rewriteReference(ctx, s, oldRef, newRef, rawRewrite); err != nil {
+		newRef, _ := name.NewTag("newrepo/img:v2")
+		if err := rewriteReference(ctx, s, oldRef, newRef, "newrepo/img:v2", host+"/src/repo:v1"); err != nil {
 			t.Fatalf("rewriteReference: %v", err)
 		}
-		// condition fires → registry reverts to host, no library/ to strip
 		assertAnnotationsInStore(t, s, "newrepo/img:v2", host+"/newrepo/img:v2")
 	})
 }

--- a/cmd/hauler/cli/store/copy_test.go
+++ b/cmd/hauler/cli/store/copy_test.go
@@ -295,6 +295,61 @@ func TestCopyCmd_Registry_InvalidFilenameSkipTest(t *testing.T) {
 // Directory copy tests
 // --------------------------------------------------------------------------
 
+// TestCopyCmd_Registry_RewriteStripsLibraryPrefix proves that when --rewrite
+// strips the Docker Hub "library/" prefix, store copy pushes the image to the
+// rewritten path (dstHost/myimg:v1) and NOT to the path with library/ re-added
+// (dstHost/library/myimg:v1).
+//
+// This is a regression test for the round-trip bug: rewriteReference correctly
+// updates AnnotationRefName to "myimg:v1" (library/ stripped), but
+// RewriteRefToRegistry re-adds library/ by parsing through go-containerregistry,
+// which normalises bare Docker Hub names.
+func TestCopyCmd_Registry_RewriteStripsLibraryPrefix(t *testing.T) {
+	ctx := newTestContext(t)
+
+	// Seed the image under a "library/"-style path to simulate a Docker Hub
+	// official image stored under its normalised repository name.
+	srcHost, srcOpts := newTestRegistry(t)
+	seedImage(t, srcHost, "library/myimg", "v1", srcOpts...)
+
+	s := newTestStore(t)
+	rso := defaultRootOpts(s.Root)
+	ro := defaultCliOpts()
+
+	// Store with --rewrite myimg, which should strip the library/ prefix so
+	// that copies land at targetRegistry/myimg:v1, not targetRegistry/library/myimg:v1.
+	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/library/myimg:v1"}, "", false, rso, ro, "myimg"); err != nil {
+		t.Fatalf("storeImage with rewrite: %v", err)
+	}
+
+	dstHost, dstOpts := newTestRegistry(t)
+	o := &flags.CopyOpts{
+		StoreRootOpts: defaultRootOpts(s.Root),
+		PlainHTTP:     true,
+	}
+	if err := CopyCmd(ctx, o, s, "registry://"+dstHost, ro); err != nil {
+		t.Fatalf("CopyCmd: %v", err)
+	}
+
+	// The image must be reachable at dstHost/myimg:v1 (library/ stripped).
+	wantRef, err := name.NewTag(dstHost+"/myimg:v1", name.Insecure)
+	if err != nil {
+		t.Fatalf("name.NewTag dstHost/myimg:v1: %v", err)
+	}
+	if _, err := remote.Get(wantRef, dstOpts...); err != nil {
+		t.Errorf("image not found at rewritten path %s after --rewrite myimg (library/ was re-added by RewriteRefToRegistry): %v", wantRef, err)
+	}
+
+	// And must NOT be at the library/ path.
+	badRef, err := name.NewTag(dstHost+"/library/myimg:v1", name.Insecure)
+	if err != nil {
+		t.Fatalf("name.NewTag dstHost/library/myimg:v1: %v", err)
+	}
+	if _, err := remote.Get(badRef, dstOpts...); err == nil {
+		t.Error("image should NOT be pushed to library/myimg:v1 after --rewrite myimg, but was found there")
+	}
+}
+
 // TestCopyCmd_Dir_Files copies a file artifact to a directory target and
 // verifies the file appears under its original basename.
 func TestCopyCmd_Dir_Files(t *testing.T) {

--- a/cmd/hauler/cli/store/info.go
+++ b/cmd/hauler/cli/store/info.go
@@ -319,11 +319,22 @@ func newItem(s *store.Layout, desc ocispec.Descriptor, m ocispec.Manifest, plat 
 
 	refName := desc.Annotations["io.containerd.image.name"]
 	if refName == "" {
-		refName = desc.Annotations[ocispec.AnnotationRefName]
-	}
-	ref, err := reference.Parse(refName)
-	if err != nil {
-		return item{}
+		// Fall back to AnnotationRefName. It lacks a registry prefix, so pass it
+		// through reference.Parse to add the default registry for display.
+		rannotation := desc.Annotations[ocispec.AnnotationRefName]
+		ref, err := reference.Parse(rannotation)
+		if err != nil {
+			return item{}
+		}
+		refName = ref.Name()
+	} else {
+		// ContainerdImageNameKey already contains the full reference with registry.
+		// Use it verbatim: passing it through reference.Parse would re-add "library/"
+		// for bare Docker Hub paths (e.g. "index.docker.io/busybox" normalises to
+		// "index.docker.io/library/busybox"), silently undoing a --rewrite strip.
+		if _, err := reference.Parse(refName); err != nil {
+			return item{}
+		}
 	}
 
 	if o.TypeFilter != "all" && ctype != o.TypeFilter {
@@ -331,7 +342,7 @@ func newItem(s *store.Layout, desc ocispec.Descriptor, m ocispec.Manifest, plat 
 	}
 
 	return item{
-		Reference: ref.Name(),
+		Reference: refName,
 		Type:      ctype,
 		Platform:  plat,
 		Digest:    desc.Digest.String(),

--- a/cmd/hauler/cli/store/info_test.go
+++ b/cmd/hauler/cli/store/info_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 	"os"
+	"strings"
 	"testing"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -11,6 +12,37 @@ import (
 	v1 "hauler.dev/go/hauler/v2/pkg/apis/hauler.cattle.io/v1"
 	"hauler.dev/go/hauler/v2/pkg/consts"
 )
+
+// TestNewItem_LibraryPrefixRoundTrip proves that store info re-adds "library/"
+// to single-component Docker Hub image names that were correctly stripped by
+// rewriteReference.  This reproduces the round-trip bug where
+// "hauler store add image busybox --rewrite busybox" is logged as
+// "rewriting to index.docker.io/busybox:latest" but store info still displays
+// "index.docker.io/library/busybox:latest".
+//
+// rewriteReference sets ContainerdImageNameKey = "index.docker.io/busybox:latest".
+// newItem passes that value through reference.Parse, which uses
+// go-containerregistry and re-normalises the single-component Docker Hub path
+// back to library/busybox — making the rewrite a display no-op.
+func TestNewItem_LibraryPrefixRoundTrip(t *testing.T) {
+	// Post-rewrite annotations: rewriteReference has already stripped library/.
+	desc := ocispec.Descriptor{
+		Annotations: map[string]string{
+			ocispec.AnnotationRefName:     "busybox:latest",
+			consts.ContainerdImageNameKey: "index.docker.io/busybox:latest",
+			consts.KindAnnotationName:     consts.KindAnnotationImage,
+		},
+	}
+	o := &flags.InfoOpts{TypeFilter: "all"}
+	i := newItem(nil, desc, ocispec.Manifest{Config: ocispec.Descriptor{MediaType: consts.DockerConfigJSON}}, "linux/amd64", o)
+
+	// The displayed reference must NOT contain "library/" — the whole point of
+	// --rewrite busybox is to strip that prefix so copies land at
+	// targetRegistry/busybox:latest, not targetRegistry/library/busybox:latest.
+	if strings.Contains(i.Reference, "library/") {
+		t.Errorf("store info re-added library/ after --rewrite: got %q, want a reference without library/", i.Reference)
+	}
+}
 
 func TestByteCountSI(t *testing.T) {
 	tests := []struct {

--- a/pkg/content/registry.go
+++ b/pkg/content/registry.go
@@ -163,19 +163,23 @@ func (t *RegistryTarget) Pusher(ctx context.Context, ref string) (remotes.Pusher
 // RewriteRefToRegistry rewrites sourceRef to use targetRegistry as its host, preserving the
 // repository path and tag or digest. For example:
 //
-//	"index.docker.io/library/nginx:latest" + "localhost:5000" → "localhost:5000/library/nginx:latest"
+//	"library/nginx:latest" + "localhost:5000" → "localhost:5000/library/nginx:latest"
+//	"busybox:latest"       + "localhost:5000" → "localhost:5000/busybox:latest"
+//
+// sourceRef is an AnnotationRefName value: always registry-free (the registry has
+// been stripped by writeImage). It is parsed as a raw string rather than through
+// goname.ParseReference, which would re-add "library/" for bare Docker Hub names
+// (e.g. "busybox" → "index.docker.io/library/busybox"), silently undoing any
+// library/ strip that rewriteReference performed.
 func RewriteRefToRegistry(sourceRef string, targetRegistry string) (string, error) {
-	ref, err := goname.ParseReference(sourceRef)
-	if err != nil {
-		return "", fmt.Errorf("parsing reference %q: %w", sourceRef, err)
+	if at := strings.LastIndex(sourceRef, "@"); at != -1 {
+		// digest ref: "[repo/]name@algo:hex"
+		return fmt.Sprintf("%s/%s@%s", targetRegistry, sourceRef[:at], sourceRef[at+1:]), nil
 	}
-	repo := strings.TrimPrefix(ref.Context().RepositoryStr(), "/")
-	switch r := ref.(type) {
-	case goname.Tag:
-		return fmt.Sprintf("%s/%s:%s", targetRegistry, repo, r.TagStr()), nil
-	case goname.Digest:
-		return fmt.Sprintf("%s/%s@%s", targetRegistry, repo, r.DigestStr()), nil
-	default:
-		return fmt.Sprintf("%s/%s:latest", targetRegistry, repo), nil
+	if colon := strings.LastIndex(sourceRef, ":"); colon != -1 {
+		// tag ref: "[repo/]name:tag"
+		return fmt.Sprintf("%s/%s:%s", targetRegistry, sourceRef[:colon], sourceRef[colon+1:]), nil
 	}
+	// no tag or digest separator — default to :latest
+	return fmt.Sprintf("%s/%s:latest", targetRegistry, sourceRef), nil
 }

--- a/pkg/store/export_test.go
+++ b/pkg/store/export_test.go
@@ -1,0 +1,3 @@
+package store
+
+// DockerHubAnnotationRef is now exported directly from store.go; nothing to re-export here.

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -233,7 +233,7 @@ func (l *Layout) AddImage(ctx context.Context, ref string, platform string, excl
 		if err != nil {
 			return "", fmt.Errorf("getting index digest for %q: %w", ref, err)
 		}
-		if err := l.writeIndex(parsedRef, idx, consts.KindAnnotationIndex); err != nil {
+		if err := l.writeIndex(parsedRef, idx, consts.KindAnnotationIndex, ref); err != nil {
 			return "", err
 		}
 	} else {
@@ -254,7 +254,7 @@ func (l *Layout) AddImage(ctx context.Context, ref string, platform string, excl
 		if err != nil {
 			return "", fmt.Errorf("getting image digest for %q: %w", ref, err)
 		}
-		if err := l.writeImage(parsedRef, img, consts.KindAnnotationImage, ""); err != nil {
+		if err := l.writeImage(parsedRef, img, consts.KindAnnotationImage, "", ref); err != nil {
 			return "", err
 		}
 	}
@@ -291,7 +291,7 @@ func (l *Layout) AddLocalImage(ctx context.Context, ref string) (string, error) 
 		return "", fmt.Errorf("getting image digest for %q: %w", ref, err)
 	}
 
-	if err := l.writeImage(parsedRef, img, consts.KindAnnotationImage, ""); err != nil {
+	if err := l.writeImage(parsedRef, img, consts.KindAnnotationImage, "", ref); err != nil {
 		return "", err
 	}
 	return d.String(), nil
@@ -357,7 +357,65 @@ func (l *Layout) writeImageBlobs(img v1.Image) error {
 // writeImage writes all blobs for img and adds a descriptor entry to the OCI index with the
 // given annotationRef and kind. containerdName overrides the io.containerd.image.name annotation;
 // if empty it defaults to annotationRef.Name().
-func (l *Layout) writeImage(annotationRef gname.Reference, img v1.Image, kind string, containerdName string) error {
+// dockerHubAnnotationRef returns the (annotationRefName, containerdName) pair to
+// store in AnnotationRefName and ContainerdImageNameKey.
+//
+// originalRef is the reference string as typed by the user (or as read from a
+// chart annotation). It is used to decide whether to strip the Docker Hub
+// "library/" namespace and which registry string to record:
+//
+//   - "nginx:latest"                           → "nginx:latest",        "index.docker.io/nginx:latest"
+//   - "library/nginx:latest"                   → "library/nginx:latest", "index.docker.io/library/nginx:latest"
+//   - "docker.io/nginx:latest"                 → "nginx:latest",        "docker.io/nginx:latest"
+//   - "docker.io/library/nginx:latest"         → "library/nginx:latest", "docker.io/library/nginx:latest"
+//   - "index.docker.io/library/nginx:latest"   → "library/nginx:latest", "index.docker.io/library/nginx:latest"
+//
+// Pass originalRef="" for internally derived refs (cosign sig/att/sbom, OCI
+// referrers), which inherit the strip-library behaviour used for bare names.
+func DockerHubAnnotationRef(ref gname.Reference, originalRef string) (annotationRefName, containerdName string) {
+	registry := ref.Context().RegistryStr()
+	full := ref.Name()
+	withoutReg := strings.TrimPrefix(full, registry+"/")
+
+	if registry != "index.docker.io" {
+		// Non-Docker Hub registry: no library/ normalisation to undo.
+		return withoutReg, full
+	}
+
+	// Determine whether the caller explicitly wrote "library/".
+	// If the original string is empty (derived ref) or does not contain "library/",
+	// strip it so the stored name matches what the user actually typed.
+	keepLibrary := originalRef != "" && strings.Contains(originalRef, "library/")
+	if !keepLibrary {
+		withoutReg = strings.TrimPrefix(withoutReg, "library/")
+	}
+
+	// Preserve the registry token as the user typed it ("docker.io" vs "index.docker.io").
+	displayRegistry := registry
+	if r := originalDockerRegistry(originalRef); r != "" {
+		displayRegistry = r
+	}
+
+	return withoutReg, displayRegistry + "/" + withoutReg
+}
+
+// originalDockerRegistry returns the registry token the user wrote at the start
+// of originalRef (e.g. "docker.io" or "index.docker.io"), or "" if the string
+// begins with a path component (bare name or explicit "library/...").
+func originalDockerRegistry(originalRef string) string {
+	slash := strings.Index(originalRef, "/")
+	if slash == -1 {
+		return "" // bare name, no registry prefix
+	}
+	prefix := originalRef[:slash]
+	// A registry host contains a dot or a colon (port), or is "localhost".
+	if strings.ContainsAny(prefix, ".:") || prefix == "localhost" {
+		return prefix
+	}
+	return "" // first segment is a path component, not a registry
+}
+
+func (l *Layout) writeImage(annotationRef gname.Reference, img v1.Image, kind string, containerdName string, originalRef string) error {
 	if err := l.writeImageBlobs(img); err != nil {
 		return err
 	}
@@ -380,15 +438,16 @@ func (l *Layout) writeImage(annotationRef gname.Reference, img v1.Image, kind st
 	}
 
 	if containerdName == "" {
-		containerdName = annotationRef.Name()
+		_, containerdName = DockerHubAnnotationRef(annotationRef, originalRef)
 	}
+	annotationRefName, _ := DockerHubAnnotationRef(annotationRef, originalRef)
 	desc := ocispec.Descriptor{
 		MediaType: string(mt),
 		Digest:    d,
 		Size:      int64(len(raw)),
 		Annotations: map[string]string{
 			consts.KindAnnotationName:     kind,
-			ocispec.AnnotationRefName:     strings.TrimPrefix(annotationRef.Name(), annotationRef.Context().RegistryStr()+"/"),
+			ocispec.AnnotationRefName:     annotationRefName,
 			consts.ContainerdImageNameKey: containerdName,
 		},
 	}
@@ -431,7 +490,7 @@ func (l *Layout) writeIndexBlobs(idx v1.ImageIndex) error {
 
 // writeIndex writes all blobs for an image index (including all child platform images) and adds
 // a descriptor entry to the OCI index with the given annotationRef and kind.
-func (l *Layout) writeIndex(annotationRef gname.Reference, idx v1.ImageIndex, kind string) error {
+func (l *Layout) writeIndex(annotationRef gname.Reference, idx v1.ImageIndex, kind string, originalRef string) error {
 	if err := l.writeIndexBlobs(idx); err != nil {
 		return err
 	}
@@ -457,14 +516,15 @@ func (l *Layout) writeIndex(annotationRef gname.Reference, idx v1.ImageIndex, ki
 		return fmt.Errorf("parsing index digest: %w", err)
 	}
 
+	annotationRefName, containerdName := DockerHubAnnotationRef(annotationRef, originalRef)
 	desc := ocispec.Descriptor{
 		MediaType: string(mt),
 		Digest:    d,
 		Size:      int64(len(raw)),
 		Annotations: map[string]string{
 			consts.KindAnnotationName:     kind,
-			ocispec.AnnotationRefName:     strings.TrimPrefix(annotationRef.Name(), annotationRef.Context().RegistryStr()+"/"),
-			consts.ContainerdImageNameKey: annotationRef.Name(),
+			ocispec.AnnotationRefName:     annotationRefName,
+			consts.ContainerdImageNameKey: containerdName,
 		},
 	}
 	return l.OCI.AddIndex(desc)
@@ -521,8 +581,7 @@ func (l *Layout) saveReferrers(ctx context.Context, ref gname.Reference, hash v1
 		// Embed the referrer manifest digest in the kind annotation so that multiple
 		// referrers for the same base image each get a unique entry in the OCI index.
 		kind := consts.KindAnnotationReferrers + "/" + referrerDesc.Digest.Hex
-		if err := l.writeImage(ref, img, kind, ""); err != nil {
-			return fmt.Errorf("saving OCI referrer %s for %s: %w", referrerDesc.Digest, ref.Name(), err)
+		if err := l.writeImage(ref, img, kind, "", ""); err != nil {
 		}
 		log.Debug().Msgf("saved OCI referrer %s (%s) for %s", referrerDesc.Digest, string(referrerDesc.ArtifactType), ref.Name())
 	}
@@ -558,7 +617,7 @@ func (l *Layout) saveRelatedArtifacts(ctx context.Context, ref gname.Reference, 
 			// Artifact doesn't exist at this registry; skip silently.
 			continue
 		}
-		if err := l.writeImage(ref, img, r.kind, ""); err != nil {
+		if err := l.writeImage(ref, img, r.kind, "", ""); err != nil {
 			return saved, fmt.Errorf("saving %s for %s: %w", r.kind, ref.Name(), err)
 		}
 		if d, err := img.Digest(); err == nil {

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -691,6 +691,123 @@ func TestCopy_MultiPlatform(t *testing.T) {
 //     registers it in the referrers index automatically
 //  4. Calls store.AddImage and then walks the OCI layout to confirm that a
 //     KindAnnotationReferrers-prefixed entry was saved
+//
+// TestAddImage_DockerHubLibraryNormalisation verifies the four reference forms
+// a user might type for an official Docker Hub image and asserts that the
+// stored AnnotationRefName and ContainerdImageNameKey match what the user wrote,
+// without unwanted library/ injection or registry canonicalisation.
+//
+//   - "nginx:latest"                         → "nginx:latest"        / "index.docker.io/nginx:latest"
+//   - "library/nginx:latest"                 → "library/nginx:latest"/ "index.docker.io/library/nginx:latest"
+//   - "docker.io/nginx:latest"               → "nginx:latest"        / "docker.io/nginx:latest"
+//   - "docker.io/library/nginx:latest"       → "library/nginx:latest"/ "docker.io/library/nginx:latest"
+//   - "index.docker.io/library/nginx:latest" → "library/nginx:latest"/ "index.docker.io/library/nginx:latest"
+func TestAddImage_DockerHubLibraryNormalisation(t *testing.T) {
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+	srcHost := strings.TrimPrefix(srv.URL, "http://")
+	rOpts := []remote.Option{remote.WithTransport(srv.Client().Transport)}
+
+	// Push one real image to the test registry under "library/nginx:latest"
+	// so all five aliases can pull the same manifest.
+	img, err := random.Image(64, 1)
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	baseRef, err := gname.NewTag(srcHost+"/library/nginx:latest", gname.Insecure)
+	if err != nil {
+		t.Fatalf("NewTag: %v", err)
+	}
+	if err := remote.Write(baseRef, img, rOpts...); err != nil {
+		t.Fatalf("remote.Write: %v", err)
+	}
+	// Also reachable without library/ (the test registry treats both paths as equivalent).
+	nolibRef, err := gname.NewTag(srcHost+"/nginx:latest", gname.Insecure)
+	if err != nil {
+		t.Fatalf("NewTag: %v", err)
+	}
+	if err := remote.Write(nolibRef, img, rOpts...); err != nil {
+		t.Fatalf("remote.Write: %v", err)
+	}
+
+	tests := []struct {
+		inputRef           string
+		wantAnnotationRef  string
+		wantContainerdName string
+	}{
+		{
+			inputRef:           srcHost + "/nginx:latest",
+			wantAnnotationRef:  "nginx:latest",
+			wantContainerdName: srcHost + "/nginx:latest",
+		},
+		{
+			inputRef:           srcHost + "/library/nginx:latest",
+			wantAnnotationRef:  "library/nginx:latest",
+			wantContainerdName: srcHost + "/library/nginx:latest",
+		},
+	}
+
+	// The two "explicit docker.io" cases only make sense against the real Docker Hub
+	// (we cannot redirect "docker.io/..." to our local server), so we simulate them
+	// with a stand-in local registry that mimics the docker.io→index.docker.io
+	// normalisation by checking the annotation values produced by dockerHubAnnotationRef.
+	// We test those via the unit table below, which exercises the helper directly.
+	dockerHubCases := []struct {
+		inputRef           string
+		wantAnnotationRef  string
+		wantContainerdName string
+	}{
+		{"nginx:latest", "nginx:latest", "index.docker.io/nginx:latest"},
+		{"library/nginx:latest", "library/nginx:latest", "index.docker.io/library/nginx:latest"},
+		{"docker.io/nginx:latest", "nginx:latest", "docker.io/nginx:latest"},
+		{"docker.io/library/nginx:latest", "library/nginx:latest", "docker.io/library/nginx:latest"},
+		{"index.docker.io/library/nginx:latest", "library/nginx:latest", "index.docker.io/library/nginx:latest"},
+	}
+	for _, tc := range dockerHubCases {
+		t.Run("annotation_pair/"+tc.inputRef, func(t *testing.T) {
+			ref, err := gname.ParseReference(tc.inputRef)
+			if err != nil {
+				t.Fatalf("ParseReference: %v", err)
+			}
+			gotAnnotation, gotContainerd := store.DockerHubAnnotationRef(ref, tc.inputRef)
+			if gotAnnotation != tc.wantAnnotationRef {
+				t.Errorf("AnnotationRefName = %q, want %q", gotAnnotation, tc.wantAnnotationRef)
+			}
+			if gotContainerd != tc.wantContainerdName {
+				t.Errorf("ContainerdImageNameKey = %q, want %q", gotContainerd, tc.wantContainerdName)
+			}
+		})
+	}
+
+	// Integration: AddImage round-trip through local registry.
+	ctx := context.Background()
+	for _, tc := range tests {
+		t.Run("roundtrip/"+tc.inputRef, func(t *testing.T) {
+			s, err := store.NewLayout(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewLayout: %v", err)
+			}
+			if _, err := s.AddImage(ctx, tc.inputRef, "", true, rOpts...); err != nil {
+				t.Fatalf("AddImage: %v", err)
+			}
+			found := false
+			if err := s.OCI.Walk(func(_ string, desc ocispec.Descriptor) error {
+				ann := desc.Annotations[ocispec.AnnotationRefName]
+				cdn := desc.Annotations[consts.ContainerdImageNameKey]
+				if ann == tc.wantAnnotationRef && cdn == tc.wantContainerdName {
+					found = true
+				}
+				return nil
+			}); err != nil {
+				t.Fatalf("Walk: %v", err)
+			}
+			if !found {
+				t.Errorf("no descriptor with AnnotationRefName=%q ContainerdImageNameKey=%q", tc.wantAnnotationRef, tc.wantContainerdName)
+			}
+		})
+	}
+}
+
 func TestAddImage_OCI11Referrers(t *testing.T) {
 	// 1. Start an in-process OCI 1.1 registry.
 	srv := httptest.NewServer(registry.New())

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -702,6 +703,27 @@ func TestCopy_MultiPlatform(t *testing.T) {
 //   - "docker.io/nginx:latest"               → "nginx:latest"        / "docker.io/nginx:latest"
 //   - "docker.io/library/nginx:latest"       → "library/nginx:latest"/ "docker.io/library/nginx:latest"
 //   - "index.docker.io/library/nginx:latest" → "library/nginx:latest"/ "index.docker.io/library/nginx:latest"
+//
+// dockerHubRedirectTransport rewrites any outgoing request whose host is
+// "index.docker.io" to point at a local stand-in registry, letting tests
+// exercise code paths gated on registry=="index.docker.io" (e.g. Docker Hub
+// library/ normalisation) without making real network calls to Docker Hub.
+type dockerHubRedirectTransport struct {
+	inner    http.RoundTripper
+	toScheme string
+	toHost   string
+}
+
+func (rt *dockerHubRedirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host == "index.docker.io" {
+		req = req.Clone(req.Context())
+		req.URL.Scheme = rt.toScheme
+		req.URL.Host = rt.toHost
+		req.Host = rt.toHost
+	}
+	return rt.inner.RoundTrip(req)
+}
+
 func TestAddImage_DockerHubLibraryNormalisation(t *testing.T) {
 	srv := httptest.NewServer(registry.New())
 	t.Cleanup(srv.Close)
@@ -747,11 +769,17 @@ func TestAddImage_DockerHubLibraryNormalisation(t *testing.T) {
 		},
 	}
 
-	// The two "explicit docker.io" cases only make sense against the real Docker Hub
-	// (we cannot redirect "docker.io/..." to our local server), so we simulate them
-	// with a stand-in local registry that mimics the docker.io→index.docker.io
-	// normalisation by checking the annotation values produced by dockerHubAnnotationRef.
-	// We test those via the unit table below, which exercises the helper directly.
+	// The two "explicit docker.io" forms (and the bare/library forms, which also
+	// resolve to registry "index.docker.io") are additionally exercised end-to-end
+	// through AddImage in the "roundtrip_index_docker_io" sub-tests below, using a
+	// RoundTripper that redirects requests bound for "index.docker.io" to this local
+	// registry. This is what actually caught a real regression: cmd/hauler/cli/store's
+	// storeImage/storeLocalImage originally called s.AddImage(ctx, r.Name(), ...) using
+	// the go-containerregistry-*normalized* reference instead of the raw string the user
+	// typed, which silently defeated the library/ preservation below because AddImage
+	// uses the same string both to parse the reference and as DockerHubAnnotationRef's
+	// originalRef. Any caller of AddImage/AddLocalImage must pass the reference exactly
+	// as the user wrote it.
 	dockerHubCases := []struct {
 		inputRef           string
 		wantAnnotationRef  string
@@ -775,6 +803,58 @@ func TestAddImage_DockerHubLibraryNormalisation(t *testing.T) {
 			}
 			if gotContainerd != tc.wantContainerdName {
 				t.Errorf("ContainerdImageNameKey = %q, want %q", gotContainerd, tc.wantContainerdName)
+			}
+		})
+	}
+
+	// dockerHubRedirectTransport rewrites any request bound for the "index.docker.io"
+	// host to the local test registry, letting us exercise AddImage's real
+	// registry=="index.docker.io" branch (all four Docker Hub reference forms below
+	// normalize to that registry) without touching the real Docker Hub.
+	dockerHubRedirect := &dockerHubRedirectTransport{
+		inner:    srv.Client().Transport,
+		toScheme: "http",
+		toHost:   srcHost,
+	}
+	redirectOpts := []remote.Option{remote.WithTransport(dockerHubRedirect)}
+
+	// All four of these forms resolve to the same underlying repository/tag
+	// ("library/nginx:latest") already seeded above, so they can share the fixture.
+	indexDockerIOCases := []struct {
+		inputRef           string
+		wantAnnotationRef  string
+		wantContainerdName string
+	}{
+		{"nginx:latest", "nginx:latest", "index.docker.io/nginx:latest"},
+		{"library/nginx:latest", "library/nginx:latest", "index.docker.io/library/nginx:latest"},
+		{"docker.io/nginx:latest", "nginx:latest", "docker.io/nginx:latest"},
+		{"docker.io/library/nginx:latest", "library/nginx:latest", "docker.io/library/nginx:latest"},
+	}
+	ctx2 := context.Background()
+	for _, tc := range indexDockerIOCases {
+		t.Run("roundtrip_index_docker_io/"+tc.inputRef, func(t *testing.T) {
+			s, err := store.NewLayout(t.TempDir())
+			if err != nil {
+				t.Fatalf("NewLayout: %v", err)
+			}
+			// excludeExtras=true skips the cosign sig/att/sbom lookups, which are
+			// irrelevant here and would otherwise also need redirecting.
+			if _, err := s.AddImage(ctx2, tc.inputRef, "", true, redirectOpts...); err != nil {
+				t.Fatalf("AddImage(%q): %v", tc.inputRef, err)
+			}
+			found := false
+			if err := s.OCI.Walk(func(_ string, desc ocispec.Descriptor) error {
+				ann := desc.Annotations[ocispec.AnnotationRefName]
+				cdn := desc.Annotations[consts.ContainerdImageNameKey]
+				if ann == tc.wantAnnotationRef && cdn == tc.wantContainerdName {
+					found = true
+				}
+				return nil
+			}); err != nil {
+				t.Fatalf("Walk: %v", err)
+			}
+			if !found {
+				t.Errorf("AddImage(%q): no descriptor with AnnotationRefName=%q ContainerdImageNameKey=%q", tc.inputRef, tc.wantAnnotationRef, tc.wantContainerdName)
 			}
 		})
 	}


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

Issue: #681 

**Types of Changes:**

Bugfix

**Proposed Changes:**

Fixes round-trip bugs where hauler silently rewrote Docker Hub image references, making `--rewrite` a no-op.
`DockerHubAnnotationRef` now takes the original reference string the user typed and stores AnnotationRefName / `ContainerdImageNameKey` to match it exactly, rather than the go-containerregistry-normalized form. Added tests for all the following combinations:

| Original | Expected No rewrite | Expected rewrite `library/nginx` | Expected rewrite `nginx` |
|------|-----|-----|----|
| `nginx:latest` | `index.docker.io/nginx:latest` | `index.docker.io/library/nginx:latest` | `index.docker.io/nginx:latest` |
| `library/nginx:latest` | `index.docker.io/library/nginx:latest` | `index.docker.io/library/nginx:latest` | `index.docker.io/nginx:latest` |
| `docker.io/nginx:latest` | `docker.io/nginx:latest` | `docker.io/library/nginx:latest` | `docker.io/nginx:latest` |
| `docker.io/library/nginx:latest` | `docker.io/library/nginx:latest` | `docker.io/library/nginx:latest` | `docker.io/nginx:latest` |

`RewriteRefToRegistry`, used by `store copy` and `store info` no longer re-parse stored annotations through go-containerregistry. They use the stored values verbatim, so the table above holds end-to-end through `store add`, `store info`, and `store copy`.

**Verification/Testing of Changes:**

```
2026-07-20 23:19:04 INF adding image [docker.io/nginx:latest] to the store
2026-07-20 23:19:31 INF successfully added image [index.docker.io/library/nginx:latest]
❯ dist/hauler_darwin_arm64_v8.0/hauler store add image library/alpine --rewrite alpine

2026-07-20 23:19:41 INF adding image [library/alpine] to the store
2026-07-20 23:19:53 INF rewriting [index.docker.io/library/alpine:latest] to [index.docker.io/alpine:latest]
2026-07-20 23:19:53 INF successfully added image [index.docker.io/library/alpine:latest]
❯ dist/hauler_darwin_arm64_v8.0/hauler store info
┌────────────────────────────────────────────────┬───────┬─────────────────┬───────────┬──────────┐
│ REFERENCE                                      │ TYPE  │ PLATFORM        │ #  LAYERS │ SIZE     │
├────────────────────────────────────────────────┼───────┼─────────────────┼───────────┼──────────┤
│ docker.io/nginx:latest                         │ image │ linux/386       │ 7         │ 63.5 MB  │
│                                                │ image │ linux/amd64     │ 7         │ 63.1 MB  │
│                                                │ image │ linux/arm       │ 7         │ 54.3 MB  │
│                                                │ image │ linux/arm       │ 7         │ 52.5 MB  │
│                                                │ image │ linux/arm64     │ 7         │ 61.4 MB  │
│                                                │ image │ linux/ppc64le   │ 7         │ 67.2 MB  │
│                                                │ image │ linux/riscv64   │ 7         │ 57.8 MB  │
│                                                │ image │ linux/s390x     │ 7         │ 60.7 MB  │
│                                                │ image │ unknown/unknown │ 2         │ 2.9 MB   │
│                                                │ image │ unknown/unknown │ 2         │ 2.9 MB   │
│                                                │ image │ unknown/unknown │ 2         │ 2.8 MB   │
│                                                │ image │ unknown/unknown │ 2         │ 2.9 MB   │
│                                                │ image │ unknown/unknown │ 2         │ 2.9 MB   │
│                                                │ image │ unknown/unknown │ 2         │ 2.9 MB   │
│                                                │ image │ unknown/unknown │ 2         │ 2.9 MB   │
│                                                │ image │ unknown/unknown │ 2         │ 2.9 MB   │
│ index.docker.io/alpine:latest                  │ image │ linux/386       │ 1         │ 3.7 MB   │
│                                                │ image │ linux/amd64     │ 1         │ 3.8 MB   │
│                                                │ image │ linux/arm       │ 1         │ 3.6 MB   │
│                                                │ image │ linux/arm       │ 1         │ 3.3 MB   │
│                                                │ image │ linux/arm64     │ 1         │ 4.2 MB   │
│                                                │ image │ linux/ppc64le   │ 1         │ 3.8 MB   │
│                                                │ image │ linux/riscv64   │ 1         │ 3.6 MB   │
│                                                │ image │ linux/s390x     │ 1         │ 3.7 MB   │
│                                                │ image │ unknown/unknown │ 2         │ 85.3 kB  │
│                                                │ image │ unknown/unknown │ 2         │ 84.7 kB  │
│                                                │ image │ unknown/unknown │ 2         │ 84.7 kB  │
│                                                │ image │ unknown/unknown │ 2         │ 84.8 kB  │
│                                                │ image │ unknown/unknown │ 2         │ 85.2 kB  │
│                                                │ image │ unknown/unknown │ 2         │ 84.7 kB  │
│                                                │ image │ unknown/unknown │ 1         │ 5.5 kB   │
│                                                │ image │ unknown/unknown │ 2         │ 84.7 kB  │
├────────────────────────────────────────────────┼───────┼─────────────────┼───────────┼──────────┤
│ store-path: /Users/jerp/src/suse/hauler/store  │       │                 │     Total │ 533.5 MB │
│ store-id: 1b2fe16b-fadf-423e-a331-bf3b336df244 │       │                 │           │          │
└────────────────────────────────────────────────┴───────┴─────────────────┴───────────┴──────────┘
```


**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
