### PR TITLE
feat: added hauler copy command

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -216,7 +216,43 @@ jobs:
       - name: Verify - hauler store copy
         run: |
           hauler store copy --help
-          # need more tests here
+          # verify via registry target
+          hauler store serve registry --port 5002 --readonly=false &
+          until curl -sf http://localhost:5002/v2/_catalog; do : ; done
+          hauler store copy registry://localhost:5002 --plain-http
+          # verify blobs actually landed in the registry backend
+          [ $(find registry -type f | wc -l) -gt 0 ]
+          # verify --only is accepted (a registry seeded fresh at startup from the
+          # whole store can't prove exclusion here -- registry-side filtering is
+          # covered by --only's own unit tests)
+          hauler store copy registry://localhost:5002 --plain-http --only busybox
+          pkill -f "hauler store serve registry --port 5002"
+          rm -rf registry
+          # verify via directory target (files and charts only; images and cosign artifacts are skipped)
+          hauler store copy dir://./store-copy-output
+          test -f ./store-copy-output/hauler-manifest.yaml
+          rm -rf ./store-copy-output
+
+      - name: Verify - hauler copy
+        run: |
+          hauler copy --help
+          # source registry (seeded from the store, which already has busybox)
+          hauler store serve registry --port 5004 --readonly=false --directory registry-src &
+          until curl -sf http://localhost:5004/v2/_catalog; do : ; done
+          # destination registry
+          hauler store serve registry --port 5005 --readonly=false --directory registry-dst &
+          until curl -sf http://localhost:5005/v2/_catalog; do : ; done
+          # verify a direct registry-to-registry copy, bypassing the store
+          # (destination path is deliberately distinct from anything the destination
+          # registry auto-seeded at startup, so its presence proves the copy, not the seed)
+          hauler copy localhost:5004/hauler-dev/library/busybox:latest localhost:5005/mycopy/busybox:latest --plain-http
+          test -d registry-dst/docker/registry/v2/repositories/mycopy/busybox
+          # verify --platform copies a single platform out of the index
+          hauler copy localhost:5004/hauler-dev/library/busybox:latest localhost:5005/mycopy/busybox-platform:amd64 --plain-http --platform linux/amd64
+          test -d registry-dst/docker/registry/v2/repositories/mycopy/busybox-platform
+          pkill -f "hauler store serve registry --port 5004"
+          pkill -f "hauler store serve registry --port 5005"
+          rm -rf registry-src registry-dst
 
       - name: Verify - hauler store extract
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -222,9 +222,7 @@ jobs:
           hauler store copy registry://localhost:5002 --plain-http
           # verify blobs actually landed in the registry backend
           [ $(find registry -type f | wc -l) -gt 0 ]
-          # verify --only is accepted (a registry seeded fresh at startup from the
-          # whole store can't prove exclusion here -- registry-side filtering is
-          # covered by --only's own unit tests)
+          # verify via --only
           hauler store copy registry://localhost:5002 --plain-http --only busybox
           pkill -f "hauler store serve registry --port 5002"
           rm -rf registry
@@ -236,19 +234,17 @@ jobs:
       - name: Verify - hauler copy
         run: |
           hauler copy --help
-          # source registry (seeded from the store, which already has busybox)
+          # start source registry
           hauler store serve registry --port 5004 --readonly=false --directory registry-src &
           until curl -sf http://localhost:5004/v2/_catalog; do : ; done
-          # destination registry
+          # start destination registry
           hauler store serve registry --port 5005 --readonly=false --directory registry-dst &
           until curl -sf http://localhost:5005/v2/_catalog; do : ; done
-          # verify a direct registry-to-registry copy, bypassing the store
-          # (destination path is deliberately distinct from anything the destination
-          # registry auto-seeded at startup, so its presence proves the copy, not the seed)
-          hauler copy localhost:5004/hauler-dev/library/busybox:latest localhost:5005/mycopy/busybox:latest --plain-http
+          # verify a direct registry to registry copy
+          hauler copy localhost:5004/custom-path/busybox:stable localhost:5005/mycopy/busybox:latest --plain-http
           test -d registry-dst/docker/registry/v2/repositories/mycopy/busybox
           # verify --platform copies a single platform out of the index
-          hauler copy localhost:5004/hauler-dev/library/busybox:latest localhost:5005/mycopy/busybox-platform:amd64 --plain-http --platform linux/amd64
+          hauler copy localhost:5004/custom-path/busybox:stable localhost:5005/mycopy/busybox-platform:amd64 --plain-http --platform linux/amd64
           test -d registry-dst/docker/registry/v2/repositories/mycopy/busybox-platform
           pkill -f "hauler store serve registry --port 5004"
           pkill -f "hauler store serve registry --port 5005"

--- a/cmd/hauler/cli/cli.go
+++ b/cmd/hauler/cli/cli.go
@@ -69,6 +69,7 @@ func New(ctx context.Context, ro *flags.CliRootOpts) *cobra.Command {
 	cmd.AddCommand(cranecmd.NewCmdAuthLogin("hauler"))
 	cmd.AddCommand(cranecmd.NewCmdAuthLogout("hauler"))
 	addStore(cmd, ro)
+	addCopy(cmd, ro)
 	addVersion(cmd, ro)
 	addCompletion(cmd, ro)
 

--- a/cmd/hauler/cli/copy.go
+++ b/cmd/hauler/cli/copy.go
@@ -25,7 +25,7 @@ func addCopy(parent *cobra.Command, ro *flags.CliRootOpts) {
 	cmd := &cobra.Command{
 		Use:     "copy SRC DST",
 		Aliases: []string{"cp"},
-		Short:   "Copy an artifact between registries",
+		Short:   "(EXPERIMENTAL) Copy an artifact between registries",
 		Example: `  # copy an image to another registry
   hauler copy busybox:latest registry.example.com/busybox:latest
 

--- a/cmd/hauler/cli/copy.go
+++ b/cmd/hauler/cli/copy.go
@@ -1,0 +1,176 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+	gname "github.com/google/go-containerregistry/pkg/name"
+	gv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/spf13/cobra"
+
+	"hauler.dev/go/hauler/v2/internal/flags"
+	"hauler.dev/go/hauler/v2/pkg/audit"
+	"hauler.dev/go/hauler/v2/pkg/content"
+	"hauler.dev/go/hauler/v2/pkg/log"
+	"hauler.dev/go/hauler/v2/pkg/retry"
+	"hauler.dev/go/hauler/v2/pkg/store"
+)
+
+func addCopy(parent *cobra.Command, ro *flags.CliRootOpts) {
+	o := &flags.ImageCopyOpts{}
+
+	cmd := &cobra.Command{
+		Use:     "copy SRC DST",
+		Aliases: []string{"cp"},
+		Short:   "Copy an artifact between registries",
+		Example: `  # copy an image to another registry
+  hauler copy busybox:latest registry.example.com/busybox:latest
+
+  # copy a specific platform out of a multi-arch image
+  hauler copy ghcr.io/hauler-dev/hauler-debug:v2.0.3 registry.example.com/hauler-debug:v2.0.3 --platform linux/amd64
+
+  # copy to a registry with a self-signed certificate
+  hauler copy busybox:latest registry.example.com/busybox:latest --insecure-skip-tls-verify
+
+  # copy to a registry with no TLS at all
+  hauler copy busybox:latest registry.example.com/busybox:latest --plain-http`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return CopyImageCmd(cmd.Context(), o, args[0], args[1], ro)
+		},
+	}
+	o.AddFlags(cmd)
+	parent.AddCommand(cmd)
+}
+
+// CopyImageCmd copies src to dst directly, registry to registry, no store involved.
+func CopyImageCmd(ctx context.Context, o *flags.ImageCopyOpts, src, dst string, ro *flags.CliRootOpts) error {
+	l := log.FromContext(ctx)
+
+	retries, err := flags.ResolveRetries(o.Retries)
+	if err != nil {
+		return err
+	}
+
+	tr, err := content.BuildTransport(o.InsecureSkipTLSVerify, o.CaFile)
+	if err != nil {
+		return err
+	}
+
+	opts := []remote.Option{
+		remote.WithAuthFromKeychain(authn.DefaultKeychain),
+		remote.WithContext(ctx),
+		remote.WithTransport(tr),
+	}
+
+	var nameOpts []gname.Option
+	if o.PlainHTTP {
+		nameOpts = append(nameOpts, gname.Insecure)
+	}
+
+	srcRef, err := gname.ParseReference(src, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parsing source reference %q: %w", src, err)
+	}
+	dstRef, err := gname.ParseReference(dst, nameOpts...)
+	if err != nil {
+		return fmt.Errorf("parsing destination reference %q: %w", dst, err)
+	}
+
+	l.Infof("copying [%s] to [%s]", src, dst)
+
+	start := time.Now()
+	var digest string
+	err = retry.Operation(ctx, &flags.StoreRootOpts{Retries: retries}, ro, func() error {
+		d, copyErr := copyOnce(srcRef, dstRef, o.Platform, opts)
+		if copyErr == nil {
+			digest = d
+		}
+		return copyErr
+	})
+	if err != nil {
+		l.Errorf("unable to copy [%s] to [%s]: %v", src, dst, err)
+		return err
+	}
+
+	if flags.AuditLevel(ro) != "none" {
+		e := audit.Entry{
+			Command:   "copy",
+			Args:      []string{src, dst},
+			Type:      "image",
+			Reference: dst,
+			Digest:    digest,
+		}
+		if flags.AuditLevel(ro) == "verbose" {
+			sys := audit.BuildSystem()
+			g := audit.BuildGlobal(ro, nil)
+			e.System = &sys
+			e.Global = &g
+			e.Flags = map[string]any{
+				"insecure-skip-tls-verify": o.InsecureSkipTLSVerify,
+				"plain-http":               o.PlainHTTP,
+				"ca-file":                  o.CaFile,
+				"platform":                 o.Platform,
+			}
+		}
+		if err := audit.Append(ro.HaulerDir, e); err != nil {
+			l.Warnf("failed to write audit entry: %v", err)
+		}
+		l.Debugf("generated audit id of [%s]", audit.ID())
+	} else {
+		l.Debugf("generated audit id of [none]")
+	}
+
+	l.Infof("✓ copied [%s] to [%s] (%.1fs)", src, dst, time.Since(start).Seconds())
+
+	return nil
+}
+
+// copyOnce copies srcRef to dstRef and returns the digest copied. No
+// platform filter keeps a multi-arch index intact; platform picks one child.
+func copyOnce(srcRef, dstRef gname.Reference, platform string, opts []remote.Option) (string, error) {
+	desc, err := remote.Get(srcRef, opts...)
+	if err != nil {
+		return "", fmt.Errorf("fetching descriptor for %q: %w", srcRef.Name(), err)
+	}
+
+	if idx, idxErr := desc.ImageIndex(); idxErr == nil && platform == "" {
+		if err := remote.WriteIndex(dstRef, idx, opts...); err != nil {
+			return "", fmt.Errorf("writing index for %q: %w", dstRef.Name(), err)
+		}
+		d, err := idx.Digest()
+		if err != nil {
+			return "", fmt.Errorf("getting index digest for %q: %w", srcRef.Name(), err)
+		}
+		return d.String(), nil
+	}
+
+	var img gv1.Image
+	if platform != "" {
+		p, err := store.ParsePlatform(platform)
+		if err != nil {
+			return "", err
+		}
+		img, err = remote.Image(srcRef, append(append([]remote.Option{}, opts...), remote.WithPlatform(p))...)
+		if err != nil {
+			return "", fmt.Errorf("fetching image %q: %w", srcRef.Name(), err)
+		}
+	} else {
+		img, err = desc.Image()
+		if err != nil {
+			return "", fmt.Errorf("fetching image %q: %w", srcRef.Name(), err)
+		}
+	}
+
+	if err := remote.Write(dstRef, img, opts...); err != nil {
+		return "", fmt.Errorf("writing image for %q: %w", dstRef.Name(), err)
+	}
+	d, err := img.Digest()
+	if err != nil {
+		return "", fmt.Errorf("getting image digest for %q: %w", srcRef.Name(), err)
+	}
+	return d.String(), nil
+}

--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -310,8 +310,8 @@ func addStoreCopy(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 		Use:   "copy",
 		Short: "Copy all store content to another location",
 		Example: `  # supported copy target prefixes
-	registry://  | reg:// | oci:// - Pushes the store to an OCI registry
-	directory:// | dir://          - Extracts the store to a directory`,
+  registry://  | reg:// | oci:// - Pushes the store to an OCI registry
+  directory:// | dir://          - Extracts the store to a directory`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -354,13 +354,13 @@ func addStoreAddFile(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Com
 		Use:   "file",
 		Short: "Add a file to the store",
 		Example: `  # fetch local file
-	hauler store add file file.txt
+  hauler store add file file.txt
 
-	# fetch remote file
-	hauler store add file https://get.rke2.io/install.sh
+  # fetch remote file
+  hauler store add file https://get.rke2.io/install.sh
 
-	# fetch remote file and assign new name
-	hauler store add file https://get.hauler.dev --name hauler-install.sh`,
+  # fetch remote file and assign new name
+  hauler store add file https://get.hauler.dev --name hauler-install.sh`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -384,27 +384,27 @@ func addStoreAddImage(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "image",
 		Short: "Add a image to the store",
-		Example: `	# fetch image
-	hauler store add image busybox
+		Example: `  # fetch image
+  hauler store add image busybox
 
-	# fetch image with repository and tag
-	hauler store add image library/busybox:stable
+  # fetch image with repository and tag
+  hauler store add image library/busybox:stable
 
-	# fetch image with full image reference and specific platform
-	hauler store add image ghcr.io/hauler-dev/hauler-debug:v1.2.0 --platform linux/amd64
+  # fetch image with full image reference and specific platform
+  hauler store add image ghcr.io/hauler-dev/hauler-debug:v1.2.0 --platform linux/amd64
 
-	# fetch image with full image reference via digest
-	hauler store add image gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5
+  # fetch image with full image reference via digest
+  hauler store add image gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5
 
-	# fetch image with full image reference, specific platform, and signature verification
-	curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/main/carbide-key.pub
-	hauler store add image rgcrprod.azurecr.us/rancher/rke2-runtime:v1.31.5-rke2r1 --platform linux/amd64 --key carbide-key.pub
+  # fetch image with full image reference, specific platform, and signature verification
+  curl -sfOL https://raw.githubusercontent.com/rancherfederal/carbide-releases/main/carbide-key.pub
+  hauler store add image rgcrprod.azurecr.us/rancher/rke2-runtime:v1.31.5-rke2r1 --platform linux/amd64 --key carbide-key.pub
 
-	# fetch image and rewrite path
-	hauler store add image busybox --rewrite custom-path/busybox:latest
+  # fetch image and rewrite path
+  hauler store add image busybox --rewrite custom-path/busybox:latest
 
-	# add image from local Docker daemon
-	hauler store add image my-local-app:latest --local`,
+  # add image from local Docker daemon
+  hauler store add image my-local-app:latest --local`,
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			// Check for ca-file & insecure-skip-tls-verify env variables
@@ -416,6 +416,12 @@ func addStoreAddImage(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Co
 					b, _ := strconv.ParseBool(v)
 					o.InsecureSkipTLSVerify = &b
 				}
+			}
+
+			// resolve *bool: nil unless the user explicitly passed the flag
+			if cmd.Flags().Changed("insecure-skip-tls-verify") {
+				v, _ := cmd.Flags().GetBool("insecure-skip-tls-verify")
+				o.InsecureSkipTLSVerify = &v
 			}
 			return nil
 		},
@@ -441,26 +447,26 @@ func addStoreAddChart(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Co
 	cmd := &cobra.Command{
 		Use:   "chart",
 		Short: "Add a helm chart to the store",
-		Example: `	# fetch local helm chart
-	hauler store add chart path/to/chart/directory --repo .
+		Example: `  # fetch local helm chart
+  hauler store add chart path/to/chart/directory --repo .
 
-	# fetch local compressed helm chart
-	hauler store add chart path/to/chart.tar.gz --repo .
+  # fetch local compressed helm chart
+  hauler store add chart path/to/chart.tar.gz --repo .
 
-	# fetch remote oci helm chart
-	hauler store add chart hauler-helm --repo oci://ghcr.io/hauler-dev
+  # fetch remote oci helm chart
+  hauler store add chart hauler-helm --repo oci://ghcr.io/hauler-dev
 
-	# fetch remote oci helm chart with version
-	hauler store add chart hauler-helm --repo oci://ghcr.io/hauler-dev --version 1.2.0
+  # fetch remote oci helm chart with version
+  hauler store add chart hauler-helm --repo oci://ghcr.io/hauler-dev --version 1.2.0
 
-	# fetch remote helm chart
-	hauler store add chart rancher --repo https://releases.rancher.com/server-charts/stable
+  # fetch remote helm chart
+  hauler store add chart rancher --repo https://releases.rancher.com/server-charts/stable
 
-	# fetch remote helm chart with specific version
-	hauler store add chart rancher --repo https://releases.rancher.com/server-charts/latest --version 2.10.1
+  # fetch remote helm chart with specific version
+  hauler store add chart rancher --repo https://releases.rancher.com/server-charts/latest --version 2.10.1
 
-	# fetch remote helm chart and rewrite path
-	hauler store add chart hauler-helm --repo oci://ghcr.io/hauler-dev --rewrite custom-path/hauler-chart:latest`,
+  # fetch remote helm chart and rewrite path
+  hauler store add chart hauler-helm --repo oci://ghcr.io/hauler-dev --rewrite custom-path/hauler-chart:latest`,
 		Args: cobra.ExactArgs(1),
 		PreRunE: func(cmd *cobra.Command, args []string) error {
 			n, err := flags.ResolveConcurrency(cmd.Flags().Changed("concurrency"), o.Concurrency)
@@ -502,25 +508,25 @@ func addStoreRemove(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comm
 		Use:   "remove <artifact-ref>",
 		Short: "Remove an artifact from the content store",
 		Example: `  # remove an image using full store reference
-	hauler store info
-	hauler store remove index.docker.io/library/busybox:stable
+  hauler store info
+  hauler store remove index.docker.io/library/busybox:stable
 
-	# remove a chart using full store reference
-	hauler store info
-	hauler store remove hauler/rancher:2.8.4
+  # remove a chart using full store reference
+  hauler store info
+  hauler store remove hauler/rancher:2.8.4
 
-	# remove a file using full store reference
-	hauler store info
-	hauler store remove hauler/rke2-install.sh
+  # remove a file using full store reference
+  hauler store info
+  hauler store remove hauler/rke2-install.sh
 
-	# remove any artifact with the latest tag
-	hauler store remove :latest
+  # remove any artifact with the latest tag
+  hauler store remove :latest
 
-	# remove any artifact with 'busybox' in the reference
-	hauler store remove busybox
+  # remove any artifact with 'busybox' in the reference
+  hauler store remove busybox
 
-	# force remove without verification
-	hauler store remove busybox:latest --force`,
+  # force remove without verification
+  hauler store remove busybox:latest --force`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -389,7 +389,7 @@ func storeLocalImage(ctx context.Context, s *store.Layout, i v1.Image, _ *flags.
 	start := time.Now()
 	ignoreErrors := flags.ShouldIgnoreErrors(ro)
 
-	l.Debugf("adding image [%s] from local Docker daemon to the store", i.Name)
+	l.Debugf("resolving image [%s] from local Docker daemon (rewrite=%q)", i.Name, rewrite)
 
 	r, err := name.ParseReference(i.Name)
 	if err != nil {
@@ -480,7 +480,11 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 		return err
 	}
 
-	log.BaseFromContext(ctx).Debugf("adding image [%s] to the store", i.Name)
+	insecureSkipTLSVerify := derefInsecure(i.InsecureSkipTLSVerify)
+	caFile := i.CaFile
+
+	log.BaseFromContext(ctx).Debugf("resolving image [%s] (platform=%q, excludeExtras=%t, verified=%t, insecureSkipTLSVerify=%t, caFile=%q, rewrite=%q, digest=%q)",
+		i.Name, platform, excludeExtras, verified, insecureSkipTLSVerify, caFile, rewrite, pinnedDigest)
 
 	r, err := name.ParseReference(i.Name)
 	if err != nil {
@@ -492,9 +496,6 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 			return err
 		}
 	}
-
-	insecureSkipTLSVerify := derefInsecure(i.InsecureSkipTLSVerify)
-	caFile := i.CaFile
 
 	// fetch image along with any associated signatures and attestations.
 	// A fresh store.ImageStats is built inside the closure on every attempt,

--- a/cmd/hauler/cli/store/audit.go
+++ b/cmd/hauler/cli/store/audit.go
@@ -4,11 +4,5 @@ import "hauler.dev/go/hauler/v2/internal/flags"
 
 // auditLevel returns the resolved audit level (none, standard, verbose)
 func auditLevel(ro *flags.CliRootOpts) string {
-	if ro == nil {
-		return "none"
-	}
-	if ro.AuditLevel == "" {
-		return "standard"
-	}
-	return ro.AuditLevel
+	return flags.AuditLevel(ro)
 }

--- a/cmd/hauler/cli/store/sync_test.go
+++ b/cmd/hauler/cli/store/sync_test.go
@@ -2025,8 +2025,8 @@ func TestSyncImages_ErrorPropagation(t *testing.T) {
 // bug: with concurrency=1 and a bad ref placed before several good refs, the
 // bad job's failure cancels the errgroup's derived context. Jobs queued after
 // it never get a chance to call s.AddImage, so they must never log the
-// "adding image [...] to the store" INFO line either -- otherwise a failed
-// sync of 1 image looks like it attempted all of them.
+// "resolving image [...]" line either -- otherwise a failed sync of 1 image
+// looks like it attempted all of them.
 //
 // concurrency=1 makes cancellation deterministic: errgroup.SetLimit(1) means
 // each g.Go call blocks acquiring its semaphore slot until the previous job's
@@ -2047,7 +2047,7 @@ func TestRunImageJobs_CancelledJobsDoNotLogAddingImage(t *testing.T) {
 
 	s := newTestStore(t)
 	var buf bytes.Buffer
-	// "adding image [...]" now logs at Debug (cmd/hauler/cli/store/add.go),
+	// "resolving image [...]" now logs at Debug (cmd/hauler/cli/store/add.go),
 	// so this test needs Debug-level output visible. Per-logger .Level() is
 	// not sufficient on its own: zerolog's Logger.should() gates on
 	// max(logger.level, zerolog.GlobalLevel()) -- and GlobalLevel is
@@ -2073,9 +2073,9 @@ func TestRunImageJobs_CancelledJobsDoNotLogAddingImage(t *testing.T) {
 		t.Fatal("runImageJobs: expected error, got nil")
 	}
 
-	got := strings.Count(buf.String(), "adding image [")
+	got := strings.Count(buf.String(), "resolving image [")
 	if got != 1 {
-		t.Errorf("\"adding image [\" logged %d times, want exactly 1 (only the failed job should have attempted logging; the %d good jobs queued after it must never start)\nfull log:\n%s", got, nGood, buf.String())
+		t.Errorf("\"resolving image [\" logged %d times, want exactly 1 (only the failed job should have attempted logging; the %d good jobs queued after it must never start)\nfull log:\n%s", got, nGood, buf.String())
 	}
 }
 

--- a/internal/flags/audit_level.go
+++ b/internal/flags/audit_level.go
@@ -1,0 +1,12 @@
+package flags
+
+// AuditLevel returns the resolved audit level (none, standard, verbose).
+func AuditLevel(ro *CliRootOpts) string {
+	if ro == nil {
+		return "none"
+	}
+	if ro.AuditLevel == "" {
+		return "standard"
+	}
+	return ro.AuditLevel
+}

--- a/internal/flags/imagecopy.go
+++ b/internal/flags/imagecopy.go
@@ -1,0 +1,27 @@
+package flags
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"hauler.dev/go/hauler/v2/pkg/consts"
+)
+
+// ImageCopyOpts holds flags for `hauler copy` -- not to be confused with CopyOpts (`store copy`).
+type ImageCopyOpts struct {
+	InsecureSkipTLSVerify bool
+	PlainHTTP             bool
+	CaFile                string
+	Retries               int
+	Platform              string
+}
+
+func (o *ImageCopyOpts) AddFlags(cmd *cobra.Command) {
+	f := cmd.Flags()
+
+	f.BoolVar(&o.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "(Optional) Skip TLS certificate verification")
+	f.BoolVar(&o.PlainHTTP, "plain-http", false, "(Optional) Allow plain HTTP connections")
+	f.StringVar(&o.CaFile, "ca-file", "", "(Optional) Location of CA Bundle to enable certification verification")
+	f.IntVarP(&o.Retries, "retries", "r", 0, fmt.Sprintf("Set the number of retries for operations (0 uses HAULER_RETRIES, otherwise defaults to %d)", consts.DefaultRetries))
+	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform of the image... i.e. linux/amd64 (defaults to all)")
+}

--- a/pkg/content/copy.go
+++ b/pkg/content/copy.go
@@ -1,0 +1,158 @@
+package content
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/errdefs"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/rs/zerolog"
+
+	"hauler.dev/go/hauler/v2/pkg/consts"
+)
+
+// CopyDescriptorGraph recursively copies desc and everything it references from fetcher to pusher.
+func CopyDescriptorGraph(ctx context.Context, desc ocispec.Descriptor, fetcher remotes.Fetcher, pusher remotes.Pusher) (err error) {
+	switch desc.MediaType {
+	case ocispec.MediaTypeImageManifest, consts.DockerManifestSchema2:
+		rc, err := fetcher.Fetch(ctx, desc)
+		if err != nil {
+			return fmt.Errorf("failed to fetch manifest: %w", err)
+		}
+		defer func() {
+			if closeErr := rc.Close(); closeErr != nil && err == nil {
+				err = fmt.Errorf("failed to close manifest reader: %w", closeErr)
+			}
+		}()
+
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			return fmt.Errorf("failed to read manifest: %w", err)
+		}
+
+		var manifest ocispec.Manifest
+		if err := json.Unmarshal(data, &manifest); err != nil {
+			return fmt.Errorf("failed to unmarshal manifest: %w", err)
+		}
+
+		if err := copyDescriptor(ctx, manifest.Config, fetcher, pusher); err != nil {
+			return fmt.Errorf("failed to copy config: %w", err)
+		}
+
+		for _, layer := range manifest.Layers {
+			if err := copyDescriptor(ctx, layer, fetcher, pusher); err != nil {
+				return fmt.Errorf("failed to copy layer: %w", err)
+			}
+		}
+
+		// push the manifest itself using the already-fetched data to avoid double-fetching
+		if err := pushData(ctx, desc, data, pusher); err != nil {
+			return fmt.Errorf("failed to push manifest: %w", err)
+		}
+
+	case ocispec.MediaTypeImageIndex, consts.DockerManifestListSchema2:
+		rc, err := fetcher.Fetch(ctx, desc)
+		if err != nil {
+			return fmt.Errorf("failed to fetch index: %w", err)
+		}
+		defer func() {
+			if closeErr := rc.Close(); closeErr != nil && err == nil {
+				err = fmt.Errorf("failed to close index reader: %w", closeErr)
+			}
+		}()
+
+		data, err := io.ReadAll(rc)
+		if err != nil {
+			return fmt.Errorf("failed to read index: %w", err)
+		}
+
+		var index ocispec.Index
+		if err := json.Unmarshal(data, &index); err != nil {
+			return fmt.Errorf("failed to unmarshal index: %w", err)
+		}
+
+		for _, child := range index.Manifests {
+			if err := CopyDescriptorGraph(ctx, child, fetcher, pusher); err != nil {
+				return fmt.Errorf("failed to copy child: %w", err)
+			}
+		}
+
+		// push the index itself using the already-fetched data to avoid double-fetching
+		if err := pushData(ctx, desc, data, pusher); err != nil {
+			return fmt.Errorf("failed to push index: %w", err)
+		}
+
+	default:
+		if err := copyDescriptor(ctx, desc, fetcher, pusher); err != nil {
+			return fmt.Errorf("failed to copy descriptor: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// copyDescriptor copies a single descriptor from fetcher to pusher.
+func copyDescriptor(ctx context.Context, desc ocispec.Descriptor, fetcher remotes.Fetcher, pusher remotes.Pusher) (err error) {
+	rc, err := fetcher.Fetch(ctx, desc)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := rc.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("failed to close reader: %w", closeErr)
+		}
+	}()
+
+	writer, err := pusher.Push(ctx, desc)
+	if err != nil {
+		if errdefs.IsAlreadyExists(err) {
+			zerolog.Ctx(ctx).Debug().Msgf("existing blob: %s", desc.Digest)
+			return nil // content already present on remote
+		}
+		return err
+	}
+	defer func() {
+		if closeErr := writer.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	n, err := io.Copy(writer, rc)
+	if err != nil {
+		return err
+	}
+
+	if err := writer.Commit(ctx, n, desc.Digest); err != nil {
+		return err
+	}
+	zerolog.Ctx(ctx).Debug().Msgf("pushed blob: %s", desc.Digest)
+	return nil
+}
+
+// pushData pushes already-fetched data to the pusher without re-fetching --
+// used once a manifest/index's bytes are already in hand from parsing it.
+func pushData(ctx context.Context, desc ocispec.Descriptor, data []byte, pusher remotes.Pusher) (err error) {
+	writer, err := pusher.Push(ctx, desc)
+	if err != nil {
+		if errdefs.IsAlreadyExists(err) {
+			return nil // content already present on remote
+		}
+		return fmt.Errorf("failed to get writer: %w", err)
+	}
+	defer func() {
+		if closeErr := writer.Close(); closeErr != nil && err == nil {
+			err = fmt.Errorf("failed to close writer: %w", closeErr)
+		}
+	}()
+
+	n, err := io.Copy(writer, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("failed to write data: %w", err)
+	}
+
+	return writer.Commit(ctx, n, desc.Digest)
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,7 +1,6 @@
 package store
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,8 +9,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/containerd/containerd/v2/core/remotes"
-	"github.com/containerd/errdefs"
 	"github.com/google/go-containerregistry/pkg/authn"
 	gname "github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -298,7 +295,7 @@ func (l *Layout) AddImage(ctx context.Context, ref string, platform string, excl
 		// verified index, so the chain of trust holds.
 		imgOpts := append([]remote.Option{}, allOpts...)
 		if platform != "" {
-			p, err := parsePlatform(platform)
+			p, err := ParsePlatform(platform)
 			if err != nil {
 				return "", err
 			}
@@ -640,8 +637,8 @@ func (l *Layout) saveRelatedArtifacts(ctx context.Context, ref gname.Reference, 
 	return saved, nil
 }
 
-// parsePlatform parses a platform string in "os/arch[/variant]" format into a v1.Platform.
-func parsePlatform(s string) (v1.Platform, error) {
+// ParsePlatform parses a platform string in "os/arch[/variant]" format into a v1.Platform.
+func ParsePlatform(s string) (v1.Platform, error) {
 	parts := strings.SplitN(s, "/", 3)
 	if len(parts) < 2 {
 		return v1.Platform{}, fmt.Errorf("invalid platform %q: expected os/arch[/variant]", s)
@@ -698,168 +695,14 @@ func (l *Layout) Copy(ctx context.Context, ref string, to content.Target, toRef 
 	}
 
 	// Recursively copy the descriptor graph (matches oras.Copy behavior)
-	if err := l.copyDescriptorGraph(ctx, desc, fetcher, pusher); err != nil {
+	if err := content.CopyDescriptorGraph(ctx, desc, fetcher, pusher); err != nil {
 		return ocispec.Descriptor{}, err
 	}
 
 	return desc, nil
 }
 
-// copyDescriptorGraph recursively copies a descriptor and all its referenced content
-// This matches the behavior of oras.Copy by walking the entire descriptor graph
-func (l *Layout) copyDescriptorGraph(ctx context.Context, desc ocispec.Descriptor, fetcher remotes.Fetcher, pusher remotes.Pusher) (err error) {
-	switch desc.MediaType {
-	case ocispec.MediaTypeImageManifest, consts.DockerManifestSchema2:
-		// Fetch and parse the manifest
-		rc, err := fetcher.Fetch(ctx, desc)
-		if err != nil {
-			return fmt.Errorf("failed to fetch manifest: %w", err)
-		}
-		defer func() {
-			if closeErr := rc.Close(); closeErr != nil && err == nil {
-				err = fmt.Errorf("failed to close manifest reader: %w", closeErr)
-			}
-		}()
-
-		data, err := io.ReadAll(rc)
-		if err != nil {
-			return fmt.Errorf("failed to read manifest: %w", err)
-		}
-
-		var manifest ocispec.Manifest
-		if err := json.Unmarshal(data, &manifest); err != nil {
-			return fmt.Errorf("failed to unmarshal manifest: %w", err)
-		}
-
-		// Copy config blob
-		if err := l.copyDescriptor(ctx, manifest.Config, fetcher, pusher); err != nil {
-			return fmt.Errorf("failed to copy config: %w", err)
-		}
-
-		// Copy all layer blobs
-		for _, layer := range manifest.Layers {
-			if err := l.copyDescriptor(ctx, layer, fetcher, pusher); err != nil {
-				return fmt.Errorf("failed to copy layer: %w", err)
-			}
-		}
-
-		// Push the manifest itself using the already-fetched data to avoid double-fetching
-		if err := l.pushData(ctx, desc, data, pusher); err != nil {
-			return fmt.Errorf("failed to push manifest: %w", err)
-		}
-
-	case ocispec.MediaTypeImageIndex, consts.DockerManifestListSchema2:
-		// Fetch and parse the index
-		rc, err := fetcher.Fetch(ctx, desc)
-		if err != nil {
-			return fmt.Errorf("failed to fetch index: %w", err)
-		}
-		defer func() {
-			if closeErr := rc.Close(); closeErr != nil && err == nil {
-				err = fmt.Errorf("failed to close index reader: %w", closeErr)
-			}
-		}()
-
-		data, err := io.ReadAll(rc)
-		if err != nil {
-			return fmt.Errorf("failed to read index: %w", err)
-		}
-
-		var index ocispec.Index
-		if err := json.Unmarshal(data, &index); err != nil {
-			return fmt.Errorf("failed to unmarshal index: %w", err)
-		}
-
-		// Recursively copy each child (could be manifest or nested index)
-		for _, child := range index.Manifests {
-			if err := l.copyDescriptorGraph(ctx, child, fetcher, pusher); err != nil {
-				return fmt.Errorf("failed to copy child: %w", err)
-			}
-		}
-
-		// Push the index itself using the already-fetched data to avoid double-fetching
-		if err := l.pushData(ctx, desc, data, pusher); err != nil {
-			return fmt.Errorf("failed to push index: %w", err)
-		}
-
-	default:
-		// For other types (config blobs, layers, etc.), just copy the blob
-		if err := l.copyDescriptor(ctx, desc, fetcher, pusher); err != nil {
-			return fmt.Errorf("failed to copy descriptor: %w", err)
-		}
-	}
-
-	return nil
-}
-
-// copyDescriptor copies a single descriptor from source to target
-func (l *Layout) copyDescriptor(ctx context.Context, desc ocispec.Descriptor, fetcher remotes.Fetcher, pusher remotes.Pusher) (err error) {
-	// Fetch the content
-	rc, err := fetcher.Fetch(ctx, desc)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if closeErr := rc.Close(); closeErr != nil && err == nil {
-			err = fmt.Errorf("failed to close reader: %w", closeErr)
-		}
-	}()
-
-	// Get a writer from the pusher
-	writer, err := pusher.Push(ctx, desc)
-	if err != nil {
-		if errdefs.IsAlreadyExists(err) {
-			zerolog.Ctx(ctx).Debug().Msgf("existing blob: %s", desc.Digest)
-			return nil // content already present on remote
-		}
-		return err
-	}
-	defer func() {
-		if closeErr := writer.Close(); closeErr != nil && err == nil {
-			err = closeErr
-		}
-	}()
-
-	// Copy the content
-	n, err := io.Copy(writer, rc)
-	if err != nil {
-		return err
-	}
-
-	// Commit the written content with the expected digest
-	if err := writer.Commit(ctx, n, desc.Digest); err != nil {
-		return err
-	}
-	zerolog.Ctx(ctx).Debug().Msgf("pushed blob: %s", desc.Digest)
-	return nil
-}
-
-// pushData pushes already-fetched data to the pusher without re-fetching.
-// This is used when we've already read the data for parsing and want to avoid double-fetching.
-func (l *Layout) pushData(ctx context.Context, desc ocispec.Descriptor, data []byte, pusher remotes.Pusher) (err error) {
-	// Get a writer from the pusher
-	writer, err := pusher.Push(ctx, desc)
-	if err != nil {
-		if errdefs.IsAlreadyExists(err) {
-			return nil // content already present on remote
-		}
-		return fmt.Errorf("failed to get writer: %w", err)
-	}
-	defer func() {
-		if closeErr := writer.Close(); closeErr != nil && err == nil {
-			err = fmt.Errorf("failed to close writer: %w", closeErr)
-		}
-	}()
-
-	// Write the data using io.Copy to handle short writes properly
-	n, err := io.Copy(writer, bytes.NewReader(data))
-	if err != nil {
-		return fmt.Errorf("failed to write data: %w", err)
-	}
-
-	// Commit the written content with the expected digest
-	return writer.Commit(ctx, n, desc.Digest)
-}
+// copyDescriptorGraph, copyDescriptor, and pushData moved to pkg/content.CopyDescriptorGraph.
 
 // CopyAll performs bulk copy operations on the stores oci layout to a provided target
 func (l *Layout) CopyAll(ctx context.Context, to content.Target, toMapper func(string) (string, error)) ([]ocispec.Descriptor, error) {


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- Partially... https://github.com/hauler-dev/hauler/issues/576

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Add a new top-level `hauler copy` command for direct OCI artifact copies from registry to registry
- Updated the existing artifact copy logic in `store.go` to share it between `hauler copy` and `hauler store copy` instead of duplicating it for each one
- Fix a couple of small bugs found along the way with `audit logging`, `image` flag usage parsing, and a few more
- Formatted `examples` in the CLI `--help` to be the same spacing across each of the commands
- Add integration tests for both `hauler copy` and `hauler store copy`

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

```bash
zackbradys@Zacks-MacBook-Pro hauler-dev % ./dist/hauler_darwin_arm64_v8.0/hauler --help 
Airgap Swiss Army Knife

Usage:
  hauler [flags]
  hauler [command]

Examples:
  View the Docs: https://docs.hauler.dev
  Environment Variables: HAULER_DIR | HAULER_TEMP_DIR | HAULER_STORE_DIR | HAULER_IGNORE_ERRORS | HAULER_RETRIES | HAULER_LOG_LEVEL | HAULER_AUDIT_LEVEL | HAULER_CONCURRENCY | HAULER_BLOB_CONCURRENCY
  Warnings: Hauler commands and flags marked with (EXPERIMENTAL) are not yet stable and may change in the future.

Available Commands:
  completion  Generate auto-completion scripts for various shells
  copy        (EXPERIMENTAL) Copy an artifact between registries
  help        Help about any command
  login       Log in to a registry
  logout      Log out of a registry
  store       Interact with the content store
  version     Print the current version

Flags:
      --audit-level string   Set the audit logging level (none, standard, verbose) (defaults standard)
  -d, --haulerdir string     Set the location of the hauler directory (default $HOME/.hauler)
  -h, --help                 help for hauler
      --ignore-errors        Warn and continue instead of failing on errors, including storing images that failed verification (defaults false)
  -l, --log-level string     Set the logging level (i.e. info, debug, warn) (defaults info)

Use "hauler [command] --help" for more information about a command.
zackbradys@Zacks-MacBook-Pro hauler-dev % 
zackbradys@Zacks-MacBook-Pro hauler-dev % 
zackbradys@Zacks-MacBook-Pro hauler-dev % ./dist/hauler_darwin_arm64_v8.0/hauler copy --help
(EXPERIMENTAL) Copy an artifact between registries

Usage:
  hauler copy SRC DST [flags]

Aliases:
  copy, cp

Examples:
  # copy an image to another registry
  hauler copy busybox:latest registry.example.com/busybox:latest

  # copy a specific platform out of a multi-arch image
  hauler copy ghcr.io/hauler-dev/hauler-debug:v2.0.3 registry.example.com/hauler-debug:v2.0.3 --platform linux/amd64

  # copy to a registry with a self-signed certificate
  hauler copy busybox:latest registry.example.com/busybox:latest --insecure-skip-tls-verify

  # copy to a registry with no TLS at all
  hauler copy busybox:latest registry.example.com/busybox:latest --plain-http

Flags:
      --ca-file string             (Optional) Location of CA Bundle to enable certification verification
  -h, --help                       help for copy
      --insecure-skip-tls-verify   (Optional) Skip TLS certificate verification
      --plain-http                 (Optional) Allow plain HTTP connections
  -p, --platform string            (Optional) Specify the platform of the image... i.e. linux/amd64 (defaults to all)
  -r, --retries int                Set the number of retries for operations (0 uses HAULER_RETRIES, otherwise defaults to 3)

Global Flags:
      --audit-level string   Set the audit logging level (none, standard, verbose) (defaults standard)
  -d, --haulerdir string     Set the location of the hauler directory (default $HOME/.hauler)
      --ignore-errors        Warn and continue instead of failing on errors, including storing images that failed verification (defaults false)
  -l, --log-level string     Set the logging level (i.e. info, debug, warn) (defaults info)
zackbradys@Zacks-MacBook-Pro hauler-dev % 
zackbradys@Zacks-MacBook-Pro hauler-dev % 
zackbradys@Zacks-MacBook-Pro hauler-dev % ./dist/hauler_darwin_arm64_v8.0/hauler copy docker.io/hauler/hauler-helm:2.3.2 registry.kiternetes.kit/hauler/hauler-helm:2.3.2 --insecure-skip-tls-verify 
2026-08-10 23:17:37 INF copying [docker.io/hauler/hauler-helm:2.3.2] to [registry.kiternetes.kit/hauler/hauler-helm:2.3.2]
2026-08-10 23:17:38 INF ✓ copied [docker.io/hauler/hauler-helm:2.3.2] to [registry.kiternetes.kit/hauler/hauler-helm:2.3.2] (1.5s)
zackbradys@Zacks-MacBook-Pro hauler-dev % 
zackbradys@Zacks-MacBook-Pro hauler-dev % 
zackbradys@Zacks-MacBook-Pro hauler-dev % ./dist/hauler_darwin_arm64_v8.0/hauler copy docker.io/rancher/k3s:v1.35.6-k3s1 registry.kiternetes.kit/rancher/k3s:v1.35.6-k3s1 --insecure-skip-tls-verify --log-level debug --audit-level verbose
2026-08-10 23:15:28 DBG running cli command [hauler copy]
2026-08-10 23:15:28 DBG defaulted $DOCKER_CONFIG to [/Users/zackbradys/.docker] for registry credential resolution
2026-08-10 23:15:28 INF copying [docker.io/rancher/k3s:v1.35.6-k3s1] to [registry.kiternetes.kit/rancher/k3s:v1.35.6-k3s1]
2026-08-10 23:15:50 DBG generated audit id of [019feed1-6792-76b6-b6db-73c148efacf4]
2026-08-10 23:15:50 INF ✓ copied [docker.io/rancher/k3s:v1.35.6-k3s1] to [registry.kiternetes.kit/rancher/k3s:v1.35.6-k3s1] (21.5s)
zackbradys@Zacks-MacBook-Pro hauler-dev % 
zackbradys@Zacks-MacBook-Pro hauler-dev % 
zackbradys@Zacks-MacBook-Pro hauler-dev % ./dist/hauler_darwin_arm64_v8.0/hauler store info
┌────────────────────────────────────────────────────────────────────────┬──────┬──────────┬───────────┬──────┐
│ REFERENCE                                                              │ TYPE │ PLATFORM │ #  LAYERS │ SIZE │
├────────────────────────────────────────────────────────────────────────┼──────┼──────────┼───────────┼──────┤
├────────────────────────────────────────────────────────────────────────┼──────┼──────────┼───────────┼──────┤
│ store-path: /Users/zackbradys/Documents/Coding/GitHub/hauler-dev/store │      │          │     Total │  0 B │
│ store-id: ca66dd17-57cc-4f2f-8354-4075e99f9ef9                         │      │          │           │      │
└────────────────────────────────────────────────────────────────────────┴──────┴──────────┴───────────┴──────┘
zackbradys@Zacks-MacBook-Pro hauler-dev % 
zackbradys@Zacks-MacBook-Pro hauler-dev % 
zackbradys@Zacks-MacBook-Pro hauler-dev % cat ~/.hauler/audit.log | jq
{
  "audit-id": "019feed1-6792-76b6-b6db-73c148efacf4",
  "timestamp": "2026-08-11T03:15:50Z",
  "command": "copy",
  "args": [
    "docker.io/rancher/k3s:v1.35.6-k3s1",
    "registry.kiternetes.kit/rancher/k3s:v1.35.6-k3s1"
  ],
  "type": "image",
  "reference": "registry.kiternetes.kit/rancher/k3s:v1.35.6-k3s1",
  "digest": "sha256:9d6b9c15e8031c1aea7dd7f0cdc019f5e74a23c53b9eada564b7a8dc94efc14c",
  "system": {
    "user": "zackbradys",
    "hostname": "Zacks-MacBook-Pro",
    "ip-address": "10.0.0.15"
  },
  "global": {
    "haulerdir": "/Users/zackbradys/.hauler",
    "log-level": "debug",
    "audit-level": "verbose"
  },
  "flags": {
    "ca-file": "",
    "insecure-skip-tls-verify": true,
    "plain-http": false,
    "platform": ""
  }
}
{
  "audit-id": "019feed3-5d06-736b-9328-aa41dfdad878",
  "timestamp": "2026-08-11T03:17:38Z",
  "command": "copy",
  "args": [
    "docker.io/hauler/hauler-helm:2.3.2",
    "registry.kiternetes.kit/hauler/hauler-helm:2.3.2"
  ],
  "type": "image",
  "reference": "registry.kiternetes.kit/hauler/hauler-helm:2.3.2",
  "digest": "sha256:ce481ed2f94dae87af0ba0626282405032032526bf5621875e6e393e16028ffb"
}
```

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A
