### PR TITLE
feat: speed up large blob pulls with parallel HTTP range requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containerd/errdefs v1.0.0
 	github.com/distribution/distribution/v3 v3.1.1
 	github.com/distribution/reference v0.6.0
+	github.com/docker/go-units v0.5.0
 	github.com/google/go-containerregistry v0.21.7
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
@@ -129,7 +130,6 @@ require (
 	github.com/docker/go-connections v0.7.0 // indirect
 	github.com/docker/go-events v0.0.0-20250808211157-605354379745 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
-	github.com/docker/go-units v0.5.0 // indirect
 	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dylibso/observe-sdk/go v0.0.0-20240819160327-2d926c5d788a // indirect

--- a/internal/flags/store.go
+++ b/internal/flags/store.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 
+	"github.com/docker/go-units"
 	"github.com/spf13/cobra"
+	"hauler.dev/go/hauler/v2/pkg/blob"
 	"hauler.dev/go/hauler/v2/pkg/consts"
 	"hauler.dev/go/hauler/v2/pkg/log"
 	"hauler.dev/go/hauler/v2/pkg/store"
@@ -22,6 +25,11 @@ type StoreRootOpts struct {
 	StoreDir     string
 	Retries      int
 	TempOverride string
+
+	// Large-blob parallel retrieval knobs. Empty/zero → env var → built-in default.
+	Concurrency    int    // --concurrency
+	ChunkThreshold string // --chunk-threshold (human size, e.g. "100MiB")
+	ChunkSize      string // --chunk-size (human size, e.g. "32MiB")
 }
 
 func (o *StoreRootOpts) AddFlags(cmd *cobra.Command) {
@@ -29,6 +37,58 @@ func (o *StoreRootOpts) AddFlags(cmd *cobra.Command) {
 	pf.StringVarP(&o.StoreDir, "store", "s", "", "Set the directory to use for the content store")
 	pf.IntVarP(&o.Retries, "retries", "r", consts.DefaultRetries, "Set the number of retries for operations")
 	pf.StringVarP(&o.TempOverride, "tempdir", "t", "", "(Optional) Override the default temporary directory determined by the OS")
+	pf.IntVar(&o.Concurrency, "concurrency", 0,
+		"(Optional) Parallel connections per blob for large-blob retrieval (0 = default 10; 1 disables chunking)")
+	pf.StringVar(&o.ChunkThreshold, "chunk-threshold", "",
+		"(Optional) Minimum blob size to trigger parallel ranged retrieval, e.g. 100MiB (default 100MiB)")
+	pf.StringVar(&o.ChunkSize, "chunk-size", "",
+		"(Optional) Range window per parallel request, e.g. 8MiB (default 8MiB)")
+}
+
+// BlobOptions resolves large-blob retrieval settings with precedence
+// flag > env var > built-in default, and returns the blob.Options to attach to
+// the store.
+func (o *StoreRootOpts) BlobOptions() (blob.Options, error) {
+	opts := blob.DefaultOptions()
+
+	// connections
+	if o.Concurrency > 0 {
+		opts.Connections = o.Concurrency
+	} else if v := os.Getenv(consts.HaulerBlobConnections); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return opts, fmt.Errorf("invalid %s=%q: %w", consts.HaulerBlobConnections, v, err)
+		}
+		opts.Connections = n
+	}
+
+	// chunk threshold
+	if v := firstNonEmpty(o.ChunkThreshold, os.Getenv(consts.HaulerBlobChunkThreshold)); v != "" {
+		n, err := units.RAMInBytes(v)
+		if err != nil {
+			return opts, fmt.Errorf("invalid chunk-threshold %q: %w", v, err)
+		}
+		opts.ChunkThreshold = n
+	}
+
+	// chunk size
+	if v := firstNonEmpty(o.ChunkSize, os.Getenv(consts.HaulerBlobChunkSize)); v != "" {
+		n, err := units.RAMInBytes(v)
+		if err != nil {
+			return opts, fmt.Errorf("invalid chunk-size %q: %w", v, err)
+		}
+		opts.ChunkSize = n
+	}
+
+	return opts, nil
+}
+
+// firstNonEmpty returns the flag value if set, else the env value.
+func firstNonEmpty(flagVal, envVal string) string {
+	if flagVal != "" {
+		return flagVal
+	}
+	return envVal
 }
 
 func (o *StoreRootOpts) Store(ctx context.Context, ro *CliRootOpts) (*store.Layout, error) {
@@ -84,6 +144,13 @@ func (o *StoreRootOpts) Store(ctx context.Context, ro *CliRootOpts) (*store.Layo
 		return nil, err
 	}
 	l.Debugf("generated store id of [%s]", s.StoreID)
+
+	bo, err := o.BlobOptions()
+	if err != nil {
+		return nil, err
+	}
+	s.BlobOpts = bo
+
 	return s, nil
 }
 

--- a/internal/flags/store.go
+++ b/internal/flags/store.go
@@ -27,9 +27,9 @@ type StoreRootOpts struct {
 	TempOverride string
 
 	// Large-blob parallel retrieval knobs. Empty/zero → env var → built-in default.
-	Concurrency    int    // --concurrency
-	ChunkThreshold string // --chunk-threshold (human size, e.g. "100MiB")
-	ChunkSize      string // --chunk-size (human size, e.g. "32MiB")
+	RangeConcurrency int    // --range-concurrency
+	RangeThreshold   string // --range-threshold (human size, e.g. "100MiB")
+	RangeSize        string // --range-size (human size, e.g. "32MiB")
 }
 
 func (o *StoreRootOpts) AddFlags(cmd *cobra.Command) {
@@ -37,12 +37,12 @@ func (o *StoreRootOpts) AddFlags(cmd *cobra.Command) {
 	pf.StringVarP(&o.StoreDir, "store", "s", "", "Set the directory to use for the content store")
 	pf.IntVarP(&o.Retries, "retries", "r", consts.DefaultRetries, "Set the number of retries for operations")
 	pf.StringVarP(&o.TempOverride, "tempdir", "t", "", "(Optional) Override the default temporary directory determined by the OS")
-	pf.IntVar(&o.Concurrency, "concurrency", 0,
+	pf.IntVar(&o.RangeConcurrency, "range-concurrency", 0,
 		"(Optional) Parallel connections per blob for large-blob retrieval (0 = default 10; 1 disables chunking)")
-	pf.StringVar(&o.ChunkThreshold, "chunk-threshold", "",
+	pf.StringVar(&o.RangeThreshold, "range-threshold", "",
 		"(Optional) Minimum blob size to trigger parallel ranged retrieval, e.g. 100MiB (default 100MiB)")
-	pf.StringVar(&o.ChunkSize, "chunk-size", "",
-		"(Optional) Range window per parallel request, e.g. 8MiB (default 8MiB)")
+	pf.StringVar(&o.RangeSize, "range-size", "",
+		"(Optional) Byte-range window per parallel request, e.g. 8MiB (default 8MiB)")
 }
 
 // BlobOptions resolves large-blob retrieval settings with precedence
@@ -52,30 +52,30 @@ func (o *StoreRootOpts) BlobOptions() (blob.Options, error) {
 	opts := blob.DefaultOptions()
 
 	// connections
-	if o.Concurrency > 0 {
-		opts.Connections = o.Concurrency
-	} else if v := os.Getenv(consts.HaulerBlobConnections); v != "" {
+	if o.RangeConcurrency > 0 {
+		opts.Connections = o.RangeConcurrency
+	} else if v := os.Getenv(consts.HaulerBlobRangeConcurrency); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil {
-			return opts, fmt.Errorf("invalid %s=%q: %w", consts.HaulerBlobConnections, v, err)
+			return opts, fmt.Errorf("invalid %s=%q: %w", consts.HaulerBlobRangeConcurrency, v, err)
 		}
 		opts.Connections = n
 	}
 
-	// chunk threshold
-	if v := firstNonEmpty(o.ChunkThreshold, os.Getenv(consts.HaulerBlobChunkThreshold)); v != "" {
+	// range threshold
+	if v := firstNonEmpty(o.RangeThreshold, os.Getenv(consts.HaulerBlobRangeThreshold)); v != "" {
 		n, err := units.RAMInBytes(v)
 		if err != nil {
-			return opts, fmt.Errorf("invalid chunk-threshold %q: %w", v, err)
+			return opts, fmt.Errorf("invalid range-threshold %q: %w", v, err)
 		}
 		opts.ChunkThreshold = n
 	}
 
-	// chunk size
-	if v := firstNonEmpty(o.ChunkSize, os.Getenv(consts.HaulerBlobChunkSize)); v != "" {
+	// range size
+	if v := firstNonEmpty(o.RangeSize, os.Getenv(consts.HaulerBlobRangeSize)); v != "" {
 		n, err := units.RAMInBytes(v)
 		if err != nil {
-			return opts, fmt.Errorf("invalid chunk-size %q: %w", v, err)
+			return opts, fmt.Errorf("invalid range-size %q: %w", v, err)
 		}
 		opts.ChunkSize = n
 	}

--- a/internal/flags/store_test.go
+++ b/internal/flags/store_test.go
@@ -1,0 +1,75 @@
+package flags
+
+import (
+	"testing"
+
+	"hauler.dev/go/hauler/v2/pkg/blob"
+	"hauler.dev/go/hauler/v2/pkg/consts"
+)
+
+func TestBlobOptions_Defaults(t *testing.T) {
+	o := &StoreRootOpts{}
+	got, err := o.BlobOptions()
+	if err != nil {
+		t.Fatalf("BlobOptions: %v", err)
+	}
+	if got.Connections != blob.DefaultConnections {
+		t.Errorf("Connections = %d, want default %d", got.Connections, blob.DefaultConnections)
+	}
+	if got.ChunkThreshold != blob.DefaultChunkThreshold {
+		t.Errorf("ChunkThreshold = %d, want default %d", got.ChunkThreshold, blob.DefaultChunkThreshold)
+	}
+	if got.ChunkSize != blob.DefaultChunkSize {
+		t.Errorf("ChunkSize = %d, want default %d", got.ChunkSize, blob.DefaultChunkSize)
+	}
+}
+
+func TestBlobOptions_FlagsWin(t *testing.T) {
+	t.Setenv(consts.HaulerBlobConnections, "9")
+	t.Setenv(consts.HaulerBlobChunkThreshold, "999MiB")
+	o := &StoreRootOpts{
+		Concurrency:    8,       // flag beats env 9
+		ChunkThreshold: "50MiB", // flag beats env 999MiB
+		ChunkSize:      "16MiB",
+	}
+	got, err := o.BlobOptions()
+	if err != nil {
+		t.Fatalf("BlobOptions: %v", err)
+	}
+	if got.Connections != 8 {
+		t.Errorf("Connections = %d, want 8 (flag)", got.Connections)
+	}
+	if got.ChunkThreshold != 50<<20 {
+		t.Errorf("ChunkThreshold = %d, want %d (flag 50MiB)", got.ChunkThreshold, 50<<20)
+	}
+	if got.ChunkSize != 16<<20 {
+		t.Errorf("ChunkSize = %d, want %d (flag 16MiB)", got.ChunkSize, 16<<20)
+	}
+}
+
+func TestBlobOptions_EnvWhenNoFlag(t *testing.T) {
+	t.Setenv(consts.HaulerBlobConnections, "6")
+	t.Setenv(consts.HaulerBlobChunkThreshold, "200MiB")
+	t.Setenv(consts.HaulerBlobChunkSize, "8MiB")
+	o := &StoreRootOpts{} // no flags set
+	got, err := o.BlobOptions()
+	if err != nil {
+		t.Fatalf("BlobOptions: %v", err)
+	}
+	if got.Connections != 6 {
+		t.Errorf("Connections = %d, want 6 (env)", got.Connections)
+	}
+	if got.ChunkThreshold != 200<<20 {
+		t.Errorf("ChunkThreshold = %d, want %d (env 200MiB)", got.ChunkThreshold, 200<<20)
+	}
+	if got.ChunkSize != 8<<20 {
+		t.Errorf("ChunkSize = %d, want %d (env 8MiB)", got.ChunkSize, 8<<20)
+	}
+}
+
+func TestBlobOptions_BadValueErrors(t *testing.T) {
+	o := &StoreRootOpts{ChunkThreshold: "not-a-size"}
+	if _, err := o.BlobOptions(); err == nil {
+		t.Fatal("expected error for unparseable --chunk-threshold, got nil")
+	}
+}

--- a/internal/flags/store_test.go
+++ b/internal/flags/store_test.go
@@ -25,12 +25,12 @@ func TestBlobOptions_Defaults(t *testing.T) {
 }
 
 func TestBlobOptions_FlagsWin(t *testing.T) {
-	t.Setenv(consts.HaulerBlobConnections, "9")
-	t.Setenv(consts.HaulerBlobChunkThreshold, "999MiB")
+	t.Setenv(consts.HaulerBlobRangeConcurrency, "9")
+	t.Setenv(consts.HaulerBlobRangeThreshold, "999MiB")
 	o := &StoreRootOpts{
-		Concurrency:    8,       // flag beats env 9
-		ChunkThreshold: "50MiB", // flag beats env 999MiB
-		ChunkSize:      "16MiB",
+		RangeConcurrency: 8,       // flag beats env 9
+		RangeThreshold:   "50MiB", // flag beats env 999MiB
+		RangeSize:        "16MiB",
 	}
 	got, err := o.BlobOptions()
 	if err != nil {
@@ -48,9 +48,9 @@ func TestBlobOptions_FlagsWin(t *testing.T) {
 }
 
 func TestBlobOptions_EnvWhenNoFlag(t *testing.T) {
-	t.Setenv(consts.HaulerBlobConnections, "6")
-	t.Setenv(consts.HaulerBlobChunkThreshold, "200MiB")
-	t.Setenv(consts.HaulerBlobChunkSize, "8MiB")
+	t.Setenv(consts.HaulerBlobRangeConcurrency, "6")
+	t.Setenv(consts.HaulerBlobRangeThreshold, "200MiB")
+	t.Setenv(consts.HaulerBlobRangeSize, "8MiB")
 	o := &StoreRootOpts{} // no flags set
 	got, err := o.BlobOptions()
 	if err != nil {
@@ -68,8 +68,8 @@ func TestBlobOptions_EnvWhenNoFlag(t *testing.T) {
 }
 
 func TestBlobOptions_BadValueErrors(t *testing.T) {
-	o := &StoreRootOpts{ChunkThreshold: "not-a-size"}
+	o := &StoreRootOpts{RangeThreshold: "not-a-size"}
 	if _, err := o.BlobOptions(); err == nil {
-		t.Fatal("expected error for unparseable --chunk-threshold, got nil")
+		t.Fatal("expected error for unparseable --range-threshold, got nil")
 	}
 }

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -1,0 +1,330 @@
+// Package blob downloads OCI blobs to a file as fast as the source registry
+// allows, using parallel HTTP Range requests (RFC 7233) when supported and
+// falling back to a single stream otherwise. It verifies the sha256 digest of
+// the assembled file and never leaves a partial/corrupt file behind.
+package blob
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
+	"golang.org/x/sync/errgroup"
+)
+
+// Built-in defaults. Kept in this package so pkg/blob stays free of any
+// hauler-internal imports.
+//
+// DefaultConnections and DefaultChunkSize mirror awscli/s3transfer's defaults
+// (max_concurrent_requests=10, multipart_chunksize=8MB): more, smaller
+// parallel streams tolerate higher-latency/loss-prone paths (e.g. a
+// registry-to-S3 redirect over a lossy link) better than fewer, larger ones,
+// since each stream carries less unacknowledged data at risk on a stall or
+// retry.
+const (
+	DefaultChunkThreshold int64 = 100 << 20 // 100 MiB
+	DefaultConnections          = 10
+	DefaultChunkSize      int64 = 8 << 20 // 8 MiB
+	DefaultChunkRetries         = 3
+)
+
+// Options tunes a Fetch. The zero value is not usable directly; use
+// DefaultOptions and override fields. Any field left at its zero value is
+// normalized to the corresponding Default* inside Fetch.
+type Options struct {
+	Keychain       authn.Keychain    // default authn.DefaultKeychain
+	Transport      http.RoundTripper // base RT; default remote.DefaultTransport
+	ChunkThreshold int64             // min blob size to parallelize
+	Connections    int               // worker-pool size; <=1 disables chunking
+	ChunkSize      int64             // Range window per request
+	ChunkRetries   int               // per-chunk transient retries
+}
+
+func DefaultOptions() Options {
+	return Options{
+		Keychain:       authn.DefaultKeychain,
+		Transport:      remote.DefaultTransport,
+		ChunkThreshold: DefaultChunkThreshold,
+		Connections:    DefaultConnections,
+		ChunkSize:      DefaultChunkSize,
+		ChunkRetries:   DefaultChunkRetries,
+	}
+}
+
+func (o *Options) normalize() {
+	if o.Keychain == nil {
+		o.Keychain = authn.DefaultKeychain
+	}
+	if o.Transport == nil {
+		o.Transport = remote.DefaultTransport
+	}
+	if o.ChunkThreshold <= 0 {
+		o.ChunkThreshold = DefaultChunkThreshold
+	}
+	if o.Connections == 0 {
+		o.Connections = DefaultConnections
+	}
+	if o.ChunkSize <= 0 {
+		o.ChunkSize = DefaultChunkSize
+	}
+	if o.ChunkRetries == 0 {
+		o.ChunkRetries = DefaultChunkRetries
+	}
+}
+
+// Fetch downloads the blob identified by desc from ref's repository to dest,
+// verifying its digest. It parallelizes with Range requests when the source
+// supports them and the blob is large enough; otherwise it streams once.
+func Fetch(ctx context.Context, ref name.Reference, desc v1.Descriptor, dest string, opts Options) error {
+	opts.normalize()
+
+	if desc.Digest.Algorithm != "sha256" {
+		return fmt.Errorf("blob: unsupported digest algorithm %q", desc.Digest.Algorithm)
+	}
+
+	client, err := buildClient(ctx, ref, opts)
+	if err != nil {
+		return err
+	}
+	reg := ref.Context()
+	blobURL := fmt.Sprintf("%s://%s/v2/%s/blobs/%s",
+		reg.Registry.Scheme(), reg.RegistryStr(), reg.RepositoryStr(), desc.Digest.String())
+
+	// Below threshold or explicit opt-out → today's behavior: one GET, one stream.
+	if desc.Size < opts.ChunkThreshold || opts.Connections <= 1 {
+		return singleStream(ctx, client, blobURL, dest, desc)
+	}
+	return ranged(ctx, client, blobURL, dest, desc, opts)
+}
+
+// buildClient constructs an authenticated http.Client for ref's registry. The
+// bearer transport only attaches Authorization to requests matching the
+// registry host, so cross-host redirects to object storage carry no token.
+func buildClient(ctx context.Context, ref name.Reference, opts Options) (*http.Client, error) {
+	reg := ref.Context().Registry
+	auth, err := opts.Keychain.Resolve(reg)
+	if err != nil {
+		return nil, fmt.Errorf("blob: resolving auth for %s: %w", reg, err)
+	}
+	scopes := []string{ref.Context().Scope(transport.PullScope)}
+	rt, err := transport.NewWithContext(ctx, reg, auth, opts.Transport, scopes)
+	if err != nil {
+		return nil, fmt.Errorf("blob: building transport for %s: %w", reg, err)
+	}
+	return &http.Client{Transport: rt}, nil
+}
+
+// singleStream performs one plain GET and copies the body to dest, then verifies.
+func singleStream(ctx context.Context, client *http.Client, blobURL, dest string, desc v1.Descriptor) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, blobURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("blob: unexpected status %d fetching %s", resp.StatusCode, blobURL)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(f, resp.Body)
+	closeErr := f.Close()
+	if copyErr != nil {
+		os.Remove(dest)
+		return copyErr
+	}
+	if closeErr != nil {
+		os.Remove(dest)
+		return closeErr
+	}
+	if err := verifyDigest(dest, desc.Digest); err != nil {
+		os.Remove(dest)
+		return err
+	}
+	return nil
+}
+
+// verifyDigest re-reads dest once and compares its sha256 to want.
+func verifyDigest(dest string, want v1.Hash) error {
+	f, err := os.Open(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	got := "sha256:" + hex.EncodeToString(h.Sum(nil))
+	if got != want.String() {
+		return fmt.Errorf("blob: digest mismatch: got %s want %s", got, want.String())
+	}
+	return nil
+}
+
+// ranged probes with a single ranged GET, then parallelizes the remainder.
+func ranged(ctx context.Context, client *http.Client, blobURL, dest string, desc v1.Descriptor, opts Options) error {
+	chunkSize := opts.ChunkSize
+	firstEnd := chunkSize - 1
+	if firstEnd > desc.Size-1 {
+		firstEnd = desc.Size - 1
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, blobURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Range", fmt.Sprintf("bytes=0-%d", firstEnd))
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// Server ignored Range: the body IS the whole blob. Stream it — no
+		// wasted round-trip. This is the fallback path.
+		defer resp.Body.Close()
+		f, err := os.Create(dest)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(f, resp.Body)
+		closeErr := f.Close()
+		if copyErr != nil {
+			os.Remove(dest)
+			return copyErr
+		}
+		if closeErr != nil {
+			os.Remove(dest)
+			return closeErr
+		}
+		if err := verifyDigest(dest, desc.Digest); err != nil {
+			os.Remove(dest)
+			return err
+		}
+		return nil
+	case http.StatusPartialContent:
+		// fall through to parallel assembly below
+	default:
+		resp.Body.Close()
+		return fmt.Errorf("blob: unexpected status %d probing range on %s", resp.StatusCode, blobURL)
+	}
+
+	// The probe's only job was to confirm the server honors Range with 206.
+	// Discard its body rather than trusting it: streaming it in with a bare
+	// io.Copy would have no retry and no short-read check, unlike every
+	// other chunk. Chunk 0 (bytes=0-firstEnd) is fetched again below through
+	// the same fetchChunk path as every other chunk, trading one extra
+	// round-trip for retry-safety on the first chunk.
+	resp.Body.Close()
+
+	f, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return err
+	}
+	fail := func(e error) error {
+		f.Close()
+		os.Remove(dest)
+		return e
+	}
+	if err := f.Truncate(desc.Size); err != nil {
+		return fail(err)
+	}
+
+	// Fetch every chunk, including chunk 0, across a bounded worker pool.
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(opts.Connections)
+	for start := int64(0); start < desc.Size; start += chunkSize {
+		start := start
+		end := start + chunkSize - 1
+		if end > desc.Size-1 {
+			end = desc.Size - 1
+		}
+		g.Go(func() error {
+			return fetchChunk(gctx, client, blobURL, f, start, end, opts.ChunkRetries)
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return fail(err)
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(dest)
+		return err
+	}
+	if err := verifyDigest(dest, desc.Digest); err != nil {
+		os.Remove(dest)
+		return err
+	}
+	return nil
+}
+
+// fetchChunk GETs one byte range and writes it at its offset, retrying a bounded
+// number of times on transient failures. Each attempt re-issues the GET to the
+// blob endpoint, so an expired presigned redirect (403) recovers via a fresh
+// redirect.
+func fetchChunk(ctx context.Context, client *http.Client, blobURL string, f *os.File, start, end int64, retries int) error {
+	want := end - start + 1
+	var lastErr error
+	for attempt := 0; attempt <= retries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(backoff(attempt)):
+			}
+		}
+		err := func() error {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, blobURL, nil)
+			if err != nil {
+				return err
+			}
+			req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", start, end))
+			resp, err := client.Do(req)
+			if err != nil {
+				return err
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusPartialContent {
+				return fmt.Errorf("blob: unexpected status %d for range %d-%d", resp.StatusCode, start, end)
+			}
+			n, err := io.Copy(io.NewOffsetWriter(f, start), resp.Body)
+			if err != nil {
+				return err
+			}
+			if n != want {
+				return fmt.Errorf("blob: short chunk %d-%d: got %d want %d", start, end, n, want)
+			}
+			return nil
+		}()
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		lastErr = err
+	}
+	return lastErr
+}
+
+// backoff returns a short escalating delay between chunk retries.
+func backoff(attempt int) time.Duration {
+	return time.Duration(attempt) * 200 * time.Millisecond
+}

--- a/pkg/blob/blob_test.go
+++ b/pkg/blob/blob_test.go
@@ -1,0 +1,436 @@
+package blob_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"hauler.dev/go/hauler/v2/pkg/blob"
+)
+
+// small shared helpers used across all tests in this file.
+func newReader(b []byte) *bytes.Reader { return bytes.NewReader(b) }
+
+var noTime = time.Time{}
+
+// deterministicBlob returns size bytes and their sha256 v1.Hash.
+func deterministicBlob(size int) ([]byte, v1.Hash) {
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	sum := sha256.Sum256(data)
+	return data, v1.Hash{Algorithm: "sha256", Hex: hex.EncodeToString(sum[:])}
+}
+
+// rangeServer serves data honoring RFC 7233 Range (via http.ServeContent) and
+// answers the /v2/ ping. reqCount counts blob GETs.
+func rangeServer(t *testing.T, data []byte, reqCount *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/blobs/") {
+			atomic.AddInt64(reqCount, 1)
+			http.ServeContent(w, r, "blob", noTime, newReader(data))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+// refFor builds an insecure reference at the given httptest host.
+func refFor(t *testing.T, srv *httptest.Server, digest v1.Hash) name.Reference {
+	t.Helper()
+	host := strings.TrimPrefix(srv.URL, "http://")
+	ref, err := name.NewDigest(host+"/test/blob@"+digest.String(), name.Insecure)
+	if err != nil {
+		t.Fatalf("new digest ref: %v", err)
+	}
+	return ref
+}
+
+func fileDigest(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read dest: %v", err)
+	}
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func TestFetch_SingleStream_BelowThreshold(t *testing.T) {
+	data, h := deterministicBlob(4096)
+	var reqs int64
+	srv := rangeServer(t, data, &reqs)
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "blob")
+	opts := blob.DefaultOptions()
+	opts.Transport = srv.Client().Transport
+	opts.ChunkThreshold = 1 << 20 // 1 MiB; blob is 4 KiB → single-stream
+
+	desc := v1.Descriptor{Digest: h, Size: int64(len(data))}
+	if err := blob.Fetch(context.Background(), refFor(t, srv, h), desc, dest, opts); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := fileDigest(t, dest); got != h.String() {
+		t.Fatalf("digest mismatch: got %s want %s", got, h.String())
+	}
+	if n := atomic.LoadInt64(&reqs); n != 1 {
+		t.Fatalf("expected exactly 1 blob GET on single-stream path, got %d", n)
+	}
+}
+
+func TestFetch_ConnectionsOne_ForcesSingleStream(t *testing.T) {
+	data, h := deterministicBlob(300 * 1024)
+	var reqs int64
+	srv := rangeServer(t, data, &reqs)
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "blob")
+	opts := blob.DefaultOptions()
+	opts.Transport = srv.Client().Transport
+	opts.ChunkThreshold = 64 * 1024 // below blob size...
+	opts.Connections = 1            // ...but connections=1 disables chunking
+
+	desc := v1.Descriptor{Digest: h, Size: int64(len(data))}
+	if err := blob.Fetch(context.Background(), refFor(t, srv, h), desc, dest, opts); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := fileDigest(t, dest); got != h.String() {
+		t.Fatalf("digest mismatch: got %s want %s", got, h.String())
+	}
+	if n := atomic.LoadInt64(&reqs); n != 1 {
+		t.Fatalf("expected exactly 1 blob GET when connections=1, got %d", n)
+	}
+}
+
+// ignoreRangeServer always returns 200 with the full body, ignoring Range.
+func ignoreRangeServer(t *testing.T, data []byte, reqCount *int64) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/blobs/") {
+			atomic.AddInt64(reqCount, 1)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(data)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+}
+
+func TestFetch_Ranged_MultiChunk(t *testing.T) {
+	data, h := deterministicBlob(300 * 1024) // 300 KiB
+	var reqs int64
+	srv := rangeServer(t, data, &reqs)
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "blob")
+	opts := blob.DefaultOptions()
+	opts.Transport = srv.Client().Transport
+	opts.ChunkThreshold = 64 * 1024 // 64 KiB → chunk
+	opts.ChunkSize = 64 * 1024      // 5 chunks (4x64 + 1x44)
+	opts.Connections = 3
+
+	desc := v1.Descriptor{Digest: h, Size: int64(len(data))}
+	if err := blob.Fetch(context.Background(), refFor(t, srv, h), desc, dest, opts); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := fileDigest(t, dest); got != h.String() {
+		t.Fatalf("digest mismatch: got %s want %s", got, h.String())
+	}
+	// 300 KiB / 64 KiB = 5 chunks. The probe (bytes=0-65535) is now a pure
+	// capability check with its body discarded, so chunk 0 is re-fetched
+	// through the same fetchChunk path as chunks 1-4: 1 probe + 5 chunk GETs
+	// (chunks 0-4) = 6 total blob GETs. This trades one extra round-trip for
+	// retry-safety on the first chunk (see TestFetch_Ranged_FirstChunkTransientRetry).
+	if n := atomic.LoadInt64(&reqs); n != 6 {
+		t.Fatalf("expected 6 blob GETs (1 probe + 5 chunks), got %d", n)
+	}
+}
+
+func TestFetch_Ranged_IgnoredFallback(t *testing.T) {
+	data, h := deterministicBlob(300 * 1024)
+	var reqs int64
+	srv := ignoreRangeServer(t, data, &reqs)
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "blob")
+	opts := blob.DefaultOptions()
+	opts.Transport = srv.Client().Transport
+	opts.ChunkThreshold = 64 * 1024
+	opts.ChunkSize = 64 * 1024
+	opts.Connections = 3
+
+	desc := v1.Descriptor{Digest: h, Size: int64(len(data))}
+	if err := blob.Fetch(context.Background(), refFor(t, srv, h), desc, dest, opts); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := fileDigest(t, dest); got != h.String() {
+		t.Fatalf("digest mismatch: got %s want %s", got, h.String())
+	}
+	// Probe got 200 (whole blob) → exactly one GET, no chunk workers.
+	if n := atomic.LoadInt64(&reqs); n != 1 {
+		t.Fatalf("expected 1 GET on 200 fallback, got %d", n)
+	}
+}
+
+func TestFetch_DigestMismatch_DeletesDest(t *testing.T) {
+	data, _ := deterministicBlob(4096)
+	// Claim a wrong digest so verification must fail.
+	wrong := v1.Hash{Algorithm: "sha256", Hex: strings.Repeat("00", 32)}
+	var reqs int64
+	srv := rangeServer(t, data, &reqs)
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "blob")
+	opts := blob.DefaultOptions()
+	opts.Transport = srv.Client().Transport
+	opts.ChunkThreshold = 1 << 20 // single-stream
+
+	desc := v1.Descriptor{Digest: wrong, Size: int64(len(data))}
+	err := blob.Fetch(context.Background(), refFor(t, srv, wrong), desc, dest, opts)
+	if err == nil {
+		t.Fatal("expected digest mismatch error, got nil")
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("expected dest deleted on mismatch, stat err = %v", statErr)
+	}
+}
+
+// TestFetch_Redirect_NoAuthForwarded: registry requires a bearer token, then
+// 307-redirects the blob GET to an "object storage" host that serves ranges and
+// asserts it received NO Authorization header.
+//
+// go-containerregistry's bearer transport validates the WWW-Authenticate
+// realm host and rejects loopback/private addresses UNLESS the realm's
+// host:port exactly matches the registry's own host:port (the "same-host
+// exception" — see transport/bearer.go's validateRealmURL and
+// TestValidateRealmURLSameHost in that package, added for
+// https://github.com/google/go-containerregistry/issues/2258). httptest
+// servers necessarily listen on 127.0.0.1, so a *separate* token server on a
+// different loopback port would trip that guard. To keep this test running
+// against a real loopback listener (rather than weakening the assertion),
+// the token endpoint is served from a "/token" path on the SAME registry
+// server instead of a second httptest.Server — its host:port then matches
+// the registry host:port and passes validateRealmURL legitimately. Object
+// storage remains a genuinely separate host, so the no-Authorization
+// assertion below still proves cross-host redirects strip auth.
+func TestFetch_Redirect_NoAuthForwarded(t *testing.T) {
+	data, h := deterministicBlob(300 * 1024)
+
+	// Object storage: serves ranges, records whether Authorization arrived.
+	var sawAuthOnStorage int64
+	storage := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			atomic.AddInt64(&sawAuthOnStorage, 1)
+		}
+		http.ServeContent(w, r, "blob", noTime, newReader(data))
+	}))
+	defer storage.Close()
+
+	// Registry: /v2/ challenges with Bearer (realm on this same server, see
+	// comment above); /token issues a bearer token; blob GET requires the
+	// token then redirects cross-host to object storage.
+	var registry *httptest.Server
+	registry = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.Header().Set("WWW-Authenticate",
+				fmt.Sprintf(`Bearer realm="%s/token",service="registry"`, registry.URL))
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.URL.Path == "/token" {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"token":"sekret"}`))
+			return
+		}
+		if strings.Contains(r.URL.Path, "/blobs/") {
+			if r.Header.Get("Authorization") != "Bearer sekret" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			http.Redirect(w, r, storage.URL+"/blob", http.StatusTemporaryRedirect)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer registry.Close()
+
+	dest := filepath.Join(t.TempDir(), "blob")
+	opts := blob.DefaultOptions()
+	opts.Transport = registry.Client().Transport
+	opts.ChunkThreshold = 64 * 1024
+	opts.ChunkSize = 64 * 1024
+	opts.Connections = 3
+
+	desc := v1.Descriptor{Digest: h, Size: int64(len(data))}
+	if err := blob.Fetch(context.Background(), refFor(t, registry, h), desc, dest, opts); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := fileDigest(t, dest); got != h.String() {
+		t.Fatalf("digest mismatch: got %s want %s", got, h.String())
+	}
+	if n := atomic.LoadInt64(&sawAuthOnStorage); n != 0 {
+		t.Fatalf("Authorization was forwarded to object storage %d time(s); must be 0", n)
+	}
+}
+
+// TestFetch_TransientRetry: one chunk fails twice then succeeds; per-chunk retry recovers.
+func TestFetch_TransientRetry(t *testing.T) {
+	data, h := deterministicBlob(200 * 1024)
+	var flaky int64 // counts requests to the [64Ki,128Ki) chunk
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/blobs/") {
+			if r.Header.Get("Range") == "bytes=65536-131071" {
+				if atomic.AddInt64(&flaky, 1) <= 2 {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+			}
+			http.ServeContent(w, r, "blob", noTime, newReader(data))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "blob")
+	opts := blob.DefaultOptions()
+	opts.Transport = srv.Client().Transport
+	opts.ChunkThreshold = 64 * 1024
+	opts.ChunkSize = 64 * 1024
+	opts.Connections = 2
+	opts.ChunkRetries = 3
+
+	desc := v1.Descriptor{Digest: h, Size: int64(len(data))}
+	if err := blob.Fetch(context.Background(), refFor(t, srv, h), desc, dest, opts); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := fileDigest(t, dest); got != h.String() {
+		t.Fatalf("digest mismatch: got %s want %s", got, h.String())
+	}
+	if n := atomic.LoadInt64(&flaky); n < 3 {
+		t.Fatalf("expected the flaky chunk to be retried to success (>=3 attempts), got %d", n)
+	}
+}
+
+// TestFetch_Ranged_FirstChunkTransientRetry: the probe (bytes=0-65535)
+// succeeds so ranged() proceeds to parallel assembly, but the *next* two
+// requests for that identical byte range fail transiently before succeeding.
+//
+// Pre-fix, the probe's body is trusted directly for chunk 0 — no further
+// request for that range is ever issued, so this scenario can't recover and
+// the test fails (only 1 request to the range: the probe).
+//
+// Post-fix, chunk 0 is fetched through the same fetchChunk path as every
+// other chunk: the probe becomes a pure capability check (body discarded)
+// and a fresh GET for bytes=0-65535 is retried with backoff like any other
+// chunk, recovering from the transient 500s.
+func TestFetch_Ranged_FirstChunkTransientRetry(t *testing.T) {
+	data, h := deterministicBlob(200 * 1024)
+	var flaky int64 // counts requests to the bytes=0-65535 range (probe's range)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/blobs/") {
+			if r.Header.Get("Range") == "bytes=0-65535" {
+				// Request 1 = probe: must succeed (206) so ranged() proceeds.
+				// Requests 2 and 3 = the first two fetchChunk attempts for
+				// chunk 0: fail transiently. Request 4 = the retry that
+				// succeeds.
+				if count := atomic.AddInt64(&flaky, 1); count == 2 || count == 3 {
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+			}
+			http.ServeContent(w, r, "blob", noTime, newReader(data))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "blob")
+	opts := blob.DefaultOptions()
+	opts.Transport = srv.Client().Transport
+	opts.ChunkThreshold = 64 * 1024
+	opts.ChunkSize = 64 * 1024
+	opts.Connections = 2
+	opts.ChunkRetries = 3
+
+	desc := v1.Descriptor{Digest: h, Size: int64(len(data))}
+	if err := blob.Fetch(context.Background(), refFor(t, srv, h), desc, dest, opts); err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+	if got := fileDigest(t, dest); got != h.String() {
+		t.Fatalf("digest mismatch: got %s want %s", got, h.String())
+	}
+	// Expect at least 4 requests to bytes=0-65535: 1 probe + 3 fetchChunk
+	// attempts (2 failures + 1 success) for chunk 0.
+	if n := atomic.LoadInt64(&flaky); n < 4 {
+		t.Fatalf("expected chunk 0 to be independently retried after the probe (>=4 requests to its range), got %d", n)
+	}
+}
+
+// TestFetch_ContextCancel: cancel mid-fetch → error and dest cleaned up.
+func TestFetch_ContextCancel(t *testing.T) {
+	data, h := deterministicBlob(2 * 1024 * 1024)
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if strings.Contains(r.URL.Path, "/blobs/") {
+			cancel() // cancel as soon as any blob request lands
+			http.ServeContent(w, r, "blob", noTime, newReader(data))
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	dest := filepath.Join(t.TempDir(), "blob")
+	opts := blob.DefaultOptions()
+	opts.Transport = srv.Client().Transport
+	opts.ChunkThreshold = 64 * 1024
+	opts.ChunkSize = 64 * 1024
+	opts.Connections = 4
+
+	desc := v1.Descriptor{Digest: h, Size: int64(len(data))}
+	err := blob.Fetch(ctx, refFor(t, srv, h), desc, dest, opts)
+	if err == nil {
+		t.Fatal("expected context cancellation error, got nil")
+	}
+	if _, statErr := os.Stat(dest); !os.IsNotExist(statErr) {
+		t.Fatalf("expected dest cleaned up after cancel, stat err = %v", statErr)
+	}
+}

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -94,6 +94,10 @@ const (
 	HaulerLogLevel     = "HAULER_LOG_LEVEL"
 	HaulerAuditLevel   = "HAULER_AUDIT_LEVEL"
 
+	HaulerBlobChunkThreshold = "HAULER_BLOB_CHUNK_THRESHOLD"
+	HaulerBlobConnections    = "HAULER_BLOB_CONNECTIONS"
+	HaulerBlobChunkSize      = "HAULER_BLOB_CHUNK_SIZE"
+
 	// container files and directories
 	ImageManifestFile = "manifest.json"
 	ImageConfigFile   = "config.json"

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -94,9 +94,9 @@ const (
 	HaulerLogLevel     = "HAULER_LOG_LEVEL"
 	HaulerAuditLevel   = "HAULER_AUDIT_LEVEL"
 
-	HaulerBlobChunkThreshold = "HAULER_BLOB_CHUNK_THRESHOLD"
-	HaulerBlobConnections    = "HAULER_BLOB_CONNECTIONS"
-	HaulerBlobChunkSize      = "HAULER_BLOB_CHUNK_SIZE"
+	HaulerBlobRangeThreshold   = "HAULER_BLOB_RANGE_THRESHOLD"
+	HaulerBlobRangeConcurrency = "HAULER_BLOB_RANGE_CONCURRENCY"
+	HaulerBlobRangeSize        = "HAULER_BLOB_RANGE_SIZE"
 
 	// container files and directories
 	ImageManifestFile = "manifest.json"

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -9,9 +9,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/containerd/errdefs"
+	units "github.com/docker/go-units"
 	"github.com/google/go-containerregistry/pkg/authn"
 	gname "github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -26,6 +28,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"hauler.dev/go/hauler/v2/pkg/artifacts"
+	"hauler.dev/go/hauler/v2/pkg/blob"
 	"hauler.dev/go/hauler/v2/pkg/consts"
 	"hauler.dev/go/hauler/v2/pkg/content"
 	"hauler.dev/go/hauler/v2/pkg/layer"
@@ -37,6 +40,7 @@ type Layout struct {
 	StoreID   string
 	haulerDir string
 	cache     layer.Cache
+	BlobOpts  blob.Options
 }
 
 type Options func(*Layout)
@@ -66,9 +70,10 @@ func NewLayout(rootdir string, opts ...Options) (*Layout, error) {
 	}
 
 	l := &Layout{
-		Root:    rootdir,
-		OCI:     ociStore,
-		StoreID: loadOrCreateStoreID(rootdir),
+		Root:     rootdir,
+		OCI:      ociStore,
+		StoreID:  loadOrCreateStoreID(rootdir),
+		BlobOpts: blob.DefaultOptions(),
 	}
 
 	for _, opt := range opts {
@@ -233,7 +238,7 @@ func (l *Layout) AddImage(ctx context.Context, ref string, platform string, excl
 		if err != nil {
 			return "", fmt.Errorf("getting index digest for %q: %w", ref, err)
 		}
-		if err := l.writeIndex(parsedRef, idx, consts.KindAnnotationIndex); err != nil {
+		if err := l.writeIndex(ctx, parsedRef, parsedRef, idx, consts.KindAnnotationIndex); err != nil {
 			return "", err
 		}
 	} else {
@@ -254,7 +259,7 @@ func (l *Layout) AddImage(ctx context.Context, ref string, platform string, excl
 		if err != nil {
 			return "", fmt.Errorf("getting image digest for %q: %w", ref, err)
 		}
-		if err := l.writeImage(parsedRef, img, consts.KindAnnotationImage, ""); err != nil {
+		if err := l.writeImage(ctx, parsedRef, parsedRef, img, consts.KindAnnotationImage, ""); err != nil {
 			return "", err
 		}
 	}
@@ -291,7 +296,7 @@ func (l *Layout) AddLocalImage(ctx context.Context, ref string) (string, error) 
 		return "", fmt.Errorf("getting image digest for %q: %w", ref, err)
 	}
 
-	if err := l.writeImage(parsedRef, img, consts.KindAnnotationImage, ""); err != nil {
+	if err := l.writeImage(ctx, nil, parsedRef, img, consts.KindAnnotationImage, ""); err != nil {
 		return "", err
 	}
 	return d.String(), nil
@@ -325,7 +330,7 @@ func ensureDockerHost() error {
 
 // writeImageBlobs writes all blobs for a single image (layers, config, manifest) to the store's
 // blob directory. It does not add an entry to the OCI index.
-func (l *Layout) writeImageBlobs(img v1.Image) error {
+func (l *Layout) writeImageBlobs(ctx context.Context, fetchRef gname.Reference, img v1.Image) error {
 	layers, err := img.Layers()
 	if err != nil {
 		return fmt.Errorf("getting layers: %w", err)
@@ -333,7 +338,7 @@ func (l *Layout) writeImageBlobs(img v1.Image) error {
 	var g errgroup.Group
 	for _, lyr := range layers {
 		lyr := lyr
-		g.Go(func() error { return l.writeLayer(lyr) })
+		g.Go(func() error { return l.writeLayerFrom(ctx, fetchRef, lyr) })
 	}
 	if err := g.Wait(); err != nil {
 		return err
@@ -357,8 +362,8 @@ func (l *Layout) writeImageBlobs(img v1.Image) error {
 // writeImage writes all blobs for img and adds a descriptor entry to the OCI index with the
 // given annotationRef and kind. containerdName overrides the io.containerd.image.name annotation;
 // if empty it defaults to annotationRef.Name().
-func (l *Layout) writeImage(annotationRef gname.Reference, img v1.Image, kind string, containerdName string) error {
-	if err := l.writeImageBlobs(img); err != nil {
+func (l *Layout) writeImage(ctx context.Context, fetchRef, annotationRef gname.Reference, img v1.Image, kind string, containerdName string) error {
+	if err := l.writeImageBlobs(ctx, fetchRef, img); err != nil {
 		return err
 	}
 
@@ -397,7 +402,7 @@ func (l *Layout) writeImage(annotationRef gname.Reference, img v1.Image, kind st
 
 // writeIndexBlobs recursively writes all child image blobs for an image index to the store's blob
 // directory. It does not write the top-level index manifest or add index entries.
-func (l *Layout) writeIndexBlobs(idx v1.ImageIndex) error {
+func (l *Layout) writeIndexBlobs(ctx context.Context, fetchRef gname.Reference, idx v1.ImageIndex) error {
 	manifest, err := idx.IndexManifest()
 	if err != nil {
 		return fmt.Errorf("getting index manifest: %w", err)
@@ -406,7 +411,7 @@ func (l *Layout) writeIndexBlobs(idx v1.ImageIndex) error {
 	for _, childDesc := range manifest.Manifests {
 		// Try as a nested index first, then fall back to a regular image.
 		if childIdx, err := idx.ImageIndex(childDesc.Digest); err == nil {
-			if err := l.writeIndexBlobs(childIdx); err != nil {
+			if err := l.writeIndexBlobs(ctx, fetchRef, childIdx); err != nil {
 				return err
 			}
 			raw, err := childIdx.RawManifest()
@@ -421,7 +426,7 @@ func (l *Layout) writeIndexBlobs(idx v1.ImageIndex) error {
 			if err != nil {
 				return fmt.Errorf("getting child image %v: %w", childDesc.Digest, err)
 			}
-			if err := l.writeImageBlobs(childImg); err != nil {
+			if err := l.writeImageBlobs(ctx, fetchRef, childImg); err != nil {
 				return err
 			}
 		}
@@ -431,8 +436,8 @@ func (l *Layout) writeIndexBlobs(idx v1.ImageIndex) error {
 
 // writeIndex writes all blobs for an image index (including all child platform images) and adds
 // a descriptor entry to the OCI index with the given annotationRef and kind.
-func (l *Layout) writeIndex(annotationRef gname.Reference, idx v1.ImageIndex, kind string) error {
-	if err := l.writeIndexBlobs(idx); err != nil {
+func (l *Layout) writeIndex(ctx context.Context, fetchRef, annotationRef gname.Reference, idx v1.ImageIndex, kind string) error {
+	if err := l.writeIndexBlobs(ctx, fetchRef, idx); err != nil {
 		return err
 	}
 
@@ -521,7 +526,7 @@ func (l *Layout) saveReferrers(ctx context.Context, ref gname.Reference, hash v1
 		// Embed the referrer manifest digest in the kind annotation so that multiple
 		// referrers for the same base image each get a unique entry in the OCI index.
 		kind := consts.KindAnnotationReferrers + "/" + referrerDesc.Digest.Hex
-		if err := l.writeImage(ref, img, kind, ""); err != nil {
+		if err := l.writeImage(ctx, ref, ref, img, kind, ""); err != nil {
 			return fmt.Errorf("saving OCI referrer %s for %s: %w", referrerDesc.Digest, ref.Name(), err)
 		}
 		log.Debug().Msgf("saved OCI referrer %s (%s) for %s", referrerDesc.Digest, string(referrerDesc.ArtifactType), ref.Name())
@@ -558,7 +563,7 @@ func (l *Layout) saveRelatedArtifacts(ctx context.Context, ref gname.Reference, 
 			// Artifact doesn't exist at this registry; skip silently.
 			continue
 		}
-		if err := l.writeImage(ref, img, r.kind, ""); err != nil {
+		if err := l.writeImage(ctx, ref, ref, img, r.kind, ""); err != nil {
 			return saved, fmt.Errorf("saving %s for %s: %w", r.kind, ref.Name(), err)
 		}
 		if d, err := img.Digest(); err == nil {
@@ -855,9 +860,97 @@ func (l *Layout) Identify(ctx context.Context, desc ocispec.Descriptor) string {
 	return m.Config.MediaType
 }
 
+// shortHex truncates a hex digest string to its first 12 characters for
+// compact log output, returning it unchanged if it's already shorter.
+func shortHex(hex string) string {
+	if len(hex) <= 12 {
+		return hex
+	}
+	return hex[:12]
+}
+
 func (l *Layout) writeBlobData(data []byte) error {
 	blob := static.NewLayer(data, "") // NOTE: MediaType isn't actually used in the writing
 	return l.writeLayer(blob)
+}
+
+// writeLayerFrom writes a single layer to the store's blob directory. For large
+// remote layers (fetchRef != nil, size >= threshold, connections > 1) it uses
+// the parallel ranged fetcher; otherwise it falls back to the single-stream
+// writeLayer path. The on-disk "already present" skip is honored first.
+func (l *Layout) writeLayerFrom(ctx context.Context, fetchRef gname.Reference, lyr v1.Layer) error {
+	if fetchRef == nil || l.BlobOpts.Connections <= 1 {
+		return l.writeLayer(lyr)
+	}
+
+	d, err := lyr.Digest()
+	if err != nil {
+		return err
+	}
+	size, err := lyr.Size()
+	if err != nil {
+		return err
+	}
+	if size < l.BlobOpts.ChunkThreshold {
+		return l.writeLayer(lyr)
+	}
+
+	dir := filepath.Join(l.Root, ocispec.ImageBlobsDir, d.Algorithm)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil && !os.IsExist(err) {
+		return err
+	}
+	blobPath := filepath.Join(dir, d.Hex)
+	// Skip entirely if the blob already exists (mirrors writeLayer).
+	if _, err := os.Stat(blobPath); err == nil {
+		return nil
+	}
+
+	// Fetch to a temp file in the same directory as blobPath (same
+	// filesystem is required for os.Rename to be atomic) rather than
+	// blobPath itself. blob.Fetch's ranged path truncates its destination to
+	// the full blob size up front to pre-size it for parallel writes; if the
+	// process crashed mid-assembly while fetching directly to blobPath, a
+	// full-size-but-incomplete file would be left there, and the "already
+	// present" skip above would trust it as complete on the next run. Using
+	// a temp sibling and only publishing via rename after blob.Fetch has
+	// already verified the sha256 digest guarantees only complete,
+	// verified blobs ever land at blobPath.
+	tmp, err := os.CreateTemp(dir, d.Hex+".*.tmp")
+	if err != nil {
+		return fmt.Errorf("creating temp file for blob %s: %w", d, err)
+	}
+	tmpPath := tmp.Name()
+	tmp.Close() // blob.Fetch opens/truncates/writes tmpPath itself
+
+	desc := v1.Descriptor{Digest: d, Size: size}
+	fetchStart := time.Now()
+	if err := blob.Fetch(ctx, fetchRef, desc, tmpPath, l.BlobOpts); err != nil {
+		// Defense-in-depth: blob.Fetch already removes its own dest file on
+		// any internal error, but clean up here too in case it didn't.
+		os.Remove(tmpPath)
+		return fmt.Errorf("fetching blob %s: %w", d, err)
+	}
+	elapsed := time.Since(fetchStart).Seconds()
+	if elapsed <= 0 {
+		elapsed = 1e-6
+	}
+	rate := (float64(size) / (1024 * 1024)) / elapsed
+	zerolog.Ctx(ctx).Info().Msgf("chunked blob fetch: sha256:%s… %s in %.1fs (%.1f MiB/s, %d conns x %s)",
+		shortHex(d.Hex), units.BytesSize(float64(size)), elapsed, rate, l.BlobOpts.Connections, units.BytesSize(float64(l.BlobOpts.ChunkSize)))
+	if err := os.Rename(tmpPath, blobPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("publishing blob %s: %w", d, err)
+	}
+	// os.CreateTemp always creates tmpPath at mode 0600 regardless of umask,
+	// and blob.Fetch's internal opens ignore their mode argument because
+	// tmpPath already exists by the time they run. Explicitly chmod the
+	// published blob so it matches the 0644 (umask-adjusted) permissions
+	// that writeLayer's os.Create path already produces for every other
+	// blob in the store.
+	if err := os.Chmod(blobPath, 0o644); err != nil {
+		return fmt.Errorf("setting permissions on blob %s: %w", d, err)
+	}
+	return nil
 }
 
 func (l *Layout) writeLayer(layer v1.Layer) error {

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -3,14 +3,18 @@ package store_test
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	ccontent "github.com/containerd/containerd/v2/core/content"
 	gname "github.com/google/go-containerregistry/pkg/name"
@@ -24,8 +28,10 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/rs/zerolog"
 
 	"hauler.dev/go/hauler/v2/pkg/artifacts"
+	"hauler.dev/go/hauler/v2/pkg/blob"
 	"hauler.dev/go/hauler/v2/pkg/consts"
 	"hauler.dev/go/hauler/v2/pkg/store"
 )
@@ -786,4 +792,430 @@ func TestAddImage_OCI11Referrers(t *testing.T) {
 		t.Fatal("expected at least one OCI referrer entry in the store, got none")
 	}
 	t.Logf("captured %d OCI referrer(s) for %s", referrerCount, baseTag.Name())
+}
+
+// TestAddImage_ChunkedMatchesSingleStream proves the store is byte-identical
+// whether large-layer chunking runs or not: same index.json and same blob files.
+func TestAddImage_ChunkedMatchesSingleStream(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	remoteOpts := []remote.Option{remote.WithTransport(srv.Client().Transport)}
+
+	// Build a single-arch image with one ~256 KiB layer and push it.
+	img, err := random.Image(256*1024, 1)
+	if err != nil {
+		t.Fatalf("random image: %v", err)
+	}
+	tag, err := gname.NewTag(host+"/test/big:v1", gname.Insecure)
+	if err != nil {
+		t.Fatalf("new tag: %v", err)
+	}
+	if err := remote.Write(tag, img, remoteOpts...); err != nil {
+		t.Fatalf("push image: %v", err)
+	}
+
+	// helper: pull into a fresh store with a given BlobOpts, return blob dir hash set.
+	pull := func(t *testing.T, bo blob.Options) (string, map[string][]byte) {
+		root := t.TempDir()
+		s, err := store.NewLayout(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bo.Transport = srv.Client().Transport // reach the in-process registry
+		s.BlobOpts = bo
+		if _, err := s.AddImage(ctx, tag.Name(), "", true, remoteOpts...); err != nil {
+			t.Fatalf("AddImage: %v", err)
+		}
+		if err := s.OCI.SaveIndex(); err != nil {
+			t.Fatal(err)
+		}
+		idx, err := os.ReadFile(filepath.Join(root, "index.json"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		blobs := map[string][]byte{}
+		base := filepath.Join(root, "blobs", "sha256")
+		entries, err := os.ReadDir(base)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range entries {
+			b, err := os.ReadFile(filepath.Join(base, e.Name()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			blobs[e.Name()] = b
+		}
+		return string(idx), blobs
+	}
+
+	// Single-stream: connections=1 disables chunking.
+	single := blob.DefaultOptions()
+	single.Connections = 1
+	singleIdx, singleBlobs := pull(t, single)
+
+	// Chunked: threshold + chunk size below the layer size to force ranged path.
+	chunked := blob.DefaultOptions()
+	chunked.Connections = 3
+	chunked.ChunkThreshold = 64 * 1024
+	chunked.ChunkSize = 64 * 1024
+	chunkedIdx, chunkedBlobs := pull(t, chunked)
+
+	if singleIdx != chunkedIdx {
+		t.Fatalf("index.json differs between single-stream and chunked pulls")
+	}
+	if len(singleBlobs) != len(chunkedBlobs) {
+		t.Fatalf("blob count differs: single=%d chunked=%d", len(singleBlobs), len(chunkedBlobs))
+	}
+	for name, sb := range singleBlobs {
+		cb, ok := chunkedBlobs[name]
+		if !ok {
+			t.Fatalf("blob %s missing from chunked pull", name)
+		}
+		if string(sb) != string(cb) {
+			t.Fatalf("blob %s differs between single-stream and chunked pulls", name)
+		}
+	}
+}
+
+// TestWriteLayerFrom_ChunkedFetch_NoLeftoverTempFile proves that a successful
+// chunked writeLayerFrom fetch (routed through a temp file + atomic rename)
+// leaves exactly the verified blob at its final path and no ".tmp" sibling
+// behind in the blobs directory.
+func TestWriteLayerFrom_ChunkedFetch_NoLeftoverTempFile(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	remoteOpts := []remote.Option{remote.WithTransport(srv.Client().Transport)}
+
+	img, err := random.Image(256*1024, 1)
+	if err != nil {
+		t.Fatalf("random image: %v", err)
+	}
+	tag, err := gname.NewTag(host+"/test/clean:v1", gname.Insecure)
+	if err != nil {
+		t.Fatalf("new tag: %v", err)
+	}
+	if err := remote.Write(tag, img, remoteOpts...); err != nil {
+		t.Fatalf("push image: %v", err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		t.Fatalf("layers: %v", err)
+	}
+	layerDigest, err := layers[0].Digest()
+	if err != nil {
+		t.Fatalf("layer digest: %v", err)
+	}
+
+	root := t.TempDir()
+	s, err := store.NewLayout(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bo := blob.DefaultOptions()
+	bo.Transport = srv.Client().Transport
+	bo.Connections = 3
+	bo.ChunkThreshold = 64 * 1024
+	bo.ChunkSize = 64 * 1024
+	s.BlobOpts = bo
+
+	if _, err := s.AddImage(ctx, tag.Name(), "", true, remoteOpts...); err != nil {
+		t.Fatalf("AddImage: %v", err)
+	}
+
+	dir := filepath.Join(root, "blobs", "sha256")
+	blobPath := filepath.Join(dir, layerDigest.Hex)
+	b, err := os.ReadFile(blobPath)
+	if err != nil {
+		t.Fatalf("reading final blob: %v", err)
+	}
+	sum := sha256.Sum256(b)
+	if got := "sha256:" + hex.EncodeToString(sum[:]); got != layerDigest.String() {
+		t.Fatalf("blob digest mismatch: got %s want %s", got, layerDigest.String())
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading blobs dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Fatalf("leftover temp file in blobs dir after successful fetch: %s", e.Name())
+		}
+	}
+}
+
+// TestWriteLayerFrom_ChunkedFetch_PublishedBlobPermissions proves that a blob
+// published through writeLayerFrom's temp-file-then-rename path ends up with
+// the same 0644 permissions as blobs written via the ordinary writeLayer
+// os.Create path, rather than inheriting os.CreateTemp's 0600 owner-only
+// mode. os.CreateTemp always creates its file at 0600 regardless of umask,
+// and blob.Fetch's internal os.OpenFile/os.Create calls silently ignore
+// their mode argument because the temp file already exists by the time they
+// run — so without an explicit chmod after the rename, chunked blobs would
+// be unreadable by anyone but the process that fetched them.
+func TestWriteLayerFrom_ChunkedFetch_PublishedBlobPermissions(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+
+	srv := httptest.NewServer(registry.New())
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	remoteOpts := []remote.Option{remote.WithTransport(srv.Client().Transport)}
+
+	img, err := random.Image(256*1024, 1)
+	if err != nil {
+		t.Fatalf("random image: %v", err)
+	}
+	tag, err := gname.NewTag(host+"/test/perms:v1", gname.Insecure)
+	if err != nil {
+		t.Fatalf("new tag: %v", err)
+	}
+	if err := remote.Write(tag, img, remoteOpts...); err != nil {
+		t.Fatalf("push image: %v", err)
+	}
+
+	layers, err := img.Layers()
+	if err != nil {
+		t.Fatalf("layers: %v", err)
+	}
+	layerDigest, err := layers[0].Digest()
+	if err != nil {
+		t.Fatalf("layer digest: %v", err)
+	}
+
+	root := t.TempDir()
+	s, err := store.NewLayout(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bo := blob.DefaultOptions()
+	bo.Transport = srv.Client().Transport
+	bo.Connections = 3
+	bo.ChunkThreshold = 64 * 1024
+	bo.ChunkSize = 64 * 1024
+	s.BlobOpts = bo
+
+	if _, err := s.AddImage(ctx, tag.Name(), "", true, remoteOpts...); err != nil {
+		t.Fatalf("AddImage: %v", err)
+	}
+
+	blobPath := filepath.Join(root, "blobs", "sha256", layerDigest.Hex)
+	info, err := os.Stat(blobPath)
+	if err != nil {
+		t.Fatalf("stat blob: %v", err)
+	}
+	if got, want := info.Mode().Perm(), os.FileMode(0o644); got != want {
+		t.Fatalf("chunked blob %s has permissions %o, want %o (blob published via temp-file rename must not retain os.CreateTemp's 0600 mode)", blobPath, got, want)
+	}
+}
+
+// TestWriteLayerFrom_ChunkedFetch_FailedFetchLeavesNoPartialOrTempFile proves
+// that when the ranged fetch of a large layer fails (digest verification
+// fails because the server serves corrupted content), no file — neither the
+// final blobPath nor any temp file — is left behind in the blobs directory.
+// This is the property that makes crash-mid-fetch safe: a corrupt/incomplete
+// blob can never reach the final path, because it only ever gets there via a
+// rename performed after blob.Fetch has already verified its digest.
+func TestWriteLayerFrom_ChunkedFetch_FailedFetchLeavesNoPartialOrTempFile(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+
+	backend := registry.New()
+
+	img, err := random.Image(256*1024, 1)
+	if err != nil {
+		t.Fatalf("random image: %v", err)
+	}
+	layers, err := img.Layers()
+	if err != nil {
+		t.Fatalf("layers: %v", err)
+	}
+	layerDigest, err := layers[0].Digest()
+	if err != nil {
+		t.Fatalf("layer digest: %v", err)
+	}
+	layerSize, err := layers[0].Size()
+	if err != nil {
+		t.Fatalf("layer size: %v", err)
+	}
+
+	// Corrupted content of the same size: real compressed layer content is
+	// never all-zero, so this reliably fails digest verification.
+	corrupt := make([]byte, layerSize)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/blobs/"+layerDigest.String()) {
+			http.ServeContent(w, r, "blob", time.Time{}, bytes.NewReader(corrupt))
+			return
+		}
+		backend.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	remoteOpts := []remote.Option{remote.WithTransport(srv.Client().Transport)}
+	tag, err := gname.NewTag(host+"/test/corrupt:v1", gname.Insecure)
+	if err != nil {
+		t.Fatalf("new tag: %v", err)
+	}
+	if err := remote.Write(tag, img, remoteOpts...); err != nil {
+		t.Fatalf("push image: %v", err)
+	}
+
+	root := t.TempDir()
+	s, err := store.NewLayout(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bo := blob.DefaultOptions()
+	bo.Transport = srv.Client().Transport
+	bo.Connections = 3
+	bo.ChunkThreshold = 64 * 1024
+	bo.ChunkSize = 64 * 1024
+	s.BlobOpts = bo
+
+	if _, err := s.AddImage(ctx, tag.Name(), "", true, remoteOpts...); err == nil {
+		t.Fatal("expected AddImage to fail due to corrupted blob content")
+	}
+
+	dir := filepath.Join(root, "blobs", "sha256")
+	blobPath := filepath.Join(dir, layerDigest.Hex)
+	if _, statErr := os.Stat(blobPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no blob at final path %s after failed fetch, stat err = %v", blobPath, statErr)
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, layerDigest.Hex+"*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no leftover files (final or temp) for %s after failed fetch, found %v", layerDigest.Hex, matches)
+	}
+}
+
+// TestWriteLayerFrom_ChunkedFetch_LogsThroughput proves that a successful
+// chunked writeLayerFrom fetch emits exactly one Info-level "chunked blob
+// fetch:" log line naming the fetched layer's digest, and that the
+// small/fallback (non-chunked) writeLayer path stays silent — no such line
+// is emitted when the blob is below ChunkThreshold or Connections<=1.
+func TestWriteLayerFrom_ChunkedFetch_LogsThroughput(t *testing.T) {
+	t.Run("chunked path logs throughput", func(t *testing.T) {
+		teardown := setup(t)
+		defer teardown()
+
+		srv := httptest.NewServer(registry.New())
+		t.Cleanup(srv.Close)
+		host := strings.TrimPrefix(srv.URL, "http://")
+		remoteOpts := []remote.Option{remote.WithTransport(srv.Client().Transport)}
+
+		img, err := random.Image(256*1024, 1)
+		if err != nil {
+			t.Fatalf("random image: %v", err)
+		}
+		tag, err := gname.NewTag(host+"/test/logthroughput:v1", gname.Insecure)
+		if err != nil {
+			t.Fatalf("new tag: %v", err)
+		}
+		if err := remote.Write(tag, img, remoteOpts...); err != nil {
+			t.Fatalf("push image: %v", err)
+		}
+
+		layers, err := img.Layers()
+		if err != nil {
+			t.Fatalf("layers: %v", err)
+		}
+		layerDigest, err := layers[0].Digest()
+		if err != nil {
+			t.Fatalf("layer digest: %v", err)
+		}
+
+		root := t.TempDir()
+		s, err := store.NewLayout(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bo := blob.DefaultOptions()
+		bo.Transport = srv.Client().Transport
+		bo.Connections = 3
+		bo.ChunkThreshold = 64 * 1024
+		bo.ChunkSize = 64 * 1024
+		s.BlobOpts = bo
+
+		var buf bytes.Buffer
+		logger := zerolog.New(&buf).Level(zerolog.InfoLevel)
+		logCtx := logger.WithContext(context.Background())
+
+		if _, err := s.AddImage(logCtx, tag.Name(), "", true, remoteOpts...); err != nil {
+			t.Fatalf("AddImage: %v", err)
+		}
+
+		out := buf.String()
+		if !strings.Contains(out, "chunked blob fetch:") {
+			t.Fatalf("expected log output to contain %q, got: %s", "chunked blob fetch:", out)
+		}
+		shortDigest := "sha256:" + layerDigest.Hex[:12]
+		if !strings.Contains(out, shortDigest) {
+			t.Fatalf("expected log output to contain short digest %q, got: %s", shortDigest, out)
+		}
+		if !strings.Contains(out, "conns x") {
+			t.Fatalf("expected log output to contain %q, got: %s", "conns x", out)
+		}
+	})
+
+	t.Run("fallback path stays silent", func(t *testing.T) {
+		teardown := setup(t)
+		defer teardown()
+
+		srv := httptest.NewServer(registry.New())
+		t.Cleanup(srv.Close)
+		host := strings.TrimPrefix(srv.URL, "http://")
+		remoteOpts := []remote.Option{remote.WithTransport(srv.Client().Transport)}
+
+		img, err := random.Image(256*1024, 1)
+		if err != nil {
+			t.Fatalf("random image: %v", err)
+		}
+		tag, err := gname.NewTag(host+"/test/logsilent:v1", gname.Insecure)
+		if err != nil {
+			t.Fatalf("new tag: %v", err)
+		}
+		if err := remote.Write(tag, img, remoteOpts...); err != nil {
+			t.Fatalf("push image: %v", err)
+		}
+
+		root := t.TempDir()
+		s, err := store.NewLayout(root)
+		if err != nil {
+			t.Fatal(err)
+		}
+		bo := blob.DefaultOptions()
+		bo.Transport = srv.Client().Transport
+		bo.Connections = 3
+		// Threshold above the layer's size forces the small/fallback path.
+		bo.ChunkThreshold = 10 * 1024 * 1024
+		bo.ChunkSize = 64 * 1024
+		s.BlobOpts = bo
+
+		var buf bytes.Buffer
+		logger := zerolog.New(&buf).Level(zerolog.InfoLevel)
+		logCtx := logger.WithContext(context.Background())
+
+		if _, err := s.AddImage(logCtx, tag.Name(), "", true, remoteOpts...); err != nil {
+			t.Fatalf("AddImage: %v", err)
+		}
+
+		out := buf.String()
+		if strings.Contains(out, "chunked blob fetch:") {
+			t.Fatalf("expected no %q in log output for fallback path, got: %s", "chunked blob fetch:", out)
+		}
+	})
 }


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

**Associated Links:**

-

**Types of Changes:**

- Feature (performance) — additive and backwards compatible; no breaking changes and no behavior change for blobs under the threshold.

**Proposed Changes:**

High level: large individual blobs (multi-GB image layers, ISOs stored as OCI artifacts) are currently pulled as a single HTTP stream, which leaves most of the available bandwidth unused on high-latency or lossy links. This adds parallel HTTP Range (RFC 7233) retrieval for large blobs on the pull path, with an automatic single-stream fallback when a registry doesn't honor Range.

Low level:

- **New `pkg/blob/`** — self-contained blob fetcher with no hauler-internal imports.
  - `Fetch()` builds an authenticated client via go-containerregistry's bearer transport (scoped to the registry host, so a cross-hrage carries no `Authorization` header), then either single-streams or parallelizes.
  - Blobs below `ChunkThreshold`, or `Connections <= 1`, take today's exact single-GET path.
  - The ranged path issues one ranged probe GET. A `206` confirms Range support and the file is assembled in parallel across a bounded `errgroup` worker pool; a `200` means the server ignored Range, so the body *is* the whole blob and is streamed straight through (no wasted round-trip).
  - The probe body is deliberately discarded and chunk 0 is refetched through the same `fetchChunk` path as every other chunk, trading one round-trip for uniform retry-safety and short-read checking.
  - Each chunk retries a bounded number of times with escalating backoff, re-issuing the GET to the blob endpoint so an expired presigned redirect (403) recovers via a fresh redirect.
  - The assembled file's sha256 is verified before it's considered good; on any error the destination is removed, so no partial or behind.

- **`pkg/store/`** — `Layout` gains a `BlobOpts blob.Options` field (defaulted in `NewLayout`). `writeImage`/`writeIndex`/`writeIma now thread `ctx` plus a `fetchRef` (the remote reference to fetch from, `nil` for local/daemon images) down to the new`writeLayerFrom`, which:
  - falls back to the existing `writeLayer` when there's no `fetchRef`, when concurrency is 1, or when the layer is under the threshold;
  - honors the existing "blob already on disk" skip first;
  - fetches into a temp sibling file and publishes via `os.Rename` only after digest verification. This matters because the ranged path pre-truncates its destination to the full blob size — fetching directly to the final blob path would leave a full-size-but-incomplete file after a crash that the on-disk skip would then trust on the next run;
  - `chmod 0644` on publish so chunked blobs match the permissions every other blob in the store gets (`os.CreateTemp` always creates at 0600);
  - logs `chunked blob fetch: sha256:<12 hex>… <size> in <s> (<MiB/s>, N conns x <chunk>)` at INFO.

- **`internal/flags/store.go`** — three new optional store-level flags with `flag > env var > built-in default` precedence, resolved by `BlobOptions()`:
  | Flag | Env | Default |
  |---|---|---|
  | `--range-concurrency` | `HAULER_BLOB_RANGE_CONCURRENCY` | `10` (`1` disables chunking) |
  | `--range-threshold` | `HAULER_BLOB_RANGE_THRESHOLD` | `100MiB` |
  | `--range-size` | `HAULER_BLOB_RANGE_SIZE` | `8MiB` |

  Sizes are human-readable and parsed with `docker/go-units` (promoted from an indirect to a direct dependency in `go.mod`); invalid values are a hard error rather than a silent fallback.

- **`pkg/consts/consts.go`** — the three new `HAULER_BLOB_RANGE_*` env var names.

**Verification/Testing of Changes:**

Automated — `make test` (all new tests pass, race detector on):

- `pkg/blob/blob_test.go` (9 tests, against `httptest` servers): below-threshold single stream; `Connections=1` forcing single stream; multi-chunk ranged assembly; `200`-instead-of-`206` fallback; digest mismatch deletes the destination; **no `Authorization` header forwarded across a
cross-host redirect**; transient-failure retry on both a normal chunk and the first chunk; context cancellation.
- `pkg/store/store_test.go`: `TestAddImage_ChunkedMatchesSingleStream` (byte-for-byte identical store contents chunked vs. not), plus `writeLayerFrom` tests for no leftover temp files, published blob permissions (0644), no partial/temp file left after a failed fetch, and the throughput log line.
- `internal/flags/store_test.go`: defaults, flags winning over env, env used when no flag, and bad values erroring.

Manual — real pull of a **9.8 GiB Harvester ISO** from Harbor (`registry.ranchercarbide.dev`, which 307-redirects to GovCloud S3):

```bash
# baseline (chunking disabled)
hauler store sync -f hauler-manifest.yaml --range-concurrency 1

# default chunked path
hauler store sync -f hauler-manifest.yaml

# explicit tuning
hauler store sync -f hauler-manifest.yaml \
  --range-concurrency 10 --range-threshold 100MiB --range-size 8MiB
```
Result: ~36.6 MiB/s chunked vs. ~15–17 MiB/s single-stream, roughly a 2x speedup. The chunked blob fetch: … INFO line reports the per-blob rate, and the resulting store is byte-identical either way.

To verify the fallback path, point at a registry that ignores Range — the fetch transparently degrades to a single stream with no error and no extra round-trip.

**Additional Context:**

* Medium-sized change, but the risk surface is narrow: everything below the 100 MiB threshold, every local/daemon-sourced image, and every registry that ignores Range all take the pre-existing code path unchanged, and --range-concurrency 1 is a complete opt-out.
* On the defaults — 10 connections × 8 MiB mirrors awscli/s3transfer (max_concurrent_requests=10, multipart_chunksize=8MB). More, smarate high-latency/lossy paths (like a registry → S3 redirect over a degraded airgap uplink) better than fewer, larger ones, sinceeach stream carries less unacknowledged data at risk on a stall or retry. That matched what the real-world Harbor pull showed. 