### PR TITLE
fix: process Helm deps before --add-images discovery

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -674,7 +674,21 @@ func storeChart(ctx context.Context, s *store.Layout, cfg v1.Chart, opts *flags.
 			}
 		}
 
-		values, err := commonutil.ToRenderValues(c, userValues, common.ReleaseOptions{Namespace: "hauler"}, caps)
+		// Reload a fresh chart for rendering so ProcessDependencies can safely
+		// rename aliased deps / drop disabled ones without mutating the chart
+		// used later by --add-dependencies.
+		renderChart, err := loader.Load(chrt.Path())
+		if err != nil {
+			return fmt.Errorf("failed to reload chart for image discovery: %w", err)
+		}
+
+		// Match helm install/template: coalesce parent values into subcharts
+		// (including dependency aliases) and honor conditions before rendering.
+		if err := util.ProcessDependencies(renderChart, userValues); err != nil {
+			return fmt.Errorf("failed to process chart dependencies for image discovery: %w", err)
+		}
+
+		values, err := commonutil.ToRenderValues(renderChart, userValues, common.ReleaseOptions{Namespace: "hauler"}, caps)
 		if err != nil {
 			return err
 		}
@@ -699,7 +713,7 @@ func storeChart(ctx context.Context, s *store.Layout, cfg v1.Chart, opts *flags.
 		)
 
 		// parse helm chart templates and values for images
-		rendered, err := engine.Render(c, values)
+		rendered, err := engine.Render(renderChart, values)
 		if err != nil {
 			// charts may fail due to values so still try helm chart annotations and lock
 			l.Warnf("%sfailed to render chart [%s]: %v", prefix, c.Name(), err)
@@ -785,7 +799,10 @@ func storeChart(ctx context.Context, s *store.Layout, cfg v1.Chart, opts *flags.
 
 			depOpts := *opts
 			depOpts.AddDependencies = true
-			depOpts.AddImages = true
+			// Do not rediscover images on dependency charts in isolation.
+			// Parent --add-images already renders the full tree (with alias
+			// overrides and conditions) after ProcessDependencies.
+			depOpts.AddImages = false
 			subCtx := context.WithValue(ctx, isSubchartKey{}, true)
 
 			var depCfg v1.Chart


### PR DESCRIPTION
## Summary

- Call Helm `ProcessDependencies` before `--add-images` template rendering so dependency **aliases** and **conditions** match `helm template` / install behavior
- Reload a fresh chart copy for that step so `--add-dependencies` still resolves original dependency names/paths
- Stop forcing `AddImages=true` when recursively adding dependencies (parent discovery already covers the processed tree)

Fixes #675

Replaces #676 (reopened with signed commits per maintainer request).

## Test plan

- [ ] `suse-observability-agent` `1.5.10` with minimal values (webhook disabled): discovered images match `helm template` (no `stackstate/container-tools`)
- [ ] Same chart with `httpHeaderInjectorWebhook.enabled=true`: discovers `suse-observability/container-tools:...` (not `stackstate/...` defaults)
- [ ] Parent chart with `--add-images --add-dependencies`: discovers overridden subchart images once; does not attempt un-overridden subchart defaults
- [ ] Existing `TestStoreChart_AddImages*` tests pass
