### PR TITLE
standardize handling of flags, env vars, and annotations

### DIFF
--- a/cmd/hauler/cli/cli.go
+++ b/cmd/hauler/cli/cli.go
@@ -18,7 +18,7 @@ func New(ctx context.Context, ro *flags.CliRootOpts) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "hauler",
 		Short:   "Airgap Swiss Army Knife",
-		Example: "  View the Docs: https://docs.hauler.dev\n  Environment Variables: " + consts.HaulerDir + " | " + consts.HaulerTempDir + " | " + consts.HaulerStoreDir + " | " + consts.HaulerIgnoreErrors + " | " + consts.HaulerLogLevel + " | " + consts.HaulerAuditLevel + " | " + consts.HaulerConcurrency + " | " + consts.HaulerBlobConcurrency + "\n  Warnings: Hauler commands and flags marked with (EXPERIMENTAL) are not yet stable and may change in the future.",
+		Example: "  View the Docs: https://docs.hauler.dev\n  Environment Variables: " + consts.HaulerDir + " | " + consts.HaulerTempDir + " | " + consts.HaulerStoreDir + " | " + consts.HaulerIgnoreErrors + " | " + consts.HaulerRetries + " | " + consts.HaulerLogLevel + " | " + consts.HaulerAuditLevel + " | " + consts.HaulerConcurrency + " | " + consts.HaulerBlobConcurrency + "\n  Warnings: Hauler commands and flags marked with (EXPERIMENTAL) are not yet stable and may change in the future.",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			// check for log level env variable or flag
 			if ro.LogLevel == "" {

--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -1002,11 +1002,8 @@ func runChartJobs(ctx context.Context, s *store.Layout, jobs []chartJob, concurr
 
 	l := log.FromContext(ctx)
 
-	tempOverride := rso.TempOverride
-	if tempOverride == "" {
-		tempOverride = os.Getenv(consts.HaulerTempDir)
-	}
-	tempRoot, err := os.MkdirTemp(tempOverride, consts.DefaultHaulerTempDirName)
+	// rso.TempOverride is already resolved (flag or HAULER_TEMP_DIR) by Store().
+	tempRoot, err := os.MkdirTemp(rso.TempOverride, consts.DefaultHaulerTempDirName)
 	if err != nil {
 		return fmt.Errorf("failed to create temp dir: %w", err)
 	}

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -31,11 +31,8 @@ var legacyChunkRe = regexp.MustCompile(`_\d+\.`)
 func LoadCmd(ctx context.Context, o *flags.LoadOpts, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
 	l := log.FromContext(ctx)
 
+	// rso.TempOverride is already resolved (flag or HAULER_TEMP_DIR) by Store().
 	tempOverride := rso.TempOverride
-
-	if tempOverride == "" {
-		tempOverride = os.Getenv(consts.HaulerTempDir)
-	}
 
 	tempDir, err := os.MkdirTemp(tempOverride, consts.DefaultHaulerTempDirName)
 	if err != nil {

--- a/cmd/hauler/cli/store/sync.go
+++ b/cmd/hauler/cli/store/sync.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -104,27 +105,33 @@ func SyncCmd(ctx context.Context, o *flags.SyncOpts, s *store.Layout, rso *flags
 		return nil
 	}
 
+	// caches stores opened via hauler.dev/store, keyed by abs path, so docs sharing a target reuse one Layout
+	targetStores := map[string]*store.Layout{}
+
 	// Everything below runs with a real store (s != nil; the dry-run branch
 	// above already returned). Force one durable index checkpoint at the end
 	// of the run since the per-artifact path only fsyncs on
 	// indexCheckpointInterval -- deferred so it still runs on error paths,
 	// where a partially-populated index is worth persisting. This does NOT
 	// run on Ctrl-C (no signal handler is installed), which is fine: process
-	// death doesn't lose page cache, so the index still reaches disk.
+	// death doesn't lose page cache, so the index still reaches disk. Covers
+	// any target stores from hauler.dev/store too, not just the primary one.
 	defer func() {
 		if err := s.OCI.SaveIndex(); err != nil {
 			l.Warnf("failed to save index at end of sync: %v", err)
 		}
 		l.Debugf("%s", formatIOStats(s.OCI.Stats().Snapshot(), s.OCI.BlobConcurrency()))
+
+		for _, ts := range targetStores {
+			if err := ts.OCI.SaveIndex(); err != nil {
+				l.Warnf("failed to save index for target store [%s]: %v", ts.Root, err)
+			}
+			l.Debugf("%s", formatIOStats(ts.OCI.Stats().Snapshot(), ts.OCI.BlobConcurrency()))
+		}
 	}()
 
-	tempOverride := rso.TempOverride
-
-	if tempOverride == "" {
-		tempOverride = os.Getenv(consts.HaulerTempDir)
-	}
-
-	tempDir, err := os.MkdirTemp(tempOverride, consts.DefaultHaulerTempDirName)
+	// rso.TempOverride is already resolved (flag or HAULER_TEMP_DIR) by Store().
+	tempDir, err := os.MkdirTemp(rso.TempOverride, consts.DefaultHaulerTempDirName)
 	if err != nil {
 		return err
 	}
@@ -164,7 +171,7 @@ func SyncCmd(ctx context.Context, o *flags.SyncOpts, s *store.Layout, rso *flags
 			return err
 		}
 		defer fi.Close()
-		err = processContent(ctx, fi, o, s, rso, ro)
+		err = processContent(ctx, fi, o, s, rso, ro, targetStores)
 		if err != nil {
 			return err
 		}
@@ -214,7 +221,7 @@ func SyncCmd(ctx context.Context, o *flags.SyncOpts, s *store.Layout, rso *flags
 			}
 			defer fi.Close()
 
-			err = processContent(ctx, fi, o, s, rso, ro)
+			err = processContent(ctx, fi, o, s, rso, ro, targetStores)
 			if err != nil {
 				return err
 			}
@@ -278,7 +285,7 @@ func SyncCmd(ctx context.Context, o *flags.SyncOpts, s *store.Layout, rso *flags
 	return nil
 }
 
-func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *store.Layout, rso *flags.StoreRootOpts, ro *flags.CliRootOpts) error {
+func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *store.Layout, rso *flags.StoreRootOpts, ro *flags.CliRootOpts, targetStores map[string]*store.Layout) error {
 	l := log.FromContext(ctx)
 
 	reader := yaml.NewYAMLReader(bufio.NewReader(fi))
@@ -303,7 +310,6 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 		}
 
 		gvk := obj.GroupVersionKind()
-		l.Infof("syncing content [%s] with [kind=%s] to store [%s]", gvk.GroupVersion(), gvk.Kind, o.StoreDir)
 
 		switch gvk.Kind {
 
@@ -314,8 +320,18 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 				if err := yaml.Unmarshal(doc, &cfg); err != nil {
 					return err
 				}
+				a := cfg.GetAnnotations()
+				docStore, err := resolveTargetStore(ctx, a, s, rso, ro, targetStores)
+				if err != nil {
+					return err
+				}
+				docRso, err := resolveDocRetries(a, rso)
+				if err != nil {
+					return err
+				}
+				l.Infof("syncing content [%s] with [kind=%s] to store [%s]", gvk.GroupVersion(), gvk.Kind, docStore.Root)
 				jobs := resolveFileJobs(cfg.Spec.Files)
-				if err := runFileJobs(ctx, s, jobs, o.Concurrency, rso, ro, newSyncProgress(o, ro)); err != nil {
+				if err := runFileJobs(ctx, docStore, jobs, o.Concurrency, docRso, ro, newSyncProgress(o, ro)); err != nil {
 					return err
 				}
 
@@ -332,11 +348,20 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 				}
 
 				a := cfg.GetAnnotations()
+				docStore, err := resolveTargetStore(ctx, a, s, rso, ro, targetStores)
+				if err != nil {
+					return err
+				}
+				docRso, err := resolveDocRetries(a, rso)
+				if err != nil {
+					return err
+				}
+				l.Infof("syncing content [%s] with [kind=%s] to store [%s]", gvk.GroupVersion(), gvk.Kind, docStore.Root)
 				jobs, err := resolveImageJobs(o, a, cfg.Spec.Images)
 				if err != nil {
 					return err
 				}
-				if err := runImageJobs(ctx, s, jobs, o.Concurrency, rso, ro, newSyncProgress(o, ro)); err != nil {
+				if err := runImageJobs(ctx, docStore, jobs, o.Concurrency, docRso, ro, newSyncProgress(o, ro)); err != nil {
 					return err
 				}
 
@@ -351,11 +376,21 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 				if err := yaml.Unmarshal(doc, &cfg); err != nil {
 					return err
 				}
-				jobs, err := resolveChartJobs(o, cfg.GetAnnotations(), filepath.Dir(fi.Name()), cfg.Spec.Charts)
+				a := cfg.GetAnnotations()
+				docStore, err := resolveTargetStore(ctx, a, s, rso, ro, targetStores)
 				if err != nil {
 					return err
 				}
-				if err := runChartJobs(ctx, s, jobs, o.Concurrency, rso, ro, newSyncProgress(o, ro)); err != nil {
+				docRso, err := resolveDocRetries(a, rso)
+				if err != nil {
+					return err
+				}
+				l.Infof("syncing content [%s] with [kind=%s] to store [%s]", gvk.GroupVersion(), gvk.Kind, docStore.Root)
+				jobs, err := resolveChartJobs(o, a, filepath.Dir(fi.Name()), cfg.Spec.Charts)
+				if err != nil {
+					return err
+				}
+				if err := runChartJobs(ctx, docStore, jobs, o.Concurrency, docRso, ro, newSyncProgress(o, ro)); err != nil {
 					return err
 				}
 
@@ -368,6 +403,64 @@ func processContent(ctx context.Context, fi *os.File, o *flags.SyncOpts, s *stor
 		}
 	}
 	return nil
+}
+
+// resolveTargetStore picks a doc's store based on its hauler.dev/store annotation,
+// falling back to def. Opens (or reuses, via targetStores) the target store otherwise.
+func resolveTargetStore(ctx context.Context, a map[string]string, def *store.Layout, rso *flags.StoreRootOpts, ro *flags.CliRootOpts, targetStores map[string]*store.Layout) (*store.Layout, error) {
+	target := a[consts.AnnotationTargetStore]
+	if target == "" {
+		return def, nil
+	}
+
+	abs, err := flags.ResolveStoreDir(ctx, ro, target)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve target store [%s]: %w", target, err)
+	}
+
+	if abs == def.Root {
+		return def, nil
+	}
+
+	if ts, ok := targetStores[abs]; ok {
+		return ts, nil
+	}
+
+	// only overriding StoreDir, everything else still comes from rso
+	altOpts := *rso
+	altOpts.StoreDir = abs
+	ts, err := altOpts.Store(ctx, ro)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open target store [%s]: %w", target, err)
+	}
+
+	targetStores[abs] = ts
+	return ts, nil
+}
+
+// resolveDocRetries returns a copy of rso with Retries overridden by a doc's
+// hauler.dev/retries annotation, or rso unchanged if it's not set. Copy, not
+// mutation, so it can't leak into a sibling doc.
+func resolveDocRetries(a map[string]string, rso *flags.StoreRootOpts) (*flags.StoreRootOpts, error) {
+	v, ok := a[consts.AnnotationRetries]
+	if !ok || v == "" {
+		return rso, nil
+	}
+
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return nil, fmt.Errorf("invalid %s value %q: %w", consts.AnnotationRetries, v, err)
+	}
+	if n < 0 {
+		return nil, fmt.Errorf("%s must be >= 0, got %d", consts.AnnotationRetries, n)
+	}
+	if n == 0 {
+		n = consts.DefaultRetries
+	}
+
+	docRso := *rso
+	docRso.Retries = n
+	return &docRso, nil
 }
 
 // resolveChartCreds reads credentials for a Chart entry from the env vars

--- a/cmd/hauler/cli/store/sync_test.go
+++ b/cmd/hauler/cli/store/sync_test.go
@@ -179,10 +179,127 @@ spec:
 	o := newSyncOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro); err != nil {
+	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro, map[string]*store.Layout{}); err != nil {
 		t.Fatalf("processContent Files v1: %v", err)
 	}
 	assertArtifactInStore(t, s, "synced.sh")
+}
+
+// a doc with hauler.dev/store set routes there instead of the default; one without it stays put.
+func TestProcessContent_Files_v1_TargetStoreAnnotation(t *testing.T) {
+	ctx := newTestContext(t)
+	s := newTestStore(t)
+	altDir := t.TempDir()
+
+	defaultURL := seedFileInHTTPServer(t, "default.sh", "#!/bin/sh\necho default")
+	routedURL := seedFileInHTTPServer(t, "routed.sh", "#!/bin/sh\necho routed")
+
+	manifest := fmt.Sprintf(`apiVersion: content.hauler.cattle.io/v1
+kind: Files
+metadata:
+  name: default-files
+spec:
+  files:
+    - path: %s
+---
+apiVersion: content.hauler.cattle.io/v1
+kind: Files
+metadata:
+  name: routed-files
+  annotations:
+    hauler.dev/store: %s
+spec:
+  files:
+    - path: %s
+`, defaultURL, altDir, routedURL)
+
+	fi := writeManifestFile(t, manifest)
+	o := newSyncOpts(s.Root)
+	ro := defaultCliOpts()
+	targetStores := map[string]*store.Layout{}
+
+	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro, targetStores); err != nil {
+		t.Fatalf("processContent Files v1 with target store: %v", err)
+	}
+
+	assertArtifactInStore(t, s, "default.sh")
+	assertArtifactNotInStore(t, s, "routed.sh")
+
+	altAbs, err := filepath.Abs(altDir)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	alt, ok := targetStores[altAbs]
+	if !ok {
+		t.Fatalf("expected a target store opened at %s, got %v", altAbs, targetStores)
+	}
+	assertArtifactInStore(t, alt, "routed.sh")
+	assertArtifactNotInStore(t, alt, "default.sh")
+}
+
+// --------------------------------------------------------------------------
+// resolveDocRetries tests
+// --------------------------------------------------------------------------
+
+func TestResolveDocRetries_NoAnnotation_ReturnsRsoUnchanged(t *testing.T) {
+	rso := defaultRootOpts(t.TempDir())
+	rso.Retries = 5
+
+	got, err := resolveDocRetries(map[string]string{}, rso)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != rso {
+		t.Fatal("expected the same *StoreRootOpts back when the annotation is absent")
+	}
+}
+
+func TestResolveDocRetries_Override_ReturnsCopyNotMutation(t *testing.T) {
+	rso := defaultRootOpts(t.TempDir())
+	rso.Retries = 5
+
+	got, err := resolveDocRetries(map[string]string{consts.AnnotationRetries: "9"}, rso)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got == rso {
+		t.Fatal("expected a copy, not the same *StoreRootOpts, when the annotation overrides retries")
+	}
+	if got.Retries != 9 {
+		t.Fatalf("got Retries %d, want 9", got.Retries)
+	}
+	if rso.Retries != 5 {
+		t.Fatalf("original rso.Retries mutated to %d, want unchanged 5", rso.Retries)
+	}
+}
+
+func TestResolveDocRetries_ZeroMeansDefault(t *testing.T) {
+	rso := defaultRootOpts(t.TempDir())
+	rso.Retries = 5
+
+	got, err := resolveDocRetries(map[string]string{consts.AnnotationRetries: "0"}, rso)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Retries != consts.DefaultRetries {
+		t.Fatalf("got Retries %d, want default %d", got.Retries, consts.DefaultRetries)
+	}
+}
+
+func TestResolveDocRetries_Negative_ReturnsError(t *testing.T) {
+	rso := defaultRootOpts(t.TempDir())
+
+	if _, err := resolveDocRetries(map[string]string{consts.AnnotationRetries: "-1"}, rso); err == nil {
+		t.Fatal("expected an error for a negative hauler.dev/retries value, got nil")
+	}
+}
+
+func TestResolveDocRetries_NotANumber_ReturnsError(t *testing.T) {
+	rso := defaultRootOpts(t.TempDir())
+
+	if _, err := resolveDocRetries(map[string]string{consts.AnnotationRetries: "banana"}, rso); err == nil {
+		t.Fatal("expected an error for a non-numeric hauler.dev/retries value, got nil")
+	}
 }
 
 func TestProcessContent_Charts_v1(t *testing.T) {
@@ -206,7 +323,7 @@ spec:
 	o := newSyncOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro); err != nil {
+	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro, map[string]*store.Layout{}); err != nil {
 		t.Fatalf("processContent Charts v1: %v", err)
 	}
 	assertArtifactInStore(t, s, "rancher-cluster-templates")
@@ -232,7 +349,7 @@ spec:
 	o := newSyncOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro); err != nil {
+	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro, map[string]*store.Layout{}); err != nil {
 		t.Fatalf("processContent Images v1: %v", err)
 	}
 	assertArtifactInStore(t, s, "myorg/myimage")
@@ -254,7 +371,7 @@ metadata:
 	o := newSyncOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro); err == nil {
+	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro, map[string]*store.Layout{}); err == nil {
 		t.Fatal("expected error for unsupported kind, got nil")
 	}
 }
@@ -279,7 +396,7 @@ spec:
 	o := newSyncOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro); err != nil {
+	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro, map[string]*store.Layout{}); err != nil {
 		t.Fatalf("expected nil for unrecognized apiVersion (warn-and-skip), got: %v", err)
 	}
 	if n := countArtifactsInStore(t, s); n != 0 {
@@ -325,7 +442,7 @@ spec:
 	o := newSyncOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro); err != nil {
+	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro, map[string]*store.Layout{}); err != nil {
 		t.Fatalf("processContent MultiDoc: %v", err)
 	}
 	assertArtifactInStore(t, s, "multi.sh")
@@ -1142,7 +1259,7 @@ spec:
 	o := newSyncOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro); err != nil {
+	if err := processContent(ctx, fi, o, s, o.StoreRootOpts, ro, map[string]*store.Layout{}); err != nil {
 		t.Fatalf("processContent: %v", err)
 	}
 

--- a/cmd/hauler/cli/store/testhelpers_test.go
+++ b/cmd/hauler/cli/store/testhelpers_test.go
@@ -344,6 +344,20 @@ func assertArtifactInStore(t *testing.T, s *store.Layout, refSubstring string) {
 	}
 }
 
+// assertArtifactNotInStore is assertArtifactInStore's opposite: fails if any
+// descriptor's AnnotationRefName contains refSubstring.
+func assertArtifactNotInStore(t *testing.T, s *store.Layout, refSubstring string) {
+	t.Helper()
+	if err := s.OCI.Walk(func(_ string, desc ocispec.Descriptor) error {
+		if strings.Contains(desc.Annotations[ocispec.AnnotationRefName], refSubstring) {
+			t.Errorf("expected no artifact with ref containing %q, found one in store", refSubstring)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("assertArtifactNotInStore walk: %v", err)
+	}
+}
+
 // assertArtifactKindInStore walks the store and fails if no descriptor has an
 // AnnotationRefName containing refSubstring AND KindAnnotationName equal to kind.
 func assertArtifactKindInStore(t *testing.T, s *store.Layout, refSubstring, kind string) {

--- a/internal/flags/retries.go
+++ b/internal/flags/retries.go
@@ -1,0 +1,36 @@
+package flags
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"hauler.dev/go/hauler/v2/pkg/consts"
+)
+
+// ResolveRetries resolves flag > HAULER_RETRIES > default, same shape as
+// ResolveBlobConcurrency. 0 means "use the default", not "never retry".
+func ResolveRetries(flagValue int) (int, error) {
+	if flagValue < 0 {
+		return 0, fmt.Errorf("--retries must be >= 0, got %d", flagValue)
+	}
+	if flagValue > 0 {
+		return flagValue, nil
+	}
+
+	v := os.Getenv(consts.HaulerRetries)
+	if v == "" {
+		return consts.DefaultRetries, nil
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s value %q: %w", consts.HaulerRetries, v, err)
+	}
+	if n < 0 {
+		return 0, fmt.Errorf("%s must be >= 0, got %d", consts.HaulerRetries, n)
+	}
+	if n == 0 {
+		return consts.DefaultRetries, nil
+	}
+	return n, nil
+}

--- a/internal/flags/store.go
+++ b/internal/flags/store.go
@@ -36,17 +36,17 @@ type StoreRootOpts struct {
 func (o *StoreRootOpts) AddFlags(cmd *cobra.Command) {
 	pf := cmd.PersistentFlags()
 	pf.StringVarP(&o.StoreDir, "store", "s", "", "Set the directory to use for the content store")
-	pf.IntVarP(&o.Retries, "retries", "r", consts.DefaultRetries, "Set the number of retries for operations")
+	pf.IntVarP(&o.Retries, "retries", "r", 0, fmt.Sprintf("Set the number of retries for operations (0 uses HAULER_RETRIES, otherwise defaults to %d)", consts.DefaultRetries))
 	pf.StringVarP(&o.TempOverride, "tempdir", "t", "", "(Optional) Override the default temporary directory determined by the OS")
 	pf.IntVar(&o.BlobConcurrency, "blob-concurrency", 0, fmt.Sprintf("(Optional) Override the maximum number of concurrent blob writes (0 auto-derives from --concurrency where set, otherwise defaults to %d)", consts.DefaultBlobConcurrency))
 }
 
-func (o *StoreRootOpts) Store(ctx context.Context, ro *CliRootOpts) (*store.Layout, error) {
+// ResolveStoreDir turns storeDir into an absolute path without opening a store for it --
+// split out of Store() so sync can check a target store's path before deciding to open one.
+func ResolveStoreDir(ctx context.Context, ro *CliRootOpts, storeDir string) (string, error) {
 	l := log.FromContext(ctx)
 
 	haulerDir := resolveHaulerDir(ro)
-
-	storeDir := o.StoreDir
 
 	if storeDir == "" {
 		storeDir = os.Getenv(consts.HaulerStoreDir)
@@ -62,22 +62,33 @@ func (o *StoreRootOpts) Store(ctx context.Context, ro *CliRootOpts) (*store.Layo
 		switch {
 		case rerr == nil:
 			if !store.MatchesStoreID(resolved, id) {
-				return nil, fmt.Errorf("store id %q was last seen at %s, but that path no longer contains that store", storeDir, resolved)
+				return "", fmt.Errorf("store id %q was last seen at %s, but that path no longer contains that store", storeDir, resolved)
 			}
 			l.Debugf("resolved store id [%s] to [%s]", storeDir, resolved)
 			storeDir = resolved
 		case storeIDPattern.MatchString(storeDir):
 			// looks like an ID, not a directory name to create
-			return nil, fmt.Errorf("no store found matching id %q (for directories, use the absolute path)", storeDir)
+			return "", fmt.Errorf("no store found matching id %q (for directories, use the absolute path)", storeDir)
 		}
 	}
 
-	abs, err := filepath.Abs(storeDir)
+	return filepath.Abs(storeDir)
+}
+
+func (o *StoreRootOpts) Store(ctx context.Context, ro *CliRootOpts) (*store.Layout, error) {
+	l := log.FromContext(ctx)
+
+	abs, err := ResolveStoreDir(ctx, ro, o.StoreDir)
 	if err != nil {
 		return nil, err
 	}
 
 	o.StoreDir = abs
+
+	// resolved once here, same as StoreDir/BlobConcurrency below
+	if o.TempOverride == "" {
+		o.TempOverride = os.Getenv(consts.HaulerTempDir)
+	}
 
 	l.Debugf("using store at [%s]", abs)
 
@@ -103,7 +114,14 @@ func (o *StoreRootOpts) Store(ctx context.Context, ro *CliRootOpts) (*store.Layo
 	}
 	o.BlobConcurrency = bc
 
-	opts := []store.Options{store.WithHaulerDir(haulerDir)}
+	// same reasoning as BlobConcurrency above
+	retries, err := ResolveRetries(o.Retries)
+	if err != nil {
+		return nil, err
+	}
+	o.Retries = retries
+
+	opts := []store.Options{store.WithHaulerDir(resolveHaulerDir(ro))}
 	if o.BlobConcurrency > 0 {
 		opts = append(opts, store.WithBlobConcurrency(o.BlobConcurrency))
 	}

--- a/internal/flags/store_retries_test.go
+++ b/internal/flags/store_retries_test.go
@@ -1,0 +1,86 @@
+package flags
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"hauler.dev/go/hauler/v2/pkg/consts"
+)
+
+// TestAddFlagsRegistersRetries verifies the flag is registered as a
+// persistent flag on the parent command, so every store subcommand inherits
+// it rather than only `store sync`.
+func TestAddFlagsRegistersRetries(t *testing.T) {
+	o := &StoreRootOpts{}
+	cmd := &cobra.Command{Use: "store"}
+	o.AddFlags(cmd)
+
+	f := cmd.PersistentFlags().Lookup("retries")
+	if f == nil {
+		t.Fatal("expected --retries to be registered as a persistent flag")
+	}
+	if f.DefValue != "0" {
+		t.Fatalf("expected default value 0 (unset), got %q", f.DefValue)
+	}
+}
+
+// TestStoreResolvesRetriesFromEnv verifies that a subcommand which never
+// touches --retries directly -- `store add`, `store load`, `store copy` --
+// still picks up HAULER_RETRIES.
+func TestStoreResolvesRetriesFromEnv(t *testing.T) {
+	t.Setenv(consts.HaulerRetries, "7")
+	t.Setenv(consts.HaulerStoreDir, t.TempDir())
+	t.Setenv(consts.HaulerDir, t.TempDir())
+
+	o := &StoreRootOpts{}
+	if _, err := o.Store(t.Context(), &CliRootOpts{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if o.Retries != 7 {
+		t.Fatalf("got Retries %d, want 7", o.Retries)
+	}
+}
+
+// TestStoreLeavesExplicitRetriesAlone verifies Store() does not overwrite an
+// explicit --retries with HAULER_RETRIES.
+func TestStoreLeavesExplicitRetriesAlone(t *testing.T) {
+	t.Setenv(consts.HaulerRetries, "7")
+	t.Setenv(consts.HaulerStoreDir, t.TempDir())
+	t.Setenv(consts.HaulerDir, t.TempDir())
+
+	o := &StoreRootOpts{Retries: 2}
+	if _, err := o.Store(t.Context(), &CliRootOpts{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if o.Retries != 2 {
+		t.Fatalf("got Retries %d, want 2 (env must not override)", o.Retries)
+	}
+}
+
+// TestStoreDefaultsRetriesWhenUnset verifies Store() falls back to
+// consts.DefaultRetries when neither --retries nor HAULER_RETRIES is set.
+func TestStoreDefaultsRetriesWhenUnset(t *testing.T) {
+	t.Setenv(consts.HaulerStoreDir, t.TempDir())
+	t.Setenv(consts.HaulerDir, t.TempDir())
+
+	o := &StoreRootOpts{}
+	if _, err := o.Store(t.Context(), &CliRootOpts{}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if o.Retries != consts.DefaultRetries {
+		t.Fatalf("got Retries %d, want default %d", o.Retries, consts.DefaultRetries)
+	}
+}
+
+// TestStoreRejectsNegativeRetries verifies that a negative --retries
+// surfaces an error instead of being silently dropped, same as
+// --blob-concurrency.
+func TestStoreRejectsNegativeRetries(t *testing.T) {
+	t.Setenv(consts.HaulerStoreDir, t.TempDir())
+	t.Setenv(consts.HaulerDir, t.TempDir())
+
+	o := &StoreRootOpts{Retries: -5}
+	if _, err := o.Store(t.Context(), &CliRootOpts{}); err == nil {
+		t.Fatal("expected an error for negative --retries, got nil")
+	}
+}

--- a/pkg/audit/audit.go
+++ b/pkg/audit/audit.go
@@ -149,8 +149,11 @@ func BuildGlobal(ro *flags.CliRootOpts, rso *flags.StoreRootOpts) GlobalEntry {
 		consts.HaulerTempDir,
 		consts.HaulerStoreDir,
 		consts.HaulerIgnoreErrors,
+		consts.HaulerRetries,
 		consts.HaulerLogLevel,
 		consts.HaulerAuditLevel,
+		consts.HaulerConcurrency,
+		consts.HaulerBlobConcurrency,
 	} {
 		if v := os.Getenv(key); v != "" {
 			env[key] = v

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -61,6 +61,11 @@ const (
 	SigstoreBundleMediaType = "application/vnd.dev.sigstore.bundle.v0.3+json"
 	OCIEmptyConfigMediaType = "application/vnd.oci.empty.v1+json"
 
+	// annotations used by all artifacts
+	AnnotationTargetStore = "hauler.dev/store"
+	AnnotationRetries     = "hauler.dev/retries"
+
+	// annotations used by images
 	ImageAnnotationKey           = "hauler.dev/key"
 	ImageAnnotationPlatform      = "hauler.dev/platform"
 	ImageAnnotationRegistry      = "hauler.dev/registry"
@@ -80,7 +85,7 @@ const (
 	ImagesContentKind = "Images"
 	ChartsContentKind = "Charts"
 	FilesContentKind  = "Files"
-	// DriverContentKind    = "Driver"
+	// DriverContentKind = "Driver"
 
 	// content groups
 	ContentGroup    = "content.hauler.cattle.io"
@@ -91,6 +96,7 @@ const (
 	HaulerTempDir         = "HAULER_TEMP_DIR"
 	HaulerStoreDir        = "HAULER_STORE_DIR"
 	HaulerIgnoreErrors    = "HAULER_IGNORE_ERRORS"
+	HaulerRetries         = "HAULER_RETRIES"
 	HaulerConcurrency     = "HAULER_CONCURRENCY"
 	HaulerBlobConcurrency = "HAULER_BLOB_CONCURRENCY"
 	HaulerLogLevel        = "HAULER_LOG_LEVEL"
@@ -118,18 +124,9 @@ const (
 	DefaultStoreInventoryName = "stores.json"
 	DefaultRetries            = 3
 	RetriesInterval           = 5
-	// DefaultConcurrency bounds the number of images that `store sync` pulls
-	// and stores concurrently. See flags.ResolveConcurrency and
-	// flags.BlobConcurrencyFor for how this feeds into the per-store blob
-	// write ceiling (DefaultBlobConcurrency below).
-	DefaultConcurrency = 5
-	// DefaultBlobConcurrency bounds the number of blob writes (layer
-	// downloads, config/manifest writes) that may be in flight at once across
-	// the whole process, regardless of how many images or errgroups are
-	// fanning out concurrently. See content.OCI.WriteBlob and
-	// content.ociPusher.Push, the two call sites that acquire against it.
-	DefaultBlobConcurrency = 16
-	CustomTimeFormat       = "2006-01-02 15:04:05"
+	DefaultConcurrency        = 5
+	DefaultBlobConcurrency    = 16
+	CustomTimeFormat          = "2006-01-02 15:04:05"
 )
 
 var FileExcludePattern = fmt.Sprintf(`^%s/[.\-_]`, DefaultNamespace)


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- N/A

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Added `hauler.dev/store` annotation so `manifests` for `images`, `charts`, and `files` can route its own content to a different store than `--store`
  - Fixes... #392
- Added `hauler.dev/retries` annotation so `manifests` can override the number of `retries`
  - Added the `HAULER_RETRIES` env var for `--retries`
- Centralized `--tempdir`/`HAULER_TEMP_DIR` resolution into `StoreRootOpts.Store()`
  - Replaces the three separate copies of the same fallback logic
- Removed `hauler.dev/rewrite`, a `annotation` in `manifests` constant that was defined but intentionally never implemented based on the original PR for `rewrites`
- Updated the env var listings in `--help` and verbose audit logging to include the vars above

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- N/A

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
