### PR TITLE
feat: Add support for force registry relocation

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -720,20 +720,24 @@ func imagesFromImagesLock(chartDir string) ([]string, error) {
 	return out, nil
 }
 
-func applyDefaultRegistry(img string, defaultRegistry string) (string, error) {
+func applyDefaultRegistry(ctx context.Context, img string, defaultRegistry string, forceRegistry bool) (string, error) {
 	img = strings.TrimSpace(strings.TrimPrefix(img, "/"))
 	if img == "" || defaultRegistry == "" {
 		return img, nil
 	}
 
-	ref, err := reference.Parse(img)
-	if err != nil {
-		return "", err
+	if !forceRegistry {
+		ref, err := reference.Parse(img)
+		if err != nil {
+			return "", err
+		}
+
+		if ref.Context().RegistryStr() != "" {
+			return img, nil
+		}
 	}
 
-	if ref.Context().RegistryStr() != "" {
-		return img, nil
-	}
+	log.FromContext(ctx).Debugf("relocating image %s to registry %s", img, defaultRegistry)
 
 	newRef, err := reference.Relocate(img, defaultRegistry)
 	if err != nil {
@@ -828,6 +832,7 @@ func resolveChartJobs(o *flags.SyncOpts, annotations map[string]string, manifest
 				AddDependencies: ch.AddDependencies,
 				ExcludeExtras:   excludeExtras,
 				Registry:        registry,
+				ForceRegistry:   o.ForceRegistry,
 				Platform:        platform,
 				ValuesFiles:     valuesFiles,
 			},
@@ -1341,7 +1346,7 @@ func fetchChart(ctx context.Context, s *store.Layout, j chartJob, tempRoot strin
 		}
 
 		for _, image := range images {
-			relocated, err := applyDefaultRegistry(image, j.opts.Registry)
+			relocated, err := applyDefaultRegistry(ctx, image, j.opts.Registry, j.opts.ForceRegistry)
 			if err != nil {
 				if ignoreErrors {
 					l.Warnf("unable to apply registry to image [%s]: %v... skipping...", image, err)
@@ -1350,11 +1355,19 @@ func fetchChart(ctx context.Context, s *store.Layout, j chartJob, tempRoot strin
 				return nil, nil, fmt.Errorf("unable to apply registry to image [%s]: %w", image, err)
 			}
 
-			imageJobs = append(imageJobs, imageJob{
+			job := imageJob{
 				img:           v1.Image{Name: relocated},
 				platform:      j.opts.Platform,
 				excludeExtras: j.opts.ExcludeExtras,
-			})
+			}
+
+			if j.opts.ForceRegistry {
+				// ForceRegistry is only used for pulling the image, therefore the
+				// rewrite is set to the initial image
+				job.rewrite = image
+			}
+
+			imageJobs = append(imageJobs, job)
 		}
 	}
 

--- a/internal/flags/add.go
+++ b/internal/flags/add.go
@@ -59,6 +59,7 @@ type AddChartOpts struct {
 	ValuesFiles     []string
 	Platform        string
 	Registry        string
+	ForceRegistry   bool
 	KubeVersion     string
 	Concurrency     int
 	NoProgress      bool
@@ -88,6 +89,7 @@ func (o *AddChartOpts) AddFlags(cmd *cobra.Command) {
 	f.StringArrayVar(&o.ValuesFiles, "values", []string{}, "(Optional) Specify helm chart values when fetching images")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform of the image, e.g. linux/amd64")
 	f.StringVarP(&o.Registry, "registry", "g", "", "(Optional) Specify the registry of the image for images that do not alredy define one")
+	f.BoolVar(&o.ForceRegistry, "force-registry", false, "(Optional) Whether to always override the registry for images by the provided registry for the image pull")
 	f.StringVar(&o.KubeVersion, "kube-version", "v1.34.1", "(Optional) Override the kubernetes version for helm template rendering")
 	f.IntVarP(&o.Concurrency, "concurrency", "j", consts.DefaultConcurrency, "(Optional) Maximum number of charts and their discovered images to fetch and store concurrently (1 = serial; also via HAULER_CONCURRENCY, explicit flag wins)")
 	f.BoolVar(&o.NoProgress, "no-progress", false, "(Optional) Disable the live progress display")

--- a/internal/flags/sync.go
+++ b/internal/flags/sync.go
@@ -19,6 +19,7 @@ type SyncOpts struct {
 	Products                     []string
 	Platform                     string
 	Registry                     string
+	ForceRegistry                bool
 	ProductRegistry              string
 	Tlog                         bool
 	ExcludeExtras                bool
@@ -41,6 +42,7 @@ func (o *SyncOpts) AddFlags(cmd *cobra.Command) {
 	f.StringSliceVar(&o.Products, "products", []string{}, "(Optional) Specify the product name to fetch collections from the product registry i.e. rancher=v2.10.1,rke2=v1.31.5+rke2r1")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform of the image... i.e linux/amd64 (defaults to all)")
 	f.StringVarP(&o.Registry, "registry", "g", "", "(Optional) Specify the registry of the image for images that do not alredy define one")
+	f.BoolVar(&o.ForceRegistry, "force-registry", false, "(Optional) Whether to always override the registry for images by the provided registry for the image pull")
 	f.StringVarP(&o.ProductRegistry, "product-registry", "c", "", "(Optional) Specify the product registry. Defaults to RGS Carbide Registry (rgcrprod.azurecr.us)")
 	f.BoolVar(&o.Tlog, "use-tlog-verify", false, "(Optional) Allow transparency log verification (defaults to false)")
 	f.BoolVar(&o.ExcludeExtras, "exclude-extras", false, "(Optional) Exclude cosign signatures, attestations, SBOMs, and OCI referrers when pulling images")


### PR DESCRIPTION
Hey, this PR is not meant to be merged and more the baseline for a discussion for a feature request.

We are using Rancher Hauler to sync container images and Helm charts to our airgapped registry. We are then customizing the imported assets (e.g.  by building wrapper charts with additional resources and additional configuration). Additionally, we are building custom container images and Helm charts. We want to use Hauler in our airgapped environment to generate a haul that is based on the previously imported and also custom assets. The biggest challenge doing this, was the fact, that the Helm charts sometimes still reference public container images like `quay.io/argoproj/argocd:v3.5.0` that need a rewrite to our internal registry for building the haul. In RKE2 we solve this topic using the `registries.yaml` described in https://docs.rke2.io/install/private_registry using containerd rewrites.

Do you know of any known architectures, solving this issue? Does Hauler already support this use-case?

Example usage of the current PR:

```
★ ./hauler store sync --force-registry --registry internal-registry.something.com/path -f out/default/argocd.yaml -p linux/amd64 -l debug
2026-08-07 10:44:44 DBG running cli command [hauler store sync]
2026-08-07 10:44:44 DBG defaulted $DOCKER_CONFIG to [/home/user/.docker] for registry credential resolution
2026-08-07 10:44:44 DBG using store at [/opt/haulbot/store]
2026-08-07 10:44:44 DBG generated store id of [f30c3747-2919-4294-bd17-ad5291df427a]
2026-08-07 10:44:44 DBG using temporary directory at [/tmp/hauler2673304074]
2026-08-07 10:44:44 INF processing manifest [out/default/argocd.yaml] to store [/opt/haulbot/store]
2026-08-07 10:44:44 INF syncing content [content.hauler.cattle.io/v1] with [kind=Charts] to store [/opt/haulbot/store]
2026-08-07 10:44:44 DBG adding chart [argo-cd] to the store
2026-08-07 10:44:45 DBG generated audit id of [019fdb65-6b2d-7ebc-a211-3b0ac617dfb7] chart=argo-cd
2026-08-07 10:44:45 DBG extracting chart archive [3dcbeba98dbaab8e864d57f31325550e14d67cf5d364fbea3346c9d30683a71c.chart] chart=argo-cd
2026-08-07 10:44:45 DBG image references identified for helm template: [2] image(s) chart=argo-cd
2026-08-07 10:44:45 DBG image references identified for helm chart annotations: [0] image(s) chart=argo-cd
2026-08-07 10:44:45 DBG image references identified for helm image lock file: [0] image(s) chart=argo-cd
2026-08-07 10:44:45 DBG successfully parsed and deduped image references: [2] image(s) chart=argo-cd
2026-08-07 10:44:45 DBG successfully parsed image references [ecr-public.aws.com/docker/library/redis:8.2.3-alpine quay.io/argoproj/argocd:v3.5.0] chart=argo-cd
2026-08-07 10:44:45 INF identified [2] image(s) in [argo-cd:4.3.1]
2026-08-07 10:44:45 DBG relocating image ecr-public.aws.com/docker/library/redis:8.2.3-alpine to registry internal-registry.something.com/path chart=argo-cd
2026-08-07 10:44:45 DBG relocating image quay.io/argoproj/argocd:v3.5.0 to registry internal-registry.something.com/path chart=argo-cd
2026-08-07 10:44:45 INF ✓ added hauler/argo-cd:4.3.1 (1 layer, 288 kB, 0.6s)
2026-08-07 10:44:45 INF identified 2 unique image(s) across 1 chart(s)
2026-08-07 10:44:45 DBG adding image [internal-registry.something.com/path/argoproj/argocd:v3.5.0] to the store
2026-08-07 10:44:45 DBG adding image [internal-registry.something.com/path/docker/library/redis:8.2.3-alpine] to the store
2026-08-07 10:44:45 INF rewriting [internal-registry.something.com/path/docker/library/redis:8.2.3-alpine] to [ecr-public.aws.com/docker/library/redis:8.2.3-alpine]
2026-08-07 10:44:45 DBG generated audit id of [019fdb65-6b2d-7ebc-a211-3b0ac617dfb7] image=internal-registry.something.com/path/docker/library/redis:8.2.3-alpine
2026-08-07 10:44:45 INF ✓ added internal-registry.something.com/path/docker/library/redis:8.2.3-alpine (7 layers, 28 MB, 0.5s)
2026-08-07 10:44:46 INF rewriting [internal-registry.something.com/path/argoproj/argocd:v3.5.0] to [quay.io/argoproj/argocd:v3.5.0]
2026-08-07 10:44:46 DBG generated audit id of [019fdb65-6b2d-7ebc-a211-3b0ac617dfb7] image=internal-registry.something.com/path/argoproj/argocd:v3.5.0
2026-08-07 10:44:46 INF ✓ added internal-registry.something.com/path/argoproj/argocd:v3.5.0 (16 layers, 210 MB, 1.4s)
2026-08-07 10:44:46 INF processing completed successfully


★ ./hauler store info
┌──────────────────────────────────────────────────────┬───────┬─────────────┬───────────┬──────────┐
│ REFERENCE                                            │ TYPE  │ PLATFORM    │ #  LAYERS │ SIZE     │
├──────────────────────────────────────────────────────┼───────┼─────────────┼───────────┼──────────┤
│ ecr-public.aws.com/docker/library/redis:8.2.3-alpine │ image │ linux/amd64 │ 7         │ 27.5 MB  │
│ hauler/argo-cd:4.3.1                                 │ chart │ -           │ 1         │ 288.1 kB │
│ quay.io/argoproj/argocd:v3.5.0                       │ image │ linux/amd64 │ 16        │ 209.9 MB │
├──────────────────────────────────────────────────────┼───────┼─────────────┼───────────┼──────────┤
│ store-path: /opt/haulbot/store                       │       │             │     Total │ 237.7 MB │
│ store-id: f30c3747-2919-4294-bd17-ad5291df427a       │       │             │           │          │
└──────────────────────────────────────────────────────┴───────┴─────────────┴───────────┴──────────┘
```

The change of the current PR just solves it to some degree, but having broader support for a `registries.yaml` like the following one would be my proposal:
```
mirrors:
  docker.io:
    endpoint:
      - "https://registry.example.com:5000"
    rewrite:
      "^rancher/(.*)": "mirrorproject/rancher-images/$1"
```

Thanks in advance :blush: 