### PR TITLE
update hauler store remove to handle registry reference as part of string

### DIFF
--- a/cmd/hauler/cli/store/remove.go
+++ b/cmd/hauler/cli/store/remove.go
@@ -91,7 +91,12 @@ func RemoveCmd(ctx context.Context, o *flags.RemoveOpts, s *store.Layout, ref st
 	var matches []match
 
 	if err := s.Walk(func(reference string, desc ocispec.Descriptor) error {
-		if !strings.Contains(reference, ref) {
+		registryRef := desc.Annotations[consts.ContainerdImageNameKey]
+		if registryRef == "" {
+			registryRef = desc.Annotations[ocispec.AnnotationRefName]
+		}
+
+		if !strings.Contains(reference, ref) && !strings.Contains(registryRef, ref) {
 			return nil
 		}
 

--- a/cmd/hauler/cli/store/remove_test.go
+++ b/cmd/hauler/cli/store/remove_test.go
@@ -125,6 +125,40 @@ func TestRemoveCmd_NotFound(t *testing.T) {
 	}
 }
 
+// TestRemoveCmd_ContainerdImageName confirms that a
+// registry-prefixed ref (which only appears in the io.containerd.image.name
+// annotation, not the registry-stripped org.opencontainers.image.ref.name
+// used to key the store's nameMap) still matches for removal.
+func TestRemoveCmd_ContainerdImageName(t *testing.T) {
+	ctx := newTestContext(t)
+	s := newTestStore(t)
+	host, rOpts := newLocalhostRegistry(t)
+	seedImage(t, host, "test/repo", "v1", rOpts...)
+
+	rso := defaultRootOpts(s.Root)
+	ro := defaultCliOpts()
+
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/repo:v1"}, "", false, rso, ro, ""); err != nil {
+		t.Fatalf("storeImage: %v", err)
+	}
+
+	if n := countArtifactsInStore(t, s); n == 0 {
+		t.Fatal("expected at least 1 artifact after storeImage, got 0")
+	}
+
+	// The registry-qualified ref only lives in io.containerd.image.name;
+	// org.opencontainers.image.ref.name (and the nameMap key derived from it)
+	// only holds the registry-stripped short form "test/repo:v1".
+	fullRef := host + "/test/repo:v1"
+	if err := RemoveCmd(ctx, &flags.RemoveOpts{Force: true}, s, fullRef, ro, rso); err != nil {
+		t.Fatalf("RemoveCmd with fully-qualified ref: %v", err)
+	}
+
+	if n := countArtifactsInStore(t, s); n != 0 {
+		t.Errorf("expected 0 artifacts after removal by containerd image name, got %d", n)
+	}
+}
+
 func TestRemoveCmd_Force_MultipleMatches(t *testing.T) {
 	ctx := newTestContext(t)
 	s := newTestStore(t)


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [x] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- [BUGFIX]: hauler store remove did not handle specifying the registry as part of the string identifier because it was only comparing to the image repo/tag. 

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- the logic now checks for a match in the  ContainerdImageNameKey annotation which contains the registry prefix for images as well as the parsed reference (no registry).

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- add image to store 
- run hauler store remove index.docker.io/library/nginx:latest and the image is found and deleted 
- previously index.docker.io/library/nginx:latest would have returned no matches 

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
