### PR TITLE
fix(registry): serve single-component repos without library/ prefix

### DIFF
--- a/pkg/content/registry.go
+++ b/pkg/content/registry.go
@@ -168,8 +168,9 @@ func (t *RegistryTarget) Pusher(ctx context.Context, ref string) (remotes.Pusher
 // repository path and tag or digest. For example:
 //
 //	"index.docker.io/library/nginx:latest" + "localhost:5000" → "localhost:5000/library/nginx:latest"
+//	"registry.k8s.io/pause:latest" + "localhost:5000" → "localhost:5000/pause:latest"
 func RewriteRefToRegistry(sourceRef string, targetRegistry string) (string, error) {
-	ref, err := goname.ParseReference(sourceRef)
+	ref, err := goname.ParseReference(sourceRef, goname.WithDefaultRegistry(""))
 	if err != nil {
 		return "", fmt.Errorf("parsing reference %q: %w", sourceRef, err)
 	}

--- a/pkg/content/registry_test.go
+++ b/pkg/content/registry_test.go
@@ -7,6 +7,10 @@ package content
 // also incorrectly conflated with PlainHTTP when selecting the http/https
 // scheme, plus a follow-up regression where Insecure was wired into the
 // registry client but not into the Docker Bearer-auth token-fetch client.
+//
+// It also covers RewriteRefToRegistry, specifically the WithDefaultRegistry("")
+// fix that prevents single-component refs from being resolved to
+// index.docker.io, which would add the "library/" namespace prefix.
 
 import (
 	"context"
@@ -332,5 +336,133 @@ func TestNewRegistryHTTPClient_FallsBackWhenDefaultTransportIsNotHTTPTransport(t
 	}
 	if transport.TLSClientConfig == nil || !transport.TLSClientConfig.InsecureSkipVerify {
 		t.Fatalf("expected InsecureSkipVerify to be honored on the fallback transport")
+	}
+}
+
+// TestRewriteRefToRegistry_SingleComponentNoLibraryPrefix verifies that a
+// single-component ref like "pause:3.10.1" is served at "target/pause:3.10.1"
+// and NOT at "target/library/pause:3.10.1". Before the fix, go-containerregistry
+// defaulted to index.docker.io and added the "library/" namespace prefix for
+// single-component repos, breaking air-gapped kubespray setups where the
+// cluster definition references bare image names.
+func TestRewriteRefToRegistry_SingleComponentNoLibraryPrefix(t *testing.T) {
+	cases := []struct {
+		name    string
+		ref     string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "tagged single component",
+			ref:  "pause:3.10.1",
+			want: "registry.evroc.dev/pause:3.10.1",
+		},
+		{
+			name: "tagged single component without tag defaults to latest",
+			ref:  "kube-apiserver",
+			want: "registry.evroc.dev/kube-apiserver:latest",
+		},
+		{
+			name: "digest single component",
+			ref:  "pause@sha256:" + strings.Repeat("a", 64),
+			want: "registry.evroc.dev/pause@sha256:" + strings.Repeat("a", 64),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := RewriteRefToRegistry(tc.ref, "registry.evroc.dev")
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("RewriteRefToRegistry(%q, ...) = %q, want %q", tc.ref, got, tc.want)
+			}
+			if strings.Contains(got, "library/") {
+				t.Errorf("result should not contain 'library/' prefix, got: %q", got)
+			}
+		})
+	}
+}
+
+// TestRewriteRefToRegistry_MultiComponentUnchanged verifies that refs with
+// multiple path components (e.g. "coredns/coredns:v1.12.4") are served at
+// "target/coredns/coredns:v1.12.4".
+func TestRewriteRefToRegistry_MultiComponentUnchanged(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{
+			name: "two-component tag",
+			ref:  "coredns/coredns:v1.12.4",
+			want: "registry.evroc.dev/coredns/coredns:v1.12.4",
+		},
+		{
+			name: "three-component tag",
+			ref:  "library/nginx:1.28.2-alpine",
+			want: "registry.evroc.dev/library/nginx:1.28.2-alpine",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := RewriteRefToRegistry(tc.ref, "registry.evroc.dev")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("RewriteRefToRegistry(%q, ...) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRewriteRefToRegistry_FullUpstreamRefStripped verifies that a ref with
+// an explicit upstream registry (e.g. "registry.k8s.io/pause:3.10.1") has the
+// upstream registry stripped, producing "target/pause:3.10.1" matching the mirror
+// model where the target replaces the upstream.
+func TestRewriteRefToRegistry_FullUpstreamRefStripped(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{
+			name: "registry.k8s.io single component",
+			ref:  "registry.k8s.io/pause:3.10.1",
+			want: "registry.evroc.dev/pause:3.10.1",
+		},
+		{
+			name: "registry.k8s.io multi component",
+			ref:  "registry.k8s.io/coredns/coredns:v1.12.4",
+			want: "registry.evroc.dev/coredns/coredns:v1.12.4",
+		},
+		{
+			name: "docker.io library multi component",
+			ref:  "index.docker.io/library/nginx:1.28.2-alpine",
+			want: "registry.evroc.dev/library/nginx:1.28.2-alpine",
+		},
+		{
+			name: "ghcr.io multi component",
+			ref:  "ghcr.io/kube-vip/kube-vip:v1.0.3",
+			want: "registry.evroc.dev/kube-vip/kube-vip:v1.0.3",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := RewriteRefToRegistry(tc.ref, "registry.evroc.dev")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("RewriteRefToRegistry(%q, ...) = %q, want %q", tc.ref, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION


Fixes #747

**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

Issue #747 

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

Bugfix. Breaking change for someone relying on the current behavior.

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

RewriteRefToRegistry used goname.ParseReference without WithDefaultRegistry(""), causing go-containerregistry to default to index.docker.io and add the "library/" namespace prefix for single-component refs (e.g. "pause:3.10.1" → "library/pause:3.10.1").

Pass WithDefaultRegistry("") so single-component refs keep their bare name. Refs with an explicit upstream registry are unaffected.

Add tests for single-component, multi-component, and full-upstream ref stripping.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

Try the steps to reproduce in #747 

