### PR TITLE
fix: 744 containerd digest pinned save

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -619,9 +619,9 @@ func rewriteReference(ctx context.Context, s *store.Layout, oldRef name.Referenc
 		newTag = tag.TagStr()
 	}
 
-	// ContainerdImageNameKey stores annotationRef.Name() verbatim, which includes the
-	// "index.docker.io" prefix for docker.io images. Do not strip "index." here or the
-	// comparison will never match images stored by writeImage/writeIndex.
+	// Stores written before the #744 fix carry "index.docker.io/..." containerd
+	// names; new writes are normalized to "docker.io/...". Normalize both sides
+	// of the comparison so rewrite matches either vintage.
 	oldRegistry := oldRefContext.RegistryStr()
 	newRegistry := newRefContext.RegistryStr()
 	// If user omitted a registry in the rewrite string, go-containerregistry defaults to
@@ -643,10 +643,16 @@ func rewriteReference(ctx context.Context, s *store.Layout, oldRef name.Referenc
 
 	log.BaseFromContext(ctx).Infof("rewriting [%s] to [%s]", oldTotalReg, newTotalReg)
 
+	// The write below still emits newTotalReg's un-normalized form (registry-preservation
+	// and library/-stripping above depend on go-containerregistry's literal "index.docker.io"
+	// default) -- only the match target is normalized, so lookup tolerates either vintage.
+	oldTotalRegNormalized := reference.NormalizeContainerd(oldTotalReg)
+
 	//find and update reference
 	matched, err := s.OCI.UpdateAnnotations(
 		func(d ocispec.Descriptor) bool {
-			return d.Annotations[ocispec.AnnotationRefName] == oldTotal && d.Annotations[consts.ContainerdImageNameKey] == oldTotalReg
+			return d.Annotations[ocispec.AnnotationRefName] == oldTotal &&
+				reference.NormalizeContainerd(d.Annotations[consts.ContainerdImageNameKey]) == oldTotalRegNormalized
 		},
 		func(a map[string]string) {
 			a[ocispec.AnnotationRefName] = newTotal

--- a/cmd/hauler/cli/store/add_test.go
+++ b/cmd/hauler/cli/store/add_test.go
@@ -449,6 +449,39 @@ func TestRewriteReference(t *testing.T) {
 	})
 }
 
+// TestRewriteReferenceMatchesContainerdNameVintage covers the #744 vintage gap:
+// stores written by older hauler v2 carry "index.docker.io/..." in
+// ContainerdImageNameKey, while stores written after the containerd-name
+// normalization fix (Task 1/2) carry "docker.io/...". rewriteReference's match
+// predicate compared that annotation verbatim, so it must be taught to match
+// either vintage against a docker.io rewrite request.
+func TestRewriteReferenceMatchesContainerdNameVintage(t *testing.T) {
+	ctx := newTestContext(t)
+
+	tests := []struct {
+		name           string
+		containerdName string
+	}{
+		{"legacy index.docker.io form", "index.docker.io/library/rewrite-legacy:v1"},
+		{"normalized docker.io form", "docker.io/library/rewrite-legacy:v1"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			seedStoreDescriptor(t, s, map[string]string{
+				ocispec.AnnotationRefName:     "library/rewrite-legacy:v1",
+				consts.ContainerdImageNameKey: tc.containerdName,
+			})
+
+			oldRef, _ := name.ParseReference("docker.io/library/rewrite-legacy:v1")
+			newRef, _ := name.ParseReference("docker.io/library/rewrite-new:v1")
+			if err := rewriteReference(ctx, s, oldRef, newRef, "docker.io/library/rewrite-new:v1"); err != nil {
+				t.Fatalf("rewriteReference should match %s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
 func TestRewriteChartReference(t *testing.T) {
 	ctx := newTestContext(t)
 

--- a/cmd/hauler/cli/store/lifecycle_test.go
+++ b/cmd/hauler/cli/store/lifecycle_test.go
@@ -3,7 +3,6 @@ package store
 // lifecycle_test.go covers the end-to-end add->save->load->copy/extract lifecycle
 // for file, image, and chart artifact types.
 //
-// Do NOT use t.Parallel() -- SaveCmd calls os.Chdir(storeDir).
 // Always use absolute paths for StoreDir and FileName.
 
 import (

--- a/cmd/hauler/cli/store/load.go
+++ b/cmd/hauler/cli/store/load.go
@@ -210,6 +210,19 @@ func unarchiveLayoutTo(ctx context.Context, haulPath string, dest string, tempDi
 		return err
 	}
 
+	// A --containerd haul's index.json is filtered for containerd's importer;
+	// the full index rides as the sidecar. Prefer it so non-image artifacts
+	// survive the round trip. A present-but-unreadable sidecar is an error --
+	// silently falling back to the filtered index would lose content.
+	sidecar := filepath.Join(tempDir, consts.HaulerIndexFile)
+	if _, err := os.Stat(sidecar); err == nil {
+		if err := os.Rename(sidecar, filepath.Join(tempDir, ocispec.ImageIndexFile)); err != nil {
+			return err
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
 	// ensure the incoming index.json has the correct annotations.
 	data, err := os.ReadFile(tempDir + "/index.json")
 	if err != nil {

--- a/cmd/hauler/cli/store/load_test.go
+++ b/cmd/hauler/cli/store/load_test.go
@@ -1,11 +1,6 @@
 package store
 
 // load_test.go covers unarchiveLayoutTo, LoadCmd, and clearDir.
-//
-// Do NOT call t.Parallel() on tests that invoke createRootLevelArchive —
-// that helper uses the mholt/archives library directly to avoid os.Chdir,
-// so it is safe for concurrent use, but the tests themselves exercise
-// unarchiveLayoutTo which is already sequential.
 
 import (
 	"context"
@@ -21,6 +16,7 @@ import (
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"hauler.dev/go/hauler/v2/internal/flags"
+	v1 "hauler.dev/go/hauler/v2/pkg/apis/hauler.cattle.io/v1"
 	"hauler.dev/go/hauler/v2/pkg/archives"
 	"hauler.dev/go/hauler/v2/pkg/consts"
 	"hauler.dev/go/hauler/v2/pkg/store"
@@ -31,9 +27,8 @@ import (
 const testHaulArchive = "../../../../testdata/haul.tar.zst"
 
 // createRootLevelArchive creates a tar.zst archive from dir with files placed
-// at the archive root (no directory prefix). This matches the layout produced
-// by SaveCmd, which uses os.Chdir + Archive(".", ...) to achieve the same
-// effect. Using mholt/archives directly avoids the os.Chdir side-effect.
+// at the archive root (no directory prefix), matching the layout SaveCmd
+// produces via archives.ArchiveFiles.
 func createRootLevelArchive(dir, outfile string) error {
 	// A trailing path separator tells mholt/archives to enumerate the
 	// directory's *contents* only — files land at archive root with no prefix.
@@ -436,6 +431,102 @@ func TestUnarchiveLayoutTo_LegacyKindMigration(t *testing.T) {
 		return nil
 	}); err != nil {
 		t.Fatalf("Walk: %v", err)
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestLoadCmd_ContainerdHaulRoundTripsNonImageContent
+// --------------------------------------------------------------------------
+
+// TestLoadCmd_ContainerdHaulRoundTripsNonImageContent verifies that loading a
+// --containerd haul recovers the file artifact that was filtered out of
+// index.json, by preferring the hauler-index.json sidecar over the filtered
+// index.
+func TestLoadCmd_ContainerdHaulRoundTripsNonImageContent(t *testing.T) {
+	ctx := newTestContext(t)
+	host, _ := newLocalhostRegistry(t)
+	seedImage(t, host, "test/roundtrip", "v1")
+
+	// Source store: one image + one file artifact. AddArtifact (used by
+	// storeFile) tags the file dev.hauler/image like every non-image
+	// artifact, but never sets ContainerdImageNameKey -- writeContainerdIndexes
+	// drops it on that missing annotation, so it's absent from index.json and
+	// only recoverable from the hauler-index.json sidecar.
+	src := newTestStore(t)
+	if _, err := src.AddImage(ctx, host+"/test/roundtrip:v1", "", false, "", false, ""); err != nil {
+		t.Fatalf("AddImage: %v", err)
+	}
+	url := seedFileInHTTPServer(t, "roundtrip.txt", "file-content")
+	if err := storeFile(ctx, src, v1.File{Path: url}, defaultCliOpts(), defaultRootOpts(src.Root)); err != nil {
+		t.Fatalf("storeFile: %v", err)
+	}
+
+	archivePath := filepath.Join(t.TempDir(), "haul.tar.zst")
+	so := newSaveOpts(src.Root, archivePath)
+	so.ContainerdCompatibility = true
+	if err := SaveCmd(ctx, so, src, defaultRootOpts(src.Root), defaultCliOpts()); err != nil {
+		t.Fatalf("SaveCmd: %v", err)
+	}
+
+	// Inspect the archive directly (mirrors TestSaveCmd_ContainerdCompatibility):
+	// the file descriptor must be genuinely absent from the filtered index.json
+	// and present only in the sidecar. Without this, the test can't distinguish
+	// "the sidecar rescued a dropped artifact" from "nothing was ever dropped"
+	// -- see Step D in the task-8 report for what that false-positive looks like.
+	archiveInspectDir := t.TempDir()
+	if err := archives.Unarchive(ctx, archivePath, archiveInspectDir); err != nil {
+		t.Fatalf("Unarchive (inspection): %v", err)
+	}
+	assertNoDescriptorReferences(t, filepath.Join(archiveInspectDir, "index.json"), "roundtrip.txt")
+	assertDescriptorReferences(t, filepath.Join(archiveInspectDir, consts.HaulerIndexFile), "roundtrip.txt")
+
+	dest := newTestStore(t)
+	lo := &flags.LoadOpts{StoreRootOpts: defaultRootOpts(dest.Root), FileName: []string{archivePath}}
+	if err := LoadCmd(ctx, lo, dest, defaultRootOpts(dest.Root), defaultCliOpts()); err != nil {
+		t.Fatalf("LoadCmd: %v", err)
+	}
+
+	assertArtifactInStore(t, dest, "test/roundtrip")
+	assertArtifactInStore(t, dest, "roundtrip.txt")
+}
+
+// descriptorReferences reads an OCI index at indexPath and reports whether
+// any top-level manifest's annotation values contain refSubstring.
+func descriptorReferences(t *testing.T, indexPath, refSubstring string) bool {
+	t.Helper()
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", indexPath, err)
+	}
+	var idx ocispec.Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatalf("unmarshal %s: %v", indexPath, err)
+	}
+	for _, d := range idx.Manifests {
+		for _, v := range d.Annotations {
+			if strings.Contains(v, refSubstring) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// assertNoDescriptorReferences fails if any manifest in the index at
+// indexPath has an annotation value containing refSubstring.
+func assertNoDescriptorReferences(t *testing.T, indexPath, refSubstring string) {
+	t.Helper()
+	if descriptorReferences(t, indexPath, refSubstring) {
+		t.Errorf("expected no descriptor in %s to reference %q, but found one", indexPath, refSubstring)
+	}
+}
+
+// assertDescriptorReferences fails unless some manifest in the index at
+// indexPath has an annotation value containing refSubstring.
+func assertDescriptorReferences(t *testing.T, indexPath, refSubstring string) {
+	t.Helper()
+	if !descriptorReferences(t, indexPath, refSubstring) {
+		t.Errorf("expected a descriptor in %s to reference %q, found none", indexPath, refSubstring)
 	}
 }
 

--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -290,10 +290,11 @@ func writeExportsManifest(ctx context.Context, dir string, outDir string, platfo
 		case desc.MediaType.IsIndex():
 			l.Debugf("index [%s]: digest=[%s]... type=[%s]... size=[%d]", refName, desc.Digest.String(), desc.MediaType, desc.Size)
 
-			// when no platform is inputted... warn the user of potential mismatch on import for docker
-			// required for docker to be able to interpret and load the image correctly
+			// when no platform is inputted... docker load keeps only one architecture per tag (last wins)
+			// containerd and OCI imports include all architectures and are unaffected
 			if platform.String() == "" {
-				l.Warnf("compatibility warning... docker... specify platform to prevent potential mismatch on import of index [%s]", refName)
+				l.Warnf("compatibility warning... docker... multi-arch index [%s] saved without --platform", refName)
+				l.Warnf("'docker load' keeps only one architecture per tag (last wins)... use --platform (i.e. linux/amd64) to select one... containerd and OCI imports include all architectures and are unaffected")
 			}
 
 			iix, err := idx.ImageIndex(desc.Digest)

--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -25,6 +25,7 @@ import (
 	"hauler.dev/go/hauler/v2/pkg/audit"
 	"hauler.dev/go/hauler/v2/pkg/consts"
 	"hauler.dev/go/hauler/v2/pkg/log"
+	"hauler.dev/go/hauler/v2/pkg/reference"
 	"hauler.dev/go/hauler/v2/pkg/store"
 )
 
@@ -45,35 +46,101 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, s *store.Layout, rso *flags
 		return err
 	}
 
-	cwd, err := os.Getwd()
+	// Generated files go to a scratch dir and are mapped into the archive root,
+	// so save never mutates the live store (the old chdir flow wrote manifest.json
+	// into it and --containerd deleted its oci-layout permanently). The one
+	// deliberate exception is audit.log: at AuditLevel "standard" or "verbose"
+	// the audit.Append call below writes a portable entry to <StoreDir>/audit.log
+	// by design (#727) -- see TestSaveCmd_DoesNotMutateStore's audit subtest.
+	scratch, err := os.MkdirTemp(rso.TempOverride, consts.DefaultHaulerTempDirName)
 	if err != nil {
 		return err
 	}
-	defer os.Chdir(cwd)
-	if err := os.Chdir(o.StoreDir); err != nil {
+	defer os.RemoveAll(scratch)
+
+	if err := writeExportsManifest(ctx, o.StoreDir, scratch, o.Platform); err != nil {
 		return err
 	}
 
-	// create the manifest.json file
-	if err := writeExportsManifest(ctx, ".", o.Platform); err != nil {
-		return err
+	files := map[string]string{
+		filepath.Join(scratch, consts.ImageManifestFile): consts.ImageManifestFile,
 	}
 
-	// strip out the oci-layout file from the haul
-	// required for containerd to be able to interpret the haul correctly for all mediatypes and artifactypes
-	if o.ContainerdCompatibility {
-		if err := os.Remove(filepath.Join(".", ocispec.ImageLayoutFile)); err != nil {
-			if !os.IsNotExist(err) {
-				return err
-			}
-		} else {
-			l.Warnf("compatibility warning... containerd... removing 'oci-layout' file to support containerd importing of images")
+	// The live store never writes an oci-layout marker on disk (nothing in
+	// pkg/content/oci.go creates one), but containerd's OCI import path and
+	// the documented archive layout both require it. Generate it into
+	// scratch like the other derived files -- only when the store lacks one,
+	// so "oci-layout" is never mapped from two different source paths into
+	// the same archive entry.
+	layoutMarkerPath := filepath.Join(o.StoreDir, ocispec.ImageLayoutFile)
+	if _, err := os.Stat(layoutMarkerPath); os.IsNotExist(err) {
+		marker, err := json.Marshal(ocispec.ImageLayout{Version: ocispec.ImageLayoutVersion})
+		if err != nil {
+			return err
 		}
+		if err := os.WriteFile(filepath.Join(scratch, ocispec.ImageLayoutFile), marker, 0644); err != nil {
+			return err
+		}
+		files[filepath.Join(scratch, ocispec.ImageLayoutFile)] = ocispec.ImageLayoutFile
+	} else if err != nil {
+		return err
+	}
+
+	if o.ContainerdCompatibility {
+		dropped, err := writeContainerdIndexes(o.StoreDir, scratch)
+		if err != nil {
+			return err
+		}
+		files[filepath.Join(scratch, ocispec.ImageIndexFile)] = ocispec.ImageIndexFile
+		files[filepath.Join(scratch, consts.HaulerIndexFile)] = consts.HaulerIndexFile
+		if dropped > 0 {
+			l.Warnf("compatibility warning... containerd... excluded [%d] non-image artifacts from index.json (full index preserved as [%s]... requires a hauler version with sidecar support to load)", dropped, consts.HaulerIndexFile)
+		}
+	} else {
+		// Default mode drops nothing, but still normalizes io.containerd.image.name
+		// so a default haul of a legacy store (or one that went through --rewrite)
+		// carries CRI-resolvable names once oci-layout steers containerd onto the
+		// OCI import path (#744 amended §3). No sidecar: nothing was filtered.
+		if err := writeDefaultIndex(o.StoreDir, scratch); err != nil {
+			return err
+		}
+		files[filepath.Join(scratch, ocispec.ImageIndexFile)] = ocispec.ImageIndexFile
+	}
+
+	entries, err := os.ReadDir(o.StoreDir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		name := e.Name()
+		full := filepath.Join(o.StoreDir, name)
+		if name == consts.ImageManifestFile {
+			continue // always regenerated into scratch
+		}
+		if name == ocispec.ImageIndexFile {
+			// Always replaced by the scratch copy -- filtered+normalized in
+			// --containerd mode, normalized-only in default mode (see
+			// writeContainerdIndexes / writeDefaultIndex).
+			continue
+		}
+		if name == consts.HaulerIndexFile {
+			// Skip unconditionally, not just in --containerd mode: a stray sidecar
+			// already in the store dir would otherwise ride into a default haul,
+			// and store load prefers the sidecar over index.json -- silent data
+			// loss (#744 fix 3).
+			continue
+		}
+		if full == absOutputfile {
+			// Saving the archive into the store dir: ArchiveFiles removes
+			// absOutputfile before reading fileMap, so mapping it here would
+			// point at a path FilesFromDisk can no longer find.
+			continue
+		}
+		files[full] = name
 	}
 
 	// create the archive
-	err = archives.Archive(ctx, ".", absOutputfile, compression, archival)
-	if err != nil {
+	if err := archives.ArchiveFiles(ctx, files, absOutputfile, compression, archival); err != nil {
 		return err
 	}
 
@@ -163,7 +230,7 @@ type exports struct {
 	records map[string]tarball.Descriptor
 }
 
-func writeExportsManifest(ctx context.Context, dir string, platformStr string) error {
+func writeExportsManifest(ctx context.Context, dir string, outDir string, platformStr string) error {
 	l := log.FromContext(ctx)
 
 	// validate platform format
@@ -217,7 +284,7 @@ func writeExportsManifest(ctx context.Context, dir string, platformStr string) e
 		// from multi-arch indexes, rather than relying on the kind string for this.
 		switch {
 		case desc.MediaType.IsImage():
-			if err := x.record(ctx, idx, desc, refName); err != nil {
+			if err := x.record(ctx, idx, desc, refName, "", platform.String() != ""); err != nil {
 				return err
 			}
 		case desc.MediaType.IsIndex():
@@ -253,7 +320,7 @@ func writeExportsManifest(ctx context.Context, dir string, platformStr string) e
 						continue
 					}
 
-					if err := x.record(ctx, iix, ixd, refName); err != nil {
+					if err := x.record(ctx, iix, ixd, refName, desc.Digest.String(), platform.String() != ""); err != nil {
 						return err
 					}
 				}
@@ -270,7 +337,95 @@ func writeExportsManifest(ctx context.Context, dir string, platformStr string) e
 		return err
 	}
 
-	return oci.WriteFile(consts.ImageManifestFile, buf.Bytes(), 0666)
+	return os.WriteFile(filepath.Join(outDir, consts.ImageManifestFile), buf.Bytes(), 0666)
+}
+
+// writeContainerdIndexes writes the two indexes a --containerd haul carries into
+// outDir: index.json filtered to image/imageIndex kinds with containerd names
+// normalized (containerd's OCI import path reads it -- non-image artifacts would
+// break the import, and un-normalized names miss CRI lookups, #744), and a
+// byte-identical full copy as consts.HaulerIndexFile so store load loses nothing.
+// The store's own files are never modified. Returns how many descriptors were
+// excluded from the filtered index.
+//
+// Kept iff kind is image/imageIndex AND ContainerdImageNameKey is present --
+// mirrors writeExportsManifest's predicate. The kind check alone isn't enough:
+// store.Layout.AddArtifact tags every artifact it writes, charts and files
+// included, with KindAnnotationImage and never sets ContainerdImageNameKey, so
+// only real images carry that annotation; the name check is what actually
+// separates them out.
+func writeContainerdIndexes(storeDir, outDir string) (int, error) {
+	data, err := os.ReadFile(filepath.Join(storeDir, ocispec.ImageIndexFile))
+	if err != nil {
+		return 0, err
+	}
+	if err := os.WriteFile(filepath.Join(outDir, consts.HaulerIndexFile), data, 0666); err != nil {
+		return 0, err
+	}
+
+	var idx ocispec.Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return 0, err
+	}
+	kept := idx.Manifests[:0:0]
+	for _, d := range idx.Manifests {
+		kind := d.Annotations[consts.KindAnnotationName]
+		if kind != consts.KindAnnotationImage && kind != consts.KindAnnotationIndex {
+			continue
+		}
+		if _, hasName := d.Annotations[consts.ContainerdImageNameKey]; !hasName {
+			continue
+		}
+		normalizeContainerdName(d.Annotations)
+		kept = append(kept, d)
+	}
+	dropped := len(idx.Manifests) - len(kept)
+	idx.Manifests = kept
+
+	out, err := json.Marshal(idx)
+	if err != nil {
+		return 0, err
+	}
+	return dropped, os.WriteFile(filepath.Join(outDir, ocispec.ImageIndexFile), out, 0666)
+}
+
+// normalizeContainerdName rewrites annotations' io.containerd.image.name through
+// reference.NormalizeContainerd in place, when present -- the v1-parity fix
+// (#744 §3) shared by both writeContainerdIndexes' filtered rewrite and
+// writeDefaultIndex's unfiltered one, so archives from stores populated by
+// older v2 versions (or run through --rewrite) still carry CRI-resolvable names.
+func normalizeContainerdName(annotations map[string]string) {
+	if name, ok := annotations[consts.ContainerdImageNameKey]; ok {
+		annotations[consts.ContainerdImageNameKey] = reference.NormalizeContainerd(name)
+	}
+}
+
+// writeDefaultIndex writes a normalized copy of storeDir's index.json into outDir
+// for default-mode (non-`--containerd`) saves: every descriptor is kept -- unlike
+// writeContainerdIndexes nothing is dropped, so default hauls carry no sidecar --
+// but io.containerd.image.name annotations are normalized where present. This
+// matters because save also restores the oci-layout marker for default hauls,
+// which steers `ctr images import` onto the OCI path where the annotation is
+// read verbatim (#744 amended §3). The store's own index.json is untouched.
+func writeDefaultIndex(storeDir, outDir string) error {
+	data, err := os.ReadFile(filepath.Join(storeDir, ocispec.ImageIndexFile))
+	if err != nil {
+		return err
+	}
+
+	var idx ocispec.Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		return err
+	}
+	for i := range idx.Manifests {
+		normalizeContainerdName(idx.Manifests[i].Annotations)
+	}
+
+	out, err := json.Marshal(idx)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(outDir, ocispec.ImageIndexFile), out, 0666)
 }
 
 func (x *exports) describe() tarball.Manifest {
@@ -281,7 +436,7 @@ func (x *exports) describe() tarball.Manifest {
 	return m
 }
 
-func (x *exports) record(ctx context.Context, index libv1.ImageIndex, desc libv1.Descriptor, refname string) error {
+func (x *exports) record(ctx context.Context, index libv1.ImageIndex, desc libv1.Descriptor, refname string, parentDigest string, platformSpecified bool) error {
 	l := log.FromContext(ctx)
 
 	digest := desc.Digest.String()
@@ -348,16 +503,27 @@ func (x *exports) record(ctx context.Context, index libv1.ImageIndex, desc libv1
 		xd.RepoTags = slices.Compact(xd.RepoTags)
 		ref = tag.Digest(digest)
 	case name.Digest:
-		// For digest-only refs, derive a deterministic, docker-valid tag from
-		// the manifest digest so ctr/docker can import the image (#642).
-		// Convention mirrors copy.go:229: "sha256-<hex>".
+		// For digest-only refs, derive a deterministic, docker-valid tag from the
+		// digest the user actually pinned (#642, #744). For a multi-arch index that
+		// is the PARENT index digest, not this child's; children disambiguate with
+		// an os-arch suffix because docker load keeps only the last of duplicate tags.
 		named, err := referencev3.ParseNormalizedNamed(tag.Repository.Name())
 		if err != nil {
 			return err
 		}
 		familiarRepo := referencev3.FamiliarName(named)
-		digestTag := strings.ReplaceAll(digest, ":", "-") // e.g. "sha256-498a..."
-		repotag := familiarRepo + ":" + digestTag
+		base := digest
+		suffix := ""
+		if parentDigest != "" {
+			base = parentDigest
+			if !platformSpecified && desc.Platform != nil {
+				suffix = "-" + desc.Platform.OS + "-" + desc.Platform.Architecture
+				if desc.Platform.Variant != "" {
+					suffix += "-" + desc.Platform.Variant
+				}
+			}
+		}
+		repotag := familiarRepo + ":" + strings.ReplaceAll(base, ":", "-") + suffix
 		xd.RepoTags = append(xd.RepoTags[:], repotag)
 		slices.Sort(xd.RepoTags)
 		xd.RepoTags = slices.Compact(xd.RepoTags)

--- a/cmd/hauler/cli/store/save_test.go
+++ b/cmd/hauler/cli/store/save_test.go
@@ -1,21 +1,27 @@
 package store
 
 // save_test.go covers writeExportsManifest and SaveCmd.
-//
-// IMPORTANT: SaveCmd calls os.Chdir(storeDir) and defers os.Chdir back. Do
-// NOT call t.Parallel() on any SaveCmd test, and always use absolute paths for
-// StoreDir and FileName so they remain valid after the chdir.
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"reflect"
+	"slices"
+	"strings"
 	"testing"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"hauler.dev/go/hauler/v2/internal/flags"
 	v1 "hauler.dev/go/hauler/v2/pkg/apis/hauler.cattle.io/v1"
 	"hauler.dev/go/hauler/v2/pkg/archives"
+	"hauler.dev/go/hauler/v2/pkg/audit"
 	"hauler.dev/go/hauler/v2/pkg/consts"
+	"hauler.dev/go/hauler/v2/pkg/reference"
 )
 
 // manifestEntry mirrors tarball.Descriptor for asserting manifest.json contents.
@@ -63,7 +69,7 @@ func TestWriteExportsManifest(t *testing.T) {
 			t.Fatalf("AddImage: %v", err)
 		}
 
-		if err := writeExportsManifest(ctx, s.Root, ""); err != nil {
+		if err := writeExportsManifest(ctx, s.Root, s.Root, ""); err != nil {
 			t.Fatalf("writeExportsManifest: %v", err)
 		}
 
@@ -82,7 +88,7 @@ func TestWriteExportsManifest(t *testing.T) {
 			t.Fatalf("AddImage: %v", err)
 		}
 
-		if err := writeExportsManifest(ctx, s.Root, "linux/amd64"); err != nil {
+		if err := writeExportsManifest(ctx, s.Root, s.Root, "linux/amd64"); err != nil {
 			t.Fatalf("writeExportsManifest: %v", err)
 		}
 
@@ -102,7 +108,7 @@ func TestWriteExportsManifest(t *testing.T) {
 			t.Fatalf("AddChartCmd: %v", err)
 		}
 
-		if err := writeExportsManifest(ctx, s.Root, ""); err != nil {
+		if err := writeExportsManifest(ctx, s.Root, s.Root, ""); err != nil {
 			t.Fatalf("writeExportsManifest: %v", err)
 		}
 
@@ -130,7 +136,7 @@ func TestWriteExportsManifest_DigestOnlyImageHasRepoTag(t *testing.T) {
 		t.Fatalf("AddImage by digest: %v", err)
 	}
 
-	if err := writeExportsManifest(ctx, s.Root, ""); err != nil {
+	if err := writeExportsManifest(ctx, s.Root, s.Root, ""); err != nil {
 		t.Fatalf("writeExportsManifest: %v", err)
 	}
 
@@ -153,7 +159,7 @@ func TestWriteExportsManifest_SkipsNonImages(t *testing.T) {
 		t.Fatalf("storeFile: %v", err)
 	}
 
-	if err := writeExportsManifest(ctx, s.Root, ""); err != nil {
+	if err := writeExportsManifest(ctx, s.Root, s.Root, ""); err != nil {
 		t.Fatalf("writeExportsManifest: %v", err)
 	}
 
@@ -163,9 +169,250 @@ func TestWriteExportsManifest_SkipsNonImages(t *testing.T) {
 	}
 }
 
+func TestWriteExportsManifest_DigestPinnedIndexUsesParentDigest(t *testing.T) {
+	ctx := newTestContext(t)
+	host, srcOpts := newLocalhostRegistry(t)
+	idx := seedIndexWithUnknown(t, host, "test/digestindex", "v1", srcOpts...)
+	parentHash, err := idx.Digest()
+	if err != nil {
+		t.Fatalf("idx.Digest: %v", err)
+	}
+
+	s := newTestStore(t)
+	if _, err := s.AddImage(ctx, host+"/test/digestindex@"+parentHash.String(), "", false, "", false, ""); err != nil {
+		t.Fatalf("AddImage by digest: %v", err)
+	}
+
+	outDir := t.TempDir()
+	if err := writeExportsManifest(ctx, s.Root, outDir, ""); err != nil {
+		t.Fatalf("writeExportsManifest: %v", err)
+	}
+
+	parentTag := strings.ReplaceAll(parentHash.String(), ":", "-")
+	var tags []string
+	for _, e := range readManifestJSON(t, outDir) {
+		tags = append(tags, e.RepoTags...)
+	}
+	// No platform given: one child per known platform, each tagged from the PARENT
+	// digest with an os-arch suffix. The child digests must appear nowhere.
+	// referencev3.FamiliarName only strips the registry host for docker.io; this
+	// test's host is a localhost test registry, so the expected tag keeps it.
+	wantSuffixes := []string{"-linux-amd64", "-linux-arm64"}
+	for _, sfx := range wantSuffixes {
+		want := host + "/test/digestindex:" + parentTag + sfx
+		if !slices.Contains(tags, want) {
+			t.Errorf("missing tag %q in %v", want, tags)
+		}
+	}
+	for _, tag := range tags {
+		if !strings.Contains(tag, parentTag) {
+			t.Errorf("tag %q not derived from parent digest %s", tag, parentHash.String())
+		}
+		if strings.Contains(tag, "-unknown-unknown") {
+			t.Errorf("tag %q carries the unknown/unknown attestation child, which save.go's existing skip must exclude", tag)
+		}
+	}
+}
+
+func TestWriteExportsManifest_DigestPinnedIndexWithPlatform(t *testing.T) {
+	ctx := newTestContext(t)
+	host, srcOpts := newLocalhostRegistry(t)
+	idx := seedIndex(t, host, "test/digestplat", "v1", srcOpts...)
+	parentHash, err := idx.Digest()
+	if err != nil {
+		t.Fatalf("idx.Digest: %v", err)
+	}
+
+	s := newTestStore(t)
+	if _, err := s.AddImage(ctx, host+"/test/digestplat@"+parentHash.String(), "", false, "", false, ""); err != nil {
+		t.Fatalf("AddImage by digest: %v", err)
+	}
+
+	outDir := t.TempDir()
+	if err := writeExportsManifest(ctx, s.Root, outDir, "linux/amd64"); err != nil {
+		t.Fatalf("writeExportsManifest: %v", err)
+	}
+
+	entries := readManifestJSON(t, outDir)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry with --platform, got %d", len(entries))
+	}
+	// See the FamiliarName note in TestWriteExportsManifest_DigestPinnedIndexUsesParentDigest.
+	want := host + "/test/digestplat:" + strings.ReplaceAll(parentHash.String(), ":", "-")
+	if !slices.Contains(entries[0].RepoTags, want) {
+		t.Errorf("RepoTags = %v, want to contain %q", entries[0].RepoTags, want)
+	}
+}
+
+// --------------------------------------------------------------------------
+// writeContainerdIndexes unit tests
+// --------------------------------------------------------------------------
+
+func TestWriteContainerdIndexes(t *testing.T) {
+	storeDir := t.TempDir()
+	// Parent index entry with a legacy un-normalized name; a chart entry shaped
+	// like what AddArtifact actually produces today (kind dev.hauler/image, no
+	// io.containerd.image.name -- see writeContainerdIndexes's doc comment) that
+	// must be filtered out on the missing-name half of the predicate; and a sigs
+	// entry that must be filtered out on the kind half.
+	storeIndex := `{
+  "schemaVersion": 2,
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "digest": "sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0",
+      "size": 10200,
+      "annotations": {
+        "io.containerd.image.name": "index.docker.io/library/busybox@sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0",
+        "kind": "dev.hauler/imageIndex",
+        "org.opencontainers.image.ref.name": "library/busybox@sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "size": 100,
+      "annotations": {"kind": "dev.hauler/image", "org.opencontainers.image.ref.name": "charts/foo:1.0.0"}
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "size": 100,
+      "annotations": {"kind": "dev.hauler/sigs", "io.containerd.image.name": "index.docker.io/library/busybox:sha256-498a.sig"}
+    }
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(storeDir, "index.json"), []byte(storeIndex), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := t.TempDir()
+	dropped, err := writeContainerdIndexes(storeDir, outDir)
+	if err != nil {
+		t.Fatalf("writeContainerdIndexes: %v", err)
+	}
+	if dropped != 2 {
+		t.Errorf("dropped = %d, want 2", dropped)
+	}
+
+	sidecar, err := os.ReadFile(filepath.Join(outDir, consts.HaulerIndexFile))
+	if err != nil {
+		t.Fatalf("sidecar missing: %v", err)
+	}
+	if string(sidecar) != storeIndex {
+		t.Errorf("sidecar is not byte-identical to the store index")
+	}
+
+	var filtered ocispec.Index
+	data, err := os.ReadFile(filepath.Join(outDir, "index.json"))
+	if err != nil {
+		t.Fatalf("filtered index missing: %v", err)
+	}
+	if err := json.Unmarshal(data, &filtered); err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered.Manifests) != 1 {
+		t.Fatalf("filtered manifests = %d, want 1", len(filtered.Manifests))
+	}
+	got := filtered.Manifests[0].Annotations[consts.ContainerdImageNameKey]
+	want := "docker.io/library/busybox@sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0"
+	if got != want {
+		t.Errorf("normalized name = %q, want %q", got, want)
+	}
+	// The store itself must be untouched.
+	after, _ := os.ReadFile(filepath.Join(storeDir, "index.json"))
+	if string(after) != storeIndex {
+		t.Errorf("store index.json was modified")
+	}
+}
+
+// TestWriteDefaultIndex covers the default-mode (non-`--containerd`) archive
+// index rewrite added for #744 fix 1: every descriptor is kept (unlike
+// writeContainerdIndexes' filtered rewrite), but io.containerd.image.name
+// annotations still get normalized where present, so a default haul of a
+// legacy store still carries CRI-resolvable names once oci-layout steers
+// containerd onto the OCI import path. Reuses TestWriteContainerdIndexes'
+// fixture shape.
+func TestWriteDefaultIndex(t *testing.T) {
+	storeDir := t.TempDir()
+	storeIndex := `{
+  "schemaVersion": 2,
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.index.v1+json",
+      "digest": "sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0",
+      "size": 10200,
+      "annotations": {
+        "io.containerd.image.name": "index.docker.io/library/busybox@sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0",
+        "kind": "dev.hauler/imageIndex",
+        "org.opencontainers.image.ref.name": "library/busybox@sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "size": 100,
+      "annotations": {"kind": "dev.hauler/image", "org.opencontainers.image.ref.name": "charts/foo:1.0.0"}
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "size": 100,
+      "annotations": {"kind": "dev.hauler/sigs", "io.containerd.image.name": "index.docker.io/library/busybox:sha256-498a.sig"}
+    }
+  ]
+}`
+	if err := os.WriteFile(filepath.Join(storeDir, "index.json"), []byte(storeIndex), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := t.TempDir()
+	if err := writeDefaultIndex(storeDir, outDir); err != nil {
+		t.Fatalf("writeDefaultIndex: %v", err)
+	}
+
+	var got ocispec.Index
+	data, err := os.ReadFile(filepath.Join(outDir, "index.json"))
+	if err != nil {
+		t.Fatalf("default index missing: %v", err)
+	}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	var original ocispec.Index
+	if err := json.Unmarshal([]byte(storeIndex), &original); err != nil {
+		t.Fatal(err)
+	}
+	// Default mode is unfiltered: same descriptor count as the store's index,
+	// unlike writeContainerdIndexes which drops the chart and sigs entries.
+	if len(got.Manifests) != len(original.Manifests) {
+		t.Fatalf("default index manifests = %d, want %d (unfiltered)", len(got.Manifests), len(original.Manifests))
+	}
+
+	wantParentName := "docker.io/library/busybox@sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0"
+	foundParent := false
+	for _, d := range got.Manifests {
+		if d.Digest.String() == "sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0" {
+			foundParent = true
+			if got := d.Annotations[consts.ContainerdImageNameKey]; got != wantParentName {
+				t.Errorf("normalized parent name = %q, want %q", got, wantParentName)
+			}
+		}
+	}
+	if !foundParent {
+		t.Fatal("parent index descriptor missing from default-mode index")
+	}
+
+	// The store itself must be untouched.
+	after, _ := os.ReadFile(filepath.Join(storeDir, "index.json"))
+	if string(after) != storeIndex {
+		t.Errorf("store index.json was modified")
+	}
+}
+
 // --------------------------------------------------------------------------
 // SaveCmd integration tests
-// Do NOT use t.Parallel() — SaveCmd calls os.Chdir.
 // --------------------------------------------------------------------------
 
 func TestSaveCmd(t *testing.T) {
@@ -178,7 +425,6 @@ func TestSaveCmd(t *testing.T) {
 		t.Fatalf("AddImage: %v", err)
 	}
 
-	// FileName must be absolute so it remains valid after SaveCmd's os.Chdir.
 	archivePath := filepath.Join(t.TempDir(), "haul.tar.zst")
 	o := newSaveOpts(s.Root, archivePath)
 
@@ -224,10 +470,293 @@ func TestSaveCmd_ContainerdCompatibility(t *testing.T) {
 		t.Fatalf("Unarchive: %v", err)
 	}
 
-	// oci-layout must be absent from the extracted archive.
-	ociLayoutPath := filepath.Join(destDir, "oci-layout")
-	if _, err := os.Stat(ociLayoutPath); !os.IsNotExist(err) {
-		t.Errorf("expected oci-layout to be absent in containerd-compatible archive, got: %v", err)
+	// oci-layout must be PRESENT so containerd takes its OCI import path (#744);
+	// index.json is filtered; the full index rides as the sidecar.
+	if _, err := os.Stat(filepath.Join(destDir, "oci-layout")); err != nil {
+		t.Errorf("expected oci-layout present in containerd archive: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destDir, consts.HaulerIndexFile)); err != nil {
+		t.Errorf("expected %s sidecar in containerd archive: %v", consts.HaulerIndexFile, err)
+	}
+	var filtered ocispec.Index
+	data, err := os.ReadFile(filepath.Join(destDir, "index.json"))
+	if err != nil {
+		t.Fatalf("read archive index.json: %v", err)
+	}
+	if err := json.Unmarshal(data, &filtered); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range filtered.Manifests {
+		kind := d.Annotations[consts.KindAnnotationName]
+		if kind != consts.KindAnnotationImage && kind != consts.KindAnnotationIndex {
+			t.Errorf("non-image kind %q leaked into containerd index.json", kind)
+		}
+	}
+}
+
+// TestSaveCmd_ContainerdCompatibility_DigestPinnedMultiArch drives #744's own
+// reproducer shape through the real pipeline in one pass: AddImage on a
+// digest-pinned multi-arch index (with the unknown/unknown attestation child
+// real registries attach) -> SaveCmd --containerd -> unarchive -> all three
+// archive files. TestWriteContainerdIndexes and TestWriteExportsManifest_*
+// exercise writeContainerdIndexes/writeExportsManifest directly against
+// synthetic or single-purpose fixtures; nothing else routes a digest-pinned
+// index through AddImage and SaveCmd together and inspects index.json,
+// hauler-index.json, and manifest.json from the same archive. A non-image
+// file artifact is included so the "zero non-image kinds" and dropped-count
+// assertions are non-vacuous.
+func TestSaveCmd_ContainerdCompatibility_DigestPinnedMultiArch(t *testing.T) {
+	ctx := newTestContext(t)
+	host, srcOpts := newLocalhostRegistry(t)
+	idx := seedIndexWithUnknown(t, host, "test/save-multiarch-digest", "v1", srcOpts...)
+	parentHash, err := idx.Digest()
+	if err != nil {
+		t.Fatalf("idx.Digest: %v", err)
+	}
+
+	s := newTestStore(t)
+	imageRef := host + "/test/save-multiarch-digest@" + parentHash.String()
+	if _, err := s.AddImage(ctx, imageRef, "", false, "", false, ""); err != nil {
+		t.Fatalf("AddImage by digest: %v", err)
+	}
+	fileURL := seedFileInHTTPServer(t, "companion.txt", "not an image")
+	if err := storeFile(ctx, s, v1.File{Path: fileURL}, defaultCliOpts(), defaultRootOpts(s.Root)); err != nil {
+		t.Fatalf("storeFile: %v", err)
+	}
+
+	archivePath := filepath.Join(t.TempDir(), "haul-multiarch-digest.tar.zst")
+	o := newSaveOpts(s.Root, archivePath)
+	o.ContainerdCompatibility = true
+	if err := SaveCmd(ctx, o, s, defaultRootOpts(s.Root), defaultCliOpts()); err != nil {
+		t.Fatalf("SaveCmd ContainerdCompatibility: %v", err)
+	}
+
+	destDir := t.TempDir()
+	if err := archives.Unarchive(ctx, archivePath, destDir); err != nil {
+		t.Fatalf("Unarchive: %v", err)
+	}
+
+	// filtered index.json: exactly the parent index descriptor, normalized name, no
+	// non-image kinds -- the attestation child and file artifact must both be gone.
+	var filtered ocispec.Index
+	data, err := os.ReadFile(filepath.Join(destDir, "index.json"))
+	if err != nil {
+		t.Fatalf("read archive index.json: %v", err)
+	}
+	if err := json.Unmarshal(data, &filtered); err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered.Manifests) != 1 {
+		t.Fatalf("filtered index.json manifests = %d, want 1 (parent index only)", len(filtered.Manifests))
+	}
+	parent := filtered.Manifests[0]
+	if parent.Digest.String() != parentHash.String() {
+		t.Errorf("filtered parent digest = %s, want %s", parent.Digest, parentHash)
+	}
+	if kind := parent.Annotations[consts.KindAnnotationName]; kind != consts.KindAnnotationIndex {
+		t.Errorf("filtered parent kind = %q, want %q", kind, consts.KindAnnotationIndex)
+	}
+	wantContainerdName := reference.NormalizeContainerd(imageRef)
+	if got := parent.Annotations[consts.ContainerdImageNameKey]; got != wantContainerdName {
+		t.Errorf("filtered parent io.containerd.image.name = %q, want %q", got, wantContainerdName)
+	}
+
+	// The parent index blob itself must ride along in blobs/ -- spec §9.1's "parent
+	// blob present" assertion, proven directly rather than only transitively via a
+	// successful Unarchive.
+	blobPath := filepath.Join(destDir, "blobs", parentHash.Algorithm, parentHash.Hex)
+	if _, err := os.Stat(blobPath); err != nil {
+		t.Errorf("parent index blob missing from archive at %s: %v", blobPath, err)
+	}
+
+	// hauler-index.json sidecar: parent index and the file artifact both present.
+	sidecarData, err := os.ReadFile(filepath.Join(destDir, consts.HaulerIndexFile))
+	if err != nil {
+		t.Fatalf("read %s: %v", consts.HaulerIndexFile, err)
+	}
+	var sidecar ocispec.Index
+	if err := json.Unmarshal(sidecarData, &sidecar); err != nil {
+		t.Fatal(err)
+	}
+	if len(sidecar.Manifests) != 2 {
+		t.Fatalf("%s manifests = %d, want 2 (parent index + file)", consts.HaulerIndexFile, len(sidecar.Manifests))
+	}
+	foundParent, foundFile := false, false
+	for _, d := range sidecar.Manifests {
+		if d.Digest.String() == parentHash.String() {
+			foundParent = true
+		}
+		if strings.Contains(d.Annotations[ocispec.AnnotationRefName], "companion.txt") {
+			foundFile = true
+		}
+	}
+	if !foundParent {
+		t.Errorf("%s missing parent index digest %s", consts.HaulerIndexFile, parentHash)
+	}
+	if !foundFile {
+		t.Errorf("%s missing companion.txt file artifact", consts.HaulerIndexFile)
+	}
+
+	// manifest.json: every digest-pinned-index tag derives from the parent digest,
+	// never a child's -- the #643/#744 regression this whole feature fixes.
+	parentTag := strings.ReplaceAll(parentHash.String(), ":", "-")
+	var tags []string
+	for _, e := range readManifestJSON(t, destDir) {
+		tags = append(tags, e.RepoTags...)
+	}
+	if len(tags) == 0 {
+		t.Fatal("manifest.json has no RepoTags for the digest-pinned index")
+	}
+	for _, tag := range tags {
+		if !strings.Contains(tag, parentTag) {
+			t.Errorf("manifest.json tag %q not derived from parent digest %s", tag, parentHash)
+		}
+		if strings.Contains(tag, "-unknown-unknown") {
+			t.Errorf("manifest.json tag %q carries the unknown/unknown attestation child", tag)
+		}
+	}
+}
+
+// snapshotDir maps every file under root (relative path) to its content hash.
+func snapshotDir(t *testing.T, root string) map[string]string {
+	t.Helper()
+	snap := map[string]string{}
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		rel, _ := filepath.Rel(root, p)
+		snap[rel] = fmt.Sprintf("%x", sha256.Sum256(data))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("snapshotDir: %v", err)
+	}
+	return snap
+}
+
+// TestSaveCmd_DoesNotMutateStore asserts save never mutates the live store,
+// with one deliberate, documented exception: audit.log. At AuditLevel
+// "standard" (the CLI default -- auditLevel in audit.go), Append writes a
+// portable entry to <storeDir>/audit.log as designed (#727); that append is
+// intentional and stays. The first two iterations run at AuditLevel "none"
+// (defaultCliOpts) and must see zero delta, byte for byte. The third
+// iteration runs at AuditLevel "standard" and must see exactly one delta:
+// audit.log created or appended to -- nothing else in the store may move.
+func TestSaveCmd_DoesNotMutateStore(t *testing.T) {
+	ctx := newTestContext(t)
+	host, _ := newLocalhostRegistry(t)
+	seedImage(t, host, "test/no-mutate", "v1")
+
+	s := newTestStore(t)
+	if _, err := s.AddImage(ctx, host+"/test/no-mutate:v1", "", false, "", false, ""); err != nil {
+		t.Fatalf("AddImage: %v", err)
+	}
+
+	before := snapshotDir(t, s.Root)
+	for _, containerd := range []bool{false, true} {
+		o := newSaveOpts(s.Root, filepath.Join(t.TempDir(), "haul.tar.zst"))
+		o.ContainerdCompatibility = containerd
+		if err := SaveCmd(ctx, o, s, defaultRootOpts(s.Root), defaultCliOpts()); err != nil {
+			t.Fatalf("SaveCmd(containerd=%v): %v", containerd, err)
+		}
+		after := snapshotDir(t, s.Root)
+		if !reflect.DeepEqual(before, after) {
+			t.Errorf("store mutated by save (containerd=%v):\nbefore: %v\nafter:  %v", containerd, before, after)
+		}
+	}
+
+	t.Run("audit standard only touches audit.log", func(t *testing.T) {
+		before := snapshotDir(t, s.Root)
+
+		ro := defaultCliOpts()
+		ro.AuditLevel = "standard"
+		// Point the global audit write at a temp dir too, so this test never
+		// touches the real $HOME/.hauler/audit.log -- see testhelpers_test.go's
+		// note on defaultCliOpts for why AuditLevel defaults to "none" there.
+		ro.HaulerDir = t.TempDir()
+
+		o := newSaveOpts(s.Root, filepath.Join(t.TempDir(), "haul.tar.zst"))
+		if err := SaveCmd(ctx, o, s, defaultRootOpts(s.Root), ro); err != nil {
+			t.Fatalf("SaveCmd(audit=standard): %v", err)
+		}
+		after := snapshotDir(t, s.Root)
+
+		var changed []string
+		for k, v := range after {
+			if bv, ok := before[k]; !ok || bv != v {
+				changed = append(changed, k)
+			}
+		}
+		for k := range before {
+			if _, ok := after[k]; !ok {
+				t.Errorf("store file %q disappeared after save", k)
+			}
+		}
+		if len(changed) != 1 || changed[0] != audit.LogFileName {
+			t.Errorf("expected only %s to change, got: %v", audit.LogFileName, changed)
+		}
+	})
+}
+
+// TestSaveCmd_OutputInsideStoreDir proves the ReadDir skip on absOutputfile
+// (#744 fold-in b): saving into a path inside the store dir a second time
+// used to map the first save's own output file, which ArchiveFiles then
+// deletes via RemoveAll before FilesFromDisk can read it -- erroring on a
+// path that no longer exists.
+func TestSaveCmd_OutputInsideStoreDir(t *testing.T) {
+	ctx := newTestContext(t)
+	host, _ := newLocalhostRegistry(t)
+	seedImage(t, host, "test/output-in-store", "v1")
+
+	s := newTestStore(t)
+	if _, err := s.AddImage(ctx, host+"/test/output-in-store:v1", "", false, "", false, ""); err != nil {
+		t.Fatalf("AddImage: %v", err)
+	}
+
+	archivePath := filepath.Join(s.Root, "haul.tar.zst")
+	o := newSaveOpts(s.Root, archivePath)
+
+	if err := SaveCmd(ctx, o, s, defaultRootOpts(s.Root), defaultCliOpts()); err != nil {
+		t.Fatalf("first SaveCmd: %v", err)
+	}
+	if err := SaveCmd(ctx, o, s, defaultRootOpts(s.Root), defaultCliOpts()); err != nil {
+		t.Fatalf("second SaveCmd (output already present in store dir): %v", err)
+	}
+}
+
+func TestSaveCmd_DefaultArchiveLayoutUnchanged(t *testing.T) {
+	ctx := newTestContext(t)
+	host, _ := newLocalhostRegistry(t)
+	seedImage(t, host, "test/default-layout", "v1")
+
+	s := newTestStore(t)
+	if _, err := s.AddImage(ctx, host+"/test/default-layout:v1", "", false, "", false, ""); err != nil {
+		t.Fatalf("AddImage: %v", err)
+	}
+	archivePath := filepath.Join(t.TempDir(), "haul.tar.zst")
+	if err := SaveCmd(ctx, newSaveOpts(s.Root, archivePath), s, defaultRootOpts(s.Root), defaultCliOpts()); err != nil {
+		t.Fatalf("SaveCmd: %v", err)
+	}
+
+	destDir := t.TempDir()
+	if err := archives.Unarchive(ctx, archivePath, destDir); err != nil {
+		t.Fatalf("Unarchive: %v", err)
+	}
+	// oci-layout here is RESTORED, not preserved: v1 parity, but v2's store
+	// never wrote one before this change (#744) -- see the scratch-marker
+	// generation in SaveCmd. Don't assume a live store already has this file.
+	for _, want := range []string{"index.json", "oci-layout", "manifest.json", "blobs"} {
+		if _, err := os.Stat(filepath.Join(destDir, want)); err != nil {
+			t.Errorf("default archive missing %s: %v", want, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(destDir, consts.HaulerIndexFile)); !os.IsNotExist(err) {
+		t.Errorf("default archive must not contain the sidecar")
 	}
 }
 
@@ -297,7 +826,6 @@ func TestParseChunkSize(t *testing.T) {
 
 // --------------------------------------------------------------------------
 // SaveCmd chunk-size integration tests
-// Do NOT use t.Parallel() — SaveCmd calls os.Chdir.
 // --------------------------------------------------------------------------
 
 func TestSaveCmd_ChunkSize(t *testing.T) {

--- a/cmd/hauler/cli/store/testhelpers_test.go
+++ b/cmd/hauler/cli/store/testhelpers_test.go
@@ -273,6 +273,57 @@ func seedIndex(t *testing.T, host, repo, tag string, opts ...remote.Option) gcrv
 	return idx
 }
 
+// seedIndexWithUnknown mirrors seedIndex but adds a third child with
+// Platform unknown/unknown, matching the attestation-manifest topology real
+// registries (e.g. the busybox image in #744) attach to a multi-arch index.
+func seedIndexWithUnknown(t *testing.T, host, repo, tag string, opts ...remote.Option) gcrv1.ImageIndex {
+	t.Helper()
+	amd64Img, err := random.Image(512, 2)
+	if err != nil {
+		t.Fatalf("seedIndexWithUnknown random.Image amd64: %v", err)
+	}
+	arm64Img, err := random.Image(512, 2)
+	if err != nil {
+		t.Fatalf("seedIndexWithUnknown random.Image arm64: %v", err)
+	}
+	unknownImg, err := random.Image(512, 2)
+	if err != nil {
+		t.Fatalf("seedIndexWithUnknown random.Image unknown: %v", err)
+	}
+	idx := mutate.AppendManifests(
+		empty.Index,
+		mutate.IndexAddendum{
+			Add: amd64Img,
+			Descriptor: gcrv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gcrv1.Platform{OS: "linux", Architecture: "amd64"},
+			},
+		},
+		mutate.IndexAddendum{
+			Add: arm64Img,
+			Descriptor: gcrv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gcrv1.Platform{OS: "linux", Architecture: "arm64"},
+			},
+		},
+		mutate.IndexAddendum{
+			Add: unknownImg,
+			Descriptor: gcrv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gcrv1.Platform{OS: "unknown", Architecture: "unknown"},
+			},
+		},
+	)
+	ref, err := name.NewTag(host+"/"+repo+":"+tag, name.Insecure)
+	if err != nil {
+		t.Fatalf("seedIndexWithUnknown name.NewTag: %v", err)
+	}
+	if err := remote.WriteIndex(ref, idx, opts...); err != nil {
+		t.Fatalf("seedIndexWithUnknown remote.WriteIndex: %v", err)
+	}
+	return idx
+}
+
 // seedFileInHTTPServer starts an httptest server serving a single file at
 // /filename with the given content. Returns the full URL. Server closed via t.Cleanup.
 func seedFileInHTTPServer(t *testing.T, filename, content string) string {

--- a/internal/flags/save.go
+++ b/internal/flags/save.go
@@ -18,7 +18,7 @@ func (o *SaveOpts) AddFlags(cmd *cobra.Command) {
 
 	f.StringVarP(&o.FileName, "filename", "f", consts.DefaultHaulerArchiveName, "(Optional) Specify the name of outputted haul")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform for runtime imports... i.e. linux/amd64 (unspecified implies all)")
-	f.BoolVar(&o.ContainerdCompatibility, "containerd", false, "(Optional) Enable import compatibility with containerd... removes oci-layout from the haul")
+	f.BoolVar(&o.ContainerdCompatibility, "containerd", false, "(Optional) Enable import compatibility with containerd... filters index.json to image content, preserving the full index as a sidecar")
 	f.StringVar(&o.ChunkSize, "chunk-size", "", "(Optional) Split the output archive into chunks of the specified size (e.g. 1G, 500M, 2048M)")
 
 }

--- a/pkg/archives/archiver.go
+++ b/pkg/archives/archiver.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/mholt/archives"
 	"hauler.dev/go/hauler/v2/pkg/log"
@@ -42,6 +43,30 @@ func Archive(ctx context.Context, dir, outfile string, compression archives.Comp
 	l := log.FromContext(ctx)
 	l.Debugf("starting the archival process for [%s]", dir)
 
+	if !isExist(dir) {
+		errMsg := fmt.Errorf("directory [%s] does not exist, cannot proceed with archival", dir)
+		l.Debugf("%s", errMsg.Error())
+		return errMsg
+	}
+
+	// FilesFromDisk maps a directory key to the directory's *contents*
+	// nested one level under the map value: {dir: "blobs"} yields an archive
+	// tree rooted at "blobs/<dir's children>", not "blobs/<dir's basename>/...".
+	// So the source dir's basename must be supplied explicitly as the map
+	// value to reproduce Archive's historical top-level-named layout.
+	archiveDirName := filepath.Base(filepath.Clean(dir))
+	if dir == "." {
+		archiveDirName = ""
+	}
+	return ArchiveFiles(ctx, map[string]string{dir: archiveDirName}, outfile, compression, archival)
+}
+
+// ArchiveFiles archives an explicit disk-path -> archive-path map rather than a
+// whole directory, so save can substitute generated files (filtered index.json,
+// manifest.json) without ever mutating the source store directory (#744).
+func ArchiveFiles(ctx context.Context, fileMap map[string]string, outfile string, compression archives.Compression, archival archives.Archival) error {
+	l := log.FromContext(ctx)
+
 	// remove outfile
 	l.Debugf("removing existing output file: [%s]", outfile)
 	if err := os.RemoveAll(outfile); err != nil {
@@ -50,27 +75,33 @@ func Archive(ctx context.Context, dir, outfile string, compression archives.Comp
 		return errMsg
 	}
 
-	if !isExist(dir) {
-		errMsg := fmt.Errorf("directory [%s] does not exist, cannot proceed with archival", dir)
-		l.Debugf("%s", errMsg.Error())
-		return errMsg
-	}
-
 	// map files on disk to their paths in the archive
-	l.Debugf("mapping files in directory [%s]", dir)
-	archiveDirName := filepath.Base(filepath.Clean(dir))
-	if dir == "." {
-		archiveDirName = ""
+	l.Debugf("mapping files for archive [%s]", outfile)
+	// mholt/archives.FilesFromDisk ranges over fileMap directly, and Go
+	// randomizes map iteration order per range -- even two ranges over the same
+	// map in one process can differ. Left alone, that made two saves of an
+	// identical store produce byte-different .tar.zst files and shifted
+	// --chunk-size boundaries. Each root is walked independently (no shared
+	// state across roots in FilesFromDisk), so calling it once per sorted key
+	// and concatenating gives the same []FileInfo the library would produce,
+	// just in a fixed order.
+	keys := make([]string, 0, len(fileMap))
+	for k := range fileMap {
+		keys = append(keys, k)
 	}
-	files, err := archives.FilesFromDisk(context.Background(), nil, map[string]string{
-		dir: archiveDirName,
-	})
-	if err != nil {
-		errMsg := fmt.Errorf("error mapping files from directory [%s]: %w", dir, err)
-		l.Debugf("%s", errMsg.Error())
-		return errMsg
+	sort.Strings(keys)
+
+	var files []archives.FileInfo
+	for _, rootOnDisk := range keys {
+		rootFiles, err := archives.FilesFromDisk(ctx, nil, map[string]string{rootOnDisk: fileMap[rootOnDisk]})
+		if err != nil {
+			errMsg := fmt.Errorf("error mapping files: %w", err)
+			l.Debugf("%s", errMsg.Error())
+			return errMsg
+		}
+		files = append(files, rootFiles...)
 	}
-	l.Debugf("successfully mapped files for directory [%s]", dir)
+	l.Debugf("successfully mapped files for archive [%s]", outfile)
 
 	// create the output file we'll write to
 	l.Debugf("creating output file [%s]", outfile)
@@ -94,7 +125,7 @@ func Archive(ctx context.Context, dir, outfile string, compression archives.Comp
 
 	// create the archive
 	l.Debugf("starting archive for [%s]", outfile)
-	err = format.Archive(context.Background(), outf, files)
+	err = format.Archive(ctx, outf, files)
 	if err != nil {
 		errMsg := fmt.Errorf("error during archive creation for output file [%s]: %w", outfile, err)
 		l.Debugf("%s", errMsg.Error())

--- a/pkg/archives/archives_test.go
+++ b/pkg/archives/archives_test.go
@@ -3,6 +3,7 @@ package archives
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -403,6 +404,108 @@ func TestJoinChunks(t *testing.T) {
 			t.Errorf("JoinChunks() included non-numeric suffix file; content = %q", data)
 		}
 	})
+}
+
+// --------------------------------------------------------------------------
+// ArchiveFiles
+// --------------------------------------------------------------------------
+
+func TestArchiveFiles(t *testing.T) {
+	ctx := context.Background()
+
+	// A "store" dir with a nested blobs tree, and a separate scratch dir whose
+	// generated index.json must land at the archive root in place of the store's.
+	storeDir := t.TempDir()
+	blobDir := filepath.Join(storeDir, "blobs", "sha256")
+	if err := os.MkdirAll(blobDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(blobDir, "aaa"), []byte("blob-bytes"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(storeDir, "index.json"), []byte(`{"stale":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	scratch := t.TempDir()
+	if err := os.WriteFile(filepath.Join(scratch, "index.json"), []byte(`{"generated":true}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := filepath.Join(t.TempDir(), "out.tar.zst")
+	files := map[string]string{
+		filepath.Join(storeDir, "blobs"):     "blobs",
+		filepath.Join(scratch, "index.json"): "index.json",
+	}
+	if err := ArchiveFiles(ctx, files, out, CompressionMap["zst"], ArchivalMap["tar"]); err != nil {
+		t.Fatalf("ArchiveFiles: %v", err)
+	}
+
+	dest := t.TempDir()
+	if err := Unarchive(ctx, out, dest); err != nil {
+		t.Fatalf("Unarchive: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "index.json"))
+	if err != nil {
+		t.Fatalf("index.json missing from archive root: %v", err)
+	}
+	if string(got) != `{"generated":true}` {
+		t.Errorf("index.json = %s, want the scratch copy, not the store's", got)
+	}
+	if _, err := os.ReadFile(filepath.Join(dest, "blobs", "sha256", "aaa")); err != nil {
+		t.Errorf("blobs tree not nested correctly: %v", err)
+	}
+}
+
+// TestArchiveFiles_DeterministicOrder guards against mholt/archives.FilesFromDisk's
+// map-range iteration (randomized per range, even within one process) leaking into
+// tar entry order: two ArchiveFiles runs over the identical multi-entry fileMap must
+// produce byte-identical archives, or identical saves would diverge and
+// --chunk-size boundaries would shift between runs (#744 fix 2).
+func TestArchiveFiles_DeterministicOrder(t *testing.T) {
+	ctx := context.Background()
+
+	srcDir := t.TempDir()
+	entries := map[string]string{
+		"alpha.txt":          "alpha-content",
+		"bravo.txt":          "bravo-content",
+		"charlie/nested.txt": "charlie-content",
+		"delta.txt":          "delta-content",
+		"echo.txt":           "echo-content",
+	}
+	for rel, content := range entries {
+		full := filepath.Join(srcDir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fileMap := map[string]string{
+		filepath.Join(srcDir, "alpha.txt"): "alpha.txt",
+		filepath.Join(srcDir, "bravo.txt"): "bravo.txt",
+		filepath.Join(srcDir, "charlie"):   "charlie",
+		filepath.Join(srcDir, "delta.txt"): "delta.txt",
+		filepath.Join(srcDir, "echo.txt"):  "echo.txt",
+	}
+
+	var digests [2]string
+	for i := range digests {
+		out := filepath.Join(t.TempDir(), "out.tar.zst")
+		if err := ArchiveFiles(ctx, fileMap, out, CompressionMap["zst"], ArchivalMap["tar"]); err != nil {
+			t.Fatalf("ArchiveFiles run %d: %v", i, err)
+		}
+		data, err := os.ReadFile(out)
+		if err != nil {
+			t.Fatalf("read archive run %d: %v", i, err)
+		}
+		digests[i] = fmt.Sprintf("%x", sha256.Sum256(data))
+	}
+
+	if digests[0] != digests[1] {
+		t.Errorf("archive digests differ across identical runs: %s vs %s", digests[0], digests[1])
+	}
 }
 
 // --------------------------------------------------------------------------

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -123,6 +123,11 @@ const (
 	ImageManifestFile = "manifest.json"
 	ImageConfigFile   = "config.json"
 
+	// HaulerIndexFile is the full-fidelity index sidecar written into --containerd
+	// hauls, whose index.json is filtered to image content for containerd's OCI
+	// import path; store load prefers this file so non-image artifacts round-trip.
+	HaulerIndexFile = "hauler-index.json"
+
 	// other constraints
 	CarbideRegistry           = "rgcrprod.azurecr.us"
 	DefaultNamespace          = "hauler"

--- a/pkg/reference/reference.go
+++ b/pkg/reference/reference.go
@@ -7,6 +7,7 @@ package reference
 import (
 	"strings"
 
+	dreference "github.com/distribution/reference"
 	gname "github.com/google/go-containerregistry/pkg/name"
 
 	"hauler.dev/go/hauler/v2/pkg/consts"
@@ -62,4 +63,19 @@ func Relocate(reference string, registry string) (gname.Reference, error) {
 		return relocated.Context().Digest(ref.Identifier()), nil
 	}
 	return relocated.Context().Tag(ref.Identifier()), nil
+}
+
+// NormalizeContainerd returns ref in the distribution-normalized form containerd
+// and CRI resolve ("docker.io/library/busybox:tag", never "index.docker.io/...").
+// Hauler v1 wrote store annotations this way via its cosign fork; v2's writeImage
+// lost it, which is the #744 regression on the OCI import path. Unparseable input
+// is returned unchanged -- never fail a flow over a name hauler itself wrote.
+// Tagless input gains ":latest" (ParseDockerRef semantics); hauler always passes
+// refs that already carry a tag or digest.
+func NormalizeContainerd(ref string) string {
+	named, err := dreference.ParseDockerRef(ref)
+	if err != nil {
+		return ref
+	}
+	return named.String()
 }

--- a/pkg/reference/reference_test.go
+++ b/pkg/reference/reference_test.go
@@ -55,3 +55,23 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeContainerd(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"index.docker.io digest ref", "index.docker.io/library/busybox@sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0", "docker.io/library/busybox@sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0"},
+		{"index.docker.io tag ref", "index.docker.io/library/nginx:1.25", "docker.io/library/nginx:1.25"},
+		{"short docker hub ref", "busybox:latest", "docker.io/library/busybox:latest"},
+		{"non-hub registry untouched", "ghcr.io/org/img:v1", "ghcr.io/org/img:v1"},
+		{"port registry untouched", "localhost:5000/test/img:v1", "localhost:5000/test/img:v1"},
+		{"unparseable returns input", "not a ref!!", "not a ref!!"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := reference.NormalizeContainerd(tc.in); got != tc.want {
+				t.Errorf("NormalizeContainerd(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -30,6 +30,7 @@ import (
 	"hauler.dev/go/hauler/v2/pkg/consts"
 	"hauler.dev/go/hauler/v2/pkg/content"
 	"hauler.dev/go/hauler/v2/pkg/layer"
+	href "hauler.dev/go/hauler/v2/pkg/reference"
 )
 
 type Layout struct {
@@ -461,6 +462,10 @@ func (l *Layout) writeImage(ctx context.Context, annotationRef gname.Reference, 
 	if containerdName == "" {
 		containerdName = annotationRef.Name()
 	}
+	// Provenance keeps the pre-normalization ref; only the containerd lookup
+	// name gets the docker.io form.
+	originalRef := containerdName
+	containerdName = href.NormalizeContainerd(containerdName)
 	desc := ocispec.Descriptor{
 		MediaType: string(mt),
 		Digest:    d,
@@ -471,7 +476,7 @@ func (l *Layout) writeImage(ctx context.Context, annotationRef gname.Reference, 
 			consts.ContainerdImageNameKey: containerdName,
 			// Captured once at the initial add so the original, pullable reference
 			// survives even if a later --rewrite overwrites the annotations above.
-			consts.OriginalRefAnnotation: containerdName,
+			consts.OriginalRefAnnotation: originalRef,
 		},
 	}
 	return l.OCI.AddIndex(desc)
@@ -546,7 +551,7 @@ func (l *Layout) writeIndex(ctx context.Context, annotationRef gname.Reference, 
 		Annotations: map[string]string{
 			consts.KindAnnotationName:     kind,
 			ocispec.AnnotationRefName:     strings.TrimPrefix(annotationRef.Name(), annotationRef.Context().RegistryStr()+"/"),
-			consts.ContainerdImageNameKey: annotationRef.Name(),
+			consts.ContainerdImageNameKey: href.NormalizeContainerd(annotationRef.Name()),
 			// Captured once at the initial add so the original, pullable reference
 			// survives even if a later --rewrite overwrites the annotations above.
 			consts.OriginalRefAnnotation: annotationRef.Name(),

--- a/pkg/store/store_annotation_test.go
+++ b/pkg/store/store_annotation_test.go
@@ -1,0 +1,126 @@
+package store
+
+// store_annotation_test.go covers containerd-name normalization in
+// writeImage/writeIndex. This file is intentionally `package store`
+// (whitebox) rather than `package store_test` because writeImage is
+// unexported.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gname "github.com/google/go-containerregistry/pkg/name"
+	gv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	gvtypes "github.com/google/go-containerregistry/pkg/v1/types"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"hauler.dev/go/hauler/v2/pkg/consts"
+)
+
+func TestWriteImageNormalizesContainerdName(t *testing.T) {
+	l, err := NewLayout(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLayout: %v", err)
+	}
+	img, err := random.Image(256, 1)
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+	ref, err := gname.ParseReference("docker.io/library/busybox:v1")
+	if err != nil {
+		t.Fatalf("ParseReference: %v", err)
+	}
+	// ref.Name() is "index.docker.io/library/busybox:v1"; the annotation must not be.
+	if err := l.writeImage(context.Background(), ref, img, consts.KindAnnotationImage, ""); err != nil {
+		t.Fatalf("writeImage: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(l.Root, "index.json"))
+	if err != nil {
+		t.Fatalf("read index.json: %v", err)
+	}
+	var idx ocispec.Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatalf("unmarshal index: %v", err)
+	}
+	if len(idx.Manifests) != 1 {
+		t.Fatalf("expected 1 descriptor, got %d", len(idx.Manifests))
+	}
+	got := idx.Manifests[0].Annotations[consts.ContainerdImageNameKey]
+	want := "docker.io/library/busybox:v1"
+	if got != want {
+		t.Errorf("io.containerd.image.name = %q, want %q", got, want)
+	}
+}
+
+// TestWriteIndexNormalizesContainerdName is writeIndex's counterpart to
+// TestWriteImageNormalizesContainerdName above -- writeImage and writeIndex
+// each call href.NormalizeContainerd independently (store.go:460, store.go:543),
+// so a fix to one is not evidence the other was updated. This is the
+// multi-arch parent-descriptor path #744's digest-pinned index goes through.
+func TestWriteIndexNormalizesContainerdName(t *testing.T) {
+	l, err := NewLayout(t.TempDir())
+	if err != nil {
+		t.Fatalf("NewLayout: %v", err)
+	}
+	amd64Img, err := random.Image(256, 1)
+	if err != nil {
+		t.Fatalf("random.Image amd64: %v", err)
+	}
+	arm64Img, err := random.Image(256, 1)
+	if err != nil {
+		t.Fatalf("random.Image arm64: %v", err)
+	}
+	idx := mutate.AppendManifests(
+		empty.Index,
+		mutate.IndexAddendum{
+			Add: amd64Img,
+			Descriptor: gv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gv1.Platform{OS: "linux", Architecture: "amd64"},
+			},
+		},
+		mutate.IndexAddendum{
+			Add: arm64Img,
+			Descriptor: gv1.Descriptor{
+				MediaType: gvtypes.OCIManifestSchema1,
+				Platform:  &gv1.Platform{OS: "linux", Architecture: "arm64"},
+			},
+		},
+	)
+	ref, err := gname.ParseReference("docker.io/library/busybox@sha256:" +
+		"498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0")
+	if err != nil {
+		t.Fatalf("ParseReference: %v", err)
+	}
+	// ref.Name() is "index.docker.io/library/busybox@sha256:..."; the annotation must not be.
+	if err := l.writeIndex(context.Background(), ref, idx, consts.KindAnnotationIndex); err != nil {
+		t.Fatalf("writeIndex: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(l.Root, "index.json"))
+	if err != nil {
+		t.Fatalf("read index.json: %v", err)
+	}
+	var ociIdx ocispec.Index
+	if err := json.Unmarshal(data, &ociIdx); err != nil {
+		t.Fatalf("unmarshal index: %v", err)
+	}
+	if len(ociIdx.Manifests) != 1 {
+		t.Fatalf("expected 1 descriptor, got %d", len(ociIdx.Manifests))
+	}
+	got := ociIdx.Manifests[0].Annotations[consts.ContainerdImageNameKey]
+	want := "docker.io/library/busybox@sha256:498a000f370d8c37927118ed80afe8adc38d1edcbfc071627d17b25c88efcab0"
+	if got != want {
+		t.Errorf("io.containerd.image.name = %q, want %q", got, want)
+	}
+	if kind := ociIdx.Manifests[0].Annotations[consts.KindAnnotationName]; kind != consts.KindAnnotationIndex {
+		t.Errorf("kind = %q, want %q", kind, consts.KindAnnotationIndex)
+	}
+}


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

**Associated Links:**

- Fixes #744
- Related: #642 / #643 (synthetic tags for digest-only images)

**Types of Changes:**

- Bugfix (with two small behavior changes noted below)

**Proposed Changes:**

Saving a digest-pinned multi-arch image and importing the haul into containerd lost the digest the user pinned, so air-gapped workloads pinned by digest failed with `ImagePullBackOff`. Three problems stacked up to cause this:

- `manifest.json` cannot describe a multi-arch index, and its synthetic tags were derived from the per-platform child digests instead of the digest the user actually asked for.
- The `oci-layout` marker file was never written into hauls (v2 regression), so `ctr images import` always fell back to the lossy Docker format instead of reading the OCI index.
- `io.containerd.image.name` annotations were written as `index.docker.io/...` (another v2 regression — v1 normalized them), which containerd/CRI cannot resolve.

What this PR does:

- Restores the v1 `docker.io/...` name normalization at the store write sites, and normalizes names in every saved haul's `index.json` (covers stores written by older v2 versions).
- Restores the `oci-layout` marker in saved hauls, so containerd imports through the OCI index and the pinned digest survives intact.
- `--containerd` hauls now ship a filtered `index.json` (images only, so containerd's importer doesn't choke on charts/files/signatures) plus a full copy as `hauler-index.json`; `store load` prefers that sidecar, so nothing is lost on round trip.
- `manifest.json` synthetic tags for digest-pinned indexes now derive from the parent digest (`repo:sha256-<parent>-<os>-<arch>` when no `--platform` is given).
- `store save` no longer modifies the store directory while packaging (it used to write `manifest.json` into it and `--containerd` deleted its `oci-layout`), and archives are byte-reproducible again.

Behavior changes to be aware of:

- Synthetic tags for digest-pinned multi-arch images changed from child-digest to parent-digest form — scripts matching the old tags need updating.
- Default hauls now carry `oci-layout`, so `ctr images import` takes the OCI path for them too. Mixed-content hauls destined for direct containerd import should use `--containerd`.

**Verification/Testing of Changes:**

- Full suite plus `-race` passes; new unit and integration tests cover the filtered index, the sidecar round trip, the parent-digest tags, and the store-not-modified guarantee.
- The archive-level reproducer from #744 now passes: the parent descriptor, blob, and a `docker.io/...@<digest>` name are all present in the haul's `index.json`.
- Verified end to end on an RKE2 cluster (v1.35.4+rke2r1, containerd via `/run/k3s/containerd/containerd.sock`) using the exact digest from #744 (`docker.io/busybox@sha256:498a...`, 10-platform index), synced and saved with `--containerd` by a binary built from this branch.

**Additional Context:**

- A `manifest.json`-only fix was not possible: the Docker tarball format cannot express an index or a digest, and containerd rebuilds manifests on that path (new digests), so digest addressability is only achievable through the OCI index.
- The `hauler-index.json` sidecar exists because the archive's `index.json` serves two readers: containerd needs it filtered, `store load` needs it complete.
