### PR TITLE
feat: Add base support for registries.yaml for using a custom image p…

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -213,6 +213,13 @@ jobs:
           # verify existing registry associated with rewritten image in store
           hauler store info | grep 'ghcr.io/custom-path/nginx'
 
+      - name: Verify - hauler store add image with registry config
+        run: |
+          # verify via image reference
+          hauler store add image registry01.io/hauler-dev/library/busybox --registries-file-path testdata/registries.yaml --platform linux/amd64
+          # verify via the hauler store contents
+          hauler store info --output json | jq -e '.artifacts | map(select(.type=="image" and .reference=="registry01.io/hauler-dev/library/busybox:latest")) | length == 1' >/dev/null
+
       - name: Verify - hauler store copy
         run: |
           hauler store copy --help
@@ -334,6 +341,8 @@ jobs:
           hauler store info --output json | jq -e '.artifacts | map(select(.type=="image" and .reference=="ghcr.io/kube-vip/kube-vip:v1.0.4")) | length == 1' >/dev/null
           # verify via sync with multiple files
           hauler store sync --filename testdata/hauler-manifest-pipeline.yaml --filename testdata/hauler-manifest.yaml
+          # sync chart with required registry config
+          hauler store sync --filename testdata/hauler-manifest-with-required-registry-config.yaml --registries-file-path testdata/registries.yaml
           # need more tests here
 
       - name: Verify - hauler store sync (image list)

--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -31,6 +31,7 @@ import (
 	"hauler.dev/go/hauler/v2/pkg/artifacts/chart"
 	"hauler.dev/go/hauler/v2/pkg/artifacts/file"
 	"hauler.dev/go/hauler/v2/pkg/audit"
+	"hauler.dev/go/hauler/v2/pkg/config"
 	"hauler.dev/go/hauler/v2/pkg/consts"
 	"hauler.dev/go/hauler/v2/pkg/cosign"
 	"hauler.dev/go/hauler/v2/pkg/getter"
@@ -242,7 +243,7 @@ func AddImageCmd(ctx context.Context, o *flags.AddImageOpts, s *store.Layout, re
 	// through to here under --ignore-errors, so err == nil already rules out
 	// the failed-but-stored-anyway case without checking ignoreErrors again.
 	verified := err == nil && !addImageVerifyConfig(o).Empty()
-	return storeImage(ctx, s, cfg, o.Platform, o.ExcludeExtras, rso, ro, o.Rewrite, pinnedDigest, verified)
+	return storeImage(ctx, s, cfg, o.Platform, o.ExcludeExtras, rso, ro, o.Rewrite, pinnedDigest, verified, o.RegistriesFilePath)
 }
 
 // addImageVerifyConfig collapses o's verification flags into a cosign.Config,
@@ -507,7 +508,7 @@ func digestRefTag(d goname.Digest) (goname.Tag, bool) {
 // storeImage re-deriving it from i's verification fields, since under
 // --ignore-errors those fields stay set even after a failed check and i alone
 // can no longer distinguish "verified" from "verification requested."
-func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform string, excludeExtras bool, rso *flags.StoreRootOpts, ro *flags.CliRootOpts, rewrite string, pinnedDigest string, verified bool) error {
+func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform string, excludeExtras bool, rso *flags.StoreRootOpts, ro *flags.CliRootOpts, rewrite string, pinnedDigest string, verified bool, registriesFilePath string) error {
 	l := log.FromContext(ctx)
 
 	start := time.Now()
@@ -532,6 +533,53 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 		} else {
 			log.BaseFromContext(ctx).Errorf("unable to parse image [%s]: %v", i.Name, err)
 			return err
+		}
+	}
+
+	var registriesConfig *config.Registries
+	if registriesFilePath != "" {
+		log.BaseFromContext(ctx).Debugf("loading registries config [%s]", registriesFilePath)
+
+		registriesConfig, err = config.RegistriesConfigFromFile(registriesFilePath)
+		if err != nil {
+			log.BaseFromContext(ctx).Errorf("failed to load registries config: %v", err)
+			return err
+		}
+	}
+
+	ref, err := reference.Parse(r.Name())
+	if err != nil {
+		return err
+	}
+
+	registryStr := ref.Context().RegistryStr()
+
+	if registriesConfig != nil && len(registriesConfig.Mirrors) > 0 {
+		// check entry specific to registry
+		mirrorConf, ok := registriesConfig.Mirrors[registryStr]
+		if !ok {
+			// fallback to default
+			mirrorConf, ok = registriesConfig.Mirrors["*"]
+		}
+
+		if ok && len(mirrorConf.Endpoints) > 0 {
+			log.BaseFromContext(ctx).Debugf("relocating img %s to %s", r.Name(), mirrorConf.Endpoints[0])
+
+			// set rewrite to original image, as the registry config should only be used for pulling the image
+			if rewrite == "" {
+				rewrite = r.Name()
+			}
+
+			relocatedRef, err := reference.Relocate(r.Name(), mirrorConf.Endpoints[0])
+			if err != nil {
+				return fmt.Errorf("failed to relocate image %q to mirror %q: %w", r.Name(), mirrorConf.Endpoints[0], err)
+			}
+
+			// parse again to prevent issues with paths in the rewritten endpoint and mismatches in the rewrite matching
+			r, err = reference.Parse(relocatedRef.Name())
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -924,12 +972,13 @@ func resolveChartJobs(o *flags.SyncOpts, annotations map[string]string, manifest
 					InsecureSkipTLSVerify: insecureSkipTLSVerify,
 					PlainHTTP:             ch.PlainHTTP,
 				},
-				AddImages:       ch.AddImages,
-				AddDependencies: ch.AddDependencies,
-				ExcludeExtras:   excludeExtras,
-				Registry:        registry,
-				Platform:        platform,
-				ValuesFiles:     valuesFiles,
+				AddImages:          ch.AddImages,
+				AddDependencies:    ch.AddDependencies,
+				ExcludeExtras:      excludeExtras,
+				Registry:           registry,
+				Platform:           platform,
+				ValuesFiles:        valuesFiles,
+				RegistriesFilePath: o.RegistriesFilePath,
 			},
 			rewrite: ch.Rewrite,
 		})
@@ -1467,8 +1516,9 @@ func fetchChart(ctx context.Context, s *store.Layout, j chartJob, tempRoot strin
 					CaFile:                j.opts.ChartOpts.CaFile,
 					InsecureSkipTLSVerify: j.opts.ChartOpts.InsecureSkipTLSVerify,
 				},
-				platform:      j.opts.Platform,
-				excludeExtras: j.opts.ExcludeExtras,
+				platform:       j.opts.Platform,
+				excludeExtras:  j.opts.ExcludeExtras,
+				registriesPath: j.opts.RegistriesFilePath,
 			})
 		}
 	}

--- a/cmd/hauler/cli/store/add_test.go
+++ b/cmd/hauler/cli/store/add_test.go
@@ -664,7 +664,7 @@ func TestStoreImage(t *testing.T) {
 			ro := defaultCliOpts()
 			ro.IgnoreErrors = tc.ignoreErrors
 
-			err := storeImage(ctx, s, v1.Image{Name: tc.imageName}, "", false, rso, ro, "", "", false)
+			err := storeImage(ctx, s, v1.Image{Name: tc.imageName}, "", false, rso, ro, "", "", false, "")
 			if (err != nil) != tc.wantErr {
 				t.Fatalf("error = %v, wantErr %v", err, tc.wantErr)
 			}
@@ -681,7 +681,7 @@ func TestStoreImage(t *testing.T) {
 
 		t.Setenv(consts.HaulerIgnoreErrors, "true")
 
-		err := storeImage(ctx, s, v1.Image{Name: host + "/nonexistent/image:missing"}, "", false, rso, ro, "", "", false)
+		err := storeImage(ctx, s, v1.Image{Name: host + "/nonexistent/image:missing"}, "", false, rso, ro, "", "", false, "")
 		if err != nil {
 			t.Fatalf("expected nil with HAULER_IGNORE_ERRORS=true, got: %v", err)
 		}
@@ -735,7 +735,7 @@ func TestStoreImage_Rewrite(t *testing.T) {
 		rso := defaultRootOpts(s.Root)
 		ro := defaultCliOpts()
 
-		err := storeImage(ctx, s, v1.Image{Name: host + "/src/repo:v1"}, "", false, rso, ro, "newrepo/img:v2", "", false)
+		err := storeImage(ctx, s, v1.Image{Name: host + "/src/repo:v1"}, "", false, rso, ro, "newrepo/img:v2", "", false, "")
 		if err != nil {
 			t.Fatalf("storeImage with rewrite: %v", err)
 		}
@@ -751,7 +751,7 @@ func TestStoreImage_Rewrite(t *testing.T) {
 		rso := defaultRootOpts(s.Root)
 		ro := defaultCliOpts()
 
-		err := storeImage(ctx, s, v1.Image{Name: host + "/src/repo:v3"}, "", false, rso, ro, "newrepo/img", "", false)
+		err := storeImage(ctx, s, v1.Image{Name: host + "/src/repo:v3"}, "", false, rso, ro, "newrepo/img", "", false, "")
 		if err != nil {
 			t.Fatalf("storeImage with tagless rewrite: %v", err)
 		}
@@ -771,7 +771,7 @@ func TestStoreImage_Rewrite(t *testing.T) {
 		ro := defaultCliOpts()
 
 		digestRef := host + "/src/repo@" + h.String()
-		err = storeImage(ctx, s, v1.Image{Name: digestRef}, "", false, rso, ro, "newrepo/img", "", false)
+		err = storeImage(ctx, s, v1.Image{Name: digestRef}, "", false, rso, ro, "newrepo/img", "", false, "")
 		if err == nil {
 			t.Fatal("expected error for digest ref rewrite without explicit tag, got nil")
 		}
@@ -845,7 +845,7 @@ func TestStoreImage_MultiArch(t *testing.T) {
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/multiarch:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/multiarch:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage multi-arch index: %v", err)
 	}
 	// Full index (both platforms) must be stored as an index, not a single image.
@@ -861,7 +861,7 @@ func TestStoreImage_PlatformFilter(t *testing.T) {
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/multiarch:v2"}, "linux/amd64", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/multiarch:v2"}, "linux/amd64", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage with platform filter: %v", err)
 	}
 	// Platform filter resolves a single manifest from the index → stored as a single image.
@@ -879,7 +879,7 @@ func TestStoreImage_CosignV2Artifacts(t *testing.T) {
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/signed:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/signed:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 	assertArtifactKindInStore(t, s, "test/signed:v1", consts.KindAnnotationSigs)
@@ -898,7 +898,7 @@ func TestStoreImage_CosignV3Referrer(t *testing.T) {
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/image:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/image:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 	assertReferrerInStore(t, s, "test/image:v1")
@@ -917,7 +917,7 @@ func TestStoreImage_ExcludeExtras(t *testing.T) {
 		rso := defaultRootOpts(s.Root)
 		ro := defaultCliOpts()
 
-		if err := storeImage(ctx, s, v1.Image{Name: host + "/test/signed:v1"}, "", true, rso, ro, "", "", false); err != nil {
+		if err := storeImage(ctx, s, v1.Image{Name: host + "/test/signed:v1"}, "", true, rso, ro, "", "", false, ""); err != nil {
 			t.Fatalf("storeImage with excludeExtras: %v", err)
 		}
 
@@ -955,7 +955,7 @@ func TestStoreImage_ExcludeExtras(t *testing.T) {
 		rso := defaultRootOpts(s.Root)
 		ro := defaultCliOpts()
 
-		if err := storeImage(ctx, s, v1.Image{Name: host + "/test/image:v1"}, "", true, rso, ro, "", "", false); err != nil {
+		if err := storeImage(ctx, s, v1.Image{Name: host + "/test/image:v1"}, "", true, rso, ro, "", "", false, ""); err != nil {
 			t.Fatalf("storeImage with excludeExtras: %v", err)
 		}
 
@@ -990,7 +990,7 @@ func TestStoreImage_ExcludeExtras(t *testing.T) {
 		rso := defaultRootOpts(s.Root)
 		ro := defaultCliOpts()
 
-		if err := storeImage(ctx, s, v1.Image{Name: host + "/test/signed:v2"}, "", false, rso, ro, "", "", false); err != nil {
+		if err := storeImage(ctx, s, v1.Image{Name: host + "/test/signed:v2"}, "", false, rso, ro, "", "", false, ""); err != nil {
 			t.Fatalf("storeImage without excludeExtras: %v", err)
 		}
 
@@ -2007,7 +2007,7 @@ func TestStoreImage_RetryDoesNotDoubleCountStats(t *testing.T) {
 	ro := defaultCliOpts()
 
 	cfg := v1.Image{Name: host + "/test/retry-stats:v1"}
-	if err := storeImage(ctx, s, cfg, "", true /* excludeExtras: keep this to just the image's own layers */, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, cfg, "", true /* excludeExtras: keep this to just the image's own layers */, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 
@@ -3336,7 +3336,7 @@ func TestStoreImage_CAFileAndInsecure(t *testing.T) {
 		insecure := false
 		img := v1.Image{Name: ref, CaFile: missingCA, InsecureSkipTLSVerify: insecure}
 		err := storeImage(ctx, s, img, "", false,
-			defaultRootOpts(s.Root), defaultCliOpts(), "", "", false)
+			defaultRootOpts(s.Root), defaultCliOpts(), "", "", false, "")
 		if err == nil {
 			t.Fatal("expected error from unreadable caFile, got nil")
 		}
@@ -3354,7 +3354,7 @@ func TestStoreImage_CAFileAndInsecure(t *testing.T) {
 		insecure := false
 		img := v1.Image{Name: ref, CaFile: junk, InsecureSkipTLSVerify: insecure}
 		err := storeImage(ctx, s, img, "", false,
-			defaultRootOpts(s.Root), defaultCliOpts(), "", "", false)
+			defaultRootOpts(s.Root), defaultCliOpts(), "", "", false, "")
 		if err == nil {
 			t.Fatal("expected error from non-PEM caFile, got nil")
 		}
@@ -3368,7 +3368,7 @@ func TestStoreImage_CAFileAndInsecure(t *testing.T) {
 		insecure := true
 		img := v1.Image{Name: ref, CaFile: missingCA, InsecureSkipTLSVerify: insecure}
 		err := storeImage(ctx, s, img, "", false,
-			defaultRootOpts(s.Root), defaultCliOpts(), "", "", false)
+			defaultRootOpts(s.Root), defaultCliOpts(), "", "", false, "")
 		if err != nil {
 			t.Fatalf("insecure should ignore caFile, got: %v", err)
 		}
@@ -3380,7 +3380,7 @@ func TestStoreImage_CAFileAndInsecure(t *testing.T) {
 		insecure := false
 		img := v1.Image{Name: ref, CaFile: writeCAFile(t), InsecureSkipTLSVerify: insecure}
 		err := storeImage(ctx, s, img, "", false,
-			defaultRootOpts(s.Root), defaultCliOpts(), "", "", false)
+			defaultRootOpts(s.Root), defaultCliOpts(), "", "", false, "")
 		if err != nil {
 			t.Fatalf("valid caFile should be accepted, got: %v", err)
 		}

--- a/cmd/hauler/cli/store/copy_test.go
+++ b/cmd/hauler/cli/store/copy_test.go
@@ -140,7 +140,7 @@ func TestCopyCmd_Registry(t *testing.T) {
 	s := newTestStore(t)
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
-	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/test/copy:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/test/copy:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 
@@ -176,7 +176,7 @@ func TestCopyCmd_Registry_OnlyFilter(t *testing.T) {
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
 	for _, repo := range []string{"myorg/repo1:v1", "myorg/repo2:v1"} {
-		if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/" + repo}, "", false, rso, ro, "", "", false); err != nil {
+		if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/" + repo}, "", false, rso, ro, "", "", false, ""); err != nil {
 			t.Fatalf("storeImage %s: %v", repo, err)
 		}
 	}
@@ -340,7 +340,7 @@ func TestCopyCmd_Registry_IgnoreErrors(t *testing.T) {
 	s := newTestStore(t)
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
-	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/test/ignore:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/test/ignore:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 
@@ -373,7 +373,7 @@ func TestCopyCmd_Registry_IgnoreErrors_EnvVar(t *testing.T) {
 	s := newTestStore(t)
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
-	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/test/ignore-env:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/test/ignore-env:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 
@@ -407,7 +407,7 @@ func TestCopyCmd_Registry_IgnoreErrors_EnvVar_MultipleArtifacts(t *testing.T) {
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
 	for _, repo := range []string{"test/ignore-env-a:v1", "test/ignore-env-b:v1"} {
-		if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/" + repo}, "", false, rso, ro, "", "", false); err != nil {
+		if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/" + repo}, "", false, rso, ro, "", "", false, ""); err != nil {
 			t.Fatalf("storeImage %s: %v", repo, err)
 		}
 	}
@@ -625,7 +625,7 @@ func TestCopyCmd_Dir_SkipsImages(t *testing.T) {
 	s := newTestStore(t)
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
-	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/test/imgskip:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/test/imgskip:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 

--- a/cmd/hauler/cli/store/create_manifest_test.go
+++ b/cmd/hauler/cli/store/create_manifest_test.go
@@ -58,7 +58,7 @@ func TestCreateManifestCmd_Image(t *testing.T) {
 	s := newTestStore(t)
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
-	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/repo:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/repo:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 
@@ -126,7 +126,7 @@ func TestCreateManifestCmd_ImageWithRewrite(t *testing.T) {
 	// storeImage with a rewrite target: the store ends up with the new ref as
 	// the "current" annotations, but consts.OriginalRefAnnotation still holds
 	// the original, pullable source ref captured at the initial add.
-	if err := storeImage(ctx, s, v1.Image{Name: host + "/src/repo:v1"}, "", false, rso, ro, "newrepo/img:v2", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/src/repo:v1"}, "", false, rso, ro, "newrepo/img:v2", "", false, ""); err != nil {
 		t.Fatalf("storeImage with rewrite: %v", err)
 	}
 	assertArtifactInStore(t, s, "newrepo/img:v2")
@@ -218,7 +218,7 @@ func TestCreateManifestCmd_MultiPlatformIndexOmitsPlatform(t *testing.T) {
 	s := newTestStore(t)
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
-	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/multiarch:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/multiarch:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage multi-arch index: %v", err)
 	}
 
@@ -395,7 +395,7 @@ func TestCreateManifestCmd_MixedContent(t *testing.T) {
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/repo:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/repo:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 	co := newAddChartOpts(chartTestdataDir, "")

--- a/cmd/hauler/cli/store/lifecycle_test.go
+++ b/cmd/hauler/cli/store/lifecycle_test.go
@@ -112,7 +112,7 @@ func TestLifecycle_Image_AddSaveLoadCopyRegistry(t *testing.T) {
 	storeA := newTestStore(t)
 	rso := defaultRootOpts(storeA.Root)
 	ro := defaultCliOpts()
-	if err := storeImage(ctx, storeA, v1.Image{Name: srcHost + "/lifecycle/app:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, storeA, v1.Image{Name: srcHost + "/lifecycle/app:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 	assertArtifactInStore(t, storeA, "lifecycle/app:v1")
@@ -271,7 +271,7 @@ func TestLifecycle_DigestOnlyImage_AddSaveLoad(t *testing.T) {
 	rso := defaultRootOpts(storeA.Root)
 	ro := defaultCliOpts()
 	digestRef := srcHost + "/lifecycle/digestonly@" + hash.String()
-	if err := storeImage(ctx, storeA, v1.Image{Name: digestRef}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, storeA, v1.Image{Name: digestRef}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage by digest: %v", err)
 	}
 	// The image should be findable by its digest hex

--- a/cmd/hauler/cli/store/remove_test.go
+++ b/cmd/hauler/cli/store/remove_test.go
@@ -163,7 +163,7 @@ func TestRemoveCmd_ContainerdImageName(t *testing.T) {
 	rso := defaultRootOpts(s.Root)
 	ro := defaultCliOpts()
 
-	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/repo:v1"}, "", false, rso, ro, "", "", false); err != nil {
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/repo:v1"}, "", false, rso, ro, "", "", false, ""); err != nil {
 		t.Fatalf("storeImage: %v", err)
 	}
 

--- a/cmd/hauler/cli/store/sync.go
+++ b/cmd/hauler/cli/store/sync.go
@@ -159,7 +159,7 @@ func SyncCmd(ctx context.Context, o *flags.SyncOpts, s *store.Layout, rso *flags
 			InsecureSkipTLSVerify: o.InsecureSkipTLSVerify,
 			CaFile:                o.CaFile,
 		}
-		err := storeImage(ctx, s, img, o.Platform, o.ExcludeExtras, rso, ro, "", "", false)
+		err := storeImage(ctx, s, img, o.Platform, o.ExcludeExtras, rso, ro, "", "", false, o.RegistriesFilePath)
 		if err != nil {
 			return fmt.Errorf("failed to fetch product manifest for [%s]: %w", productName, err)
 		}
@@ -588,11 +588,12 @@ func formatIOStats(st content.IOStatsSnapshot, ceiling int) string {
 // imageJob is the fully-resolved set of inputs needed to verify (if
 // applicable) and store a single image; see resolveImageJobs.
 type imageJob struct {
-	img           v1.Image // Name already relocated to the target registry if applicable
-	platform      string
-	excludeExtras bool
-	rewrite       string
-	local         bool
+	img            v1.Image // Name already relocated to the target registry if applicable
+	platform       string
+	excludeExtras  bool
+	rewrite        string
+	local          bool
+	registriesPath string
 
 	// resolved verification inputs, collapsed into a cosign.Config by
 	// verifyConfig and consumed by the pull worker
@@ -664,7 +665,7 @@ func resolveImageJobs(o *flags.SyncOpts, a map[string]string, images []v1.Image)
 		needsKeylessVerificaton := hasAnnotationIdentityOptions || hasCliIdentityOptions || hasImageIdentityOptions
 		needsPubKeyVerification := a[consts.ImageAnnotationKey] != "" || o.Key != "" || i.Key != ""
 
-		job := imageJob{img: i}
+		job := imageJob{img: i, registriesPath: o.RegistriesFilePath}
 
 		if needsPubKeyVerification {
 			key := o.Key
@@ -1134,7 +1135,7 @@ func runRemoteImageJobsWith(ctx context.Context, s *store.Layout, jobs []imageJo
 			// and succeeded: err is nil on success and stays non-nil on a
 			// failure that fell through to here under --ignore-errors.
 			verified := err == nil && !j.verifyConfig().Empty()
-			return storeImage(jctx, s, j.img, j.platform, j.excludeExtras, rso, ro, j.rewrite, pinned, verified)
+			return storeImage(jctx, s, j.img, j.platform, j.excludeExtras, rso, ro, j.rewrite, pinned, verified, j.registriesPath)
 		})
 	}
 	return g.Wait()

--- a/internal/flags/add.go
+++ b/internal/flags/add.go
@@ -23,6 +23,7 @@ type AddImageOpts struct {
 	Local                        bool
 	CaFile                       string
 	InsecureSkipTLSVerify        bool
+	RegistriesFilePath           string
 }
 
 func (o *AddImageOpts) AddFlags(cmd *cobra.Command) {
@@ -36,6 +37,7 @@ func (o *AddImageOpts) AddFlags(cmd *cobra.Command) {
 	f.BoolVar(&o.Tlog, "use-tlog-verify", false, "(Optional) Enable transparency log verification for key-based signature verification (keyless/OIDC verification always uses the tlog)")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform of the image... i.e. linux/amd64 (defaults to all)")
 	f.StringVar(&o.Rewrite, "rewrite", "", "(Optional) Rewrite artifact path to specified string")
+	f.StringVar(&o.RegistriesFilePath, "registries-file-path", "", "(Optional) Specify the path to a registries.yaml file, to configure registry rewrites for pulling images")
 	f.BoolVar(&o.ExcludeExtras, "exclude-extras", false, "(Optional) Exclude cosign signatures, attestations, SBOMs, and OCI referrers when pulling the image")
 	f.BoolVar(&o.Local, "local", false, "(Optional) Add image from the local Docker daemon instead of a remote registry")
 	f.StringVar(&o.CaFile, "ca-file", "", "(Optional) Location of CA Bundle to enable certification verification")
@@ -59,17 +61,18 @@ func (o *AddFileOpts) AddFlags(cmd *cobra.Command) {
 type AddChartOpts struct {
 	*StoreRootOpts
 
-	ChartOpts       *action.ChartPathOptions
-	Rewrite         string
-	AddDependencies bool
-	AddImages       bool
-	ExcludeExtras   bool
-	ValuesFiles     []string
-	Platform        string
-	Registry        string
-	KubeVersion     string
-	Concurrency     int
-	NoProgress      bool
+	ChartOpts          *action.ChartPathOptions
+	Rewrite            string
+	AddDependencies    bool
+	AddImages          bool
+	ExcludeExtras      bool
+	ValuesFiles        []string
+	Platform           string
+	RegistriesFilePath string
+	Registry           string
+	KubeVersion        string
+	Concurrency        int
+	NoProgress         bool
 }
 
 func (o *AddChartOpts) AddFlags(cmd *cobra.Command) {
@@ -86,6 +89,7 @@ func (o *AddChartOpts) AddFlags(cmd *cobra.Command) {
 	f.BoolVar(&o.ChartOpts.InsecureSkipTLSVerify, "insecure-skip-tls-verify", false, "(Optional) Skip TLS certificate verification")
 	f.StringVar(&o.ChartOpts.CaFile, "ca-file", "", "(Optional) Location of CA Bundle to enable certification verification")
 	f.StringVar(&o.Rewrite, "rewrite", "", "(Optional) Rewrite artifact path to specified string")
+	f.StringVar(&o.RegistriesFilePath, "registries-file-path", "", "(Optional) Specify the path to a registries.yaml file, to configure registry rewrites for pulling images")
 
 	cmd.MarkFlagsRequiredTogether("username", "password")
 	cmd.MarkFlagsRequiredTogether("cert-file", "key-file")

--- a/internal/flags/sync.go
+++ b/internal/flags/sync.go
@@ -19,6 +19,7 @@ type SyncOpts struct {
 	Products                     []string
 	Platform                     string
 	Registry                     string
+	RegistriesFilePath           string
 	ProductRegistry              string
 	Tlog                         bool
 	ExcludeExtras                bool
@@ -53,6 +54,7 @@ func (o *SyncOpts) AddFlags(cmd *cobra.Command) {
 	f.StringSliceVar(&o.Products, "products", []string{}, "(Optional) Specify the product name to fetch collections from the product registry i.e. rancher=v2.10.1,rke2=v1.31.5+rke2r1")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform of the image... i.e linux/amd64 (defaults to all)")
 	f.StringVarP(&o.Registry, "registry", "g", "", "(Optional) Specify the registry of the image for images that do not alredy define one")
+	f.StringVar(&o.RegistriesFilePath, "registries-file-path", "", "(Optional) Specify the path to a registries.yaml file, to configure registry rewrites for pulling images")
 	f.StringVarP(&o.ProductRegistry, "product-registry", "c", "", "(Optional) Specify the product registry. Defaults to RGS Carbide Registry (rgcrprod.azurecr.us)")
 	f.BoolVar(&o.Tlog, "use-tlog-verify", false, "(Optional) Allow transparency log verification (defaults to false)")
 	f.BoolVar(&o.ExcludeExtras, "exclude-extras", false, "(Optional) Exclude cosign signatures, attestations, SBOMs, and OCI referrers when pulling images")

--- a/pkg/config/registries.go
+++ b/pkg/config/registries.go
@@ -1,0 +1,30 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Registries struct {
+	Mirrors map[string]Mirror `yaml:"mirrors"`
+}
+
+type Mirror struct {
+	Endpoints []string `yaml:"endpoint"`
+}
+
+func RegistriesConfigFromFile(path string) (*Registries, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read registries config: %w", err)
+	}
+
+	var registries Registries
+	if err := yaml.Unmarshal(data, &registries); err != nil {
+		return nil, fmt.Errorf("failed to parse registries config: %w", err)
+	}
+
+	return &registries, nil
+}

--- a/testdata/hauler-manifest-with-required-registry-config.yaml
+++ b/testdata/hauler-manifest-with-required-registry-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: content.hauler.cattle.io/v1
+kind: Charts
+metadata:
+  name: hauler-content-charts-example
+spec:
+  charts:
+    - name: chart-with-file-dependency-chart-1.0.0.tgz
+      repoURL: testdata
+      add-dependencies: false
+      add-images: true
+      valuesFiles: 
+        - "image-with-required-registry-config.yaml"

--- a/testdata/image-with-required-registry-config.yaml
+++ b/testdata/image-with-required-registry-config.yaml
@@ -1,0 +1,4 @@
+---
+image: "registry01.io/hauler-dev/library/busybox:musl"
+labels:
+  product: "registry-config"

--- a/testdata/registries.yaml
+++ b/testdata/registries.yaml
@@ -1,0 +1,5 @@
+---
+mirrors:
+  "registry01.io":
+    endpoint:
+      - "ghcr.io"


### PR DESCRIPTION
…ulling config

**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

* RKE2 Private Registry Config Docs: https://docs.rke2.io/install/private_registry

**Types of Changes:**
Feature
<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

**Proposed Changes:**
Support for defining a `registries.yaml` as in RKE2/K3S for configuring registry relocations when pulling images. 

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

**Verification/Testing of Changes:**

* Test cases are included in the PR
* Manual testing of `hauler store add image`:
```
# setup local registry
./hauler store add image library/busybox:stable 

./hauler store info                                                                   
┌────────────────────────────────────────────────┬───────┬─────────────────┬───────────┬──────────┐
│ REFERENCE                                      │ TYPE  │ PLATFORM        │ #  LAYERS │ SIZE     │
├────────────────────────────────────────────────┼───────┼─────────────────┼───────────┼──────────┤
│ index.docker.io/library/busybox:stable         │ image │ linux/386       │ 1         │ 2.3 MB   │
│                                                │ image │ linux/amd64     │ 1         │ 2.2 MB   │
│                                                │ image │ linux/arm       │ 1         │ 1.8 MB   │
│                                                │ image │ linux/arm       │ 1         │ 951.2 kB │
│                                                │ image │ linux/arm       │ 1         │ 1.6 MB   │
│                                                │ image │ linux/arm64     │ 1         │ 1.9 MB   │
│                                                │ image │ linux/ppc64le   │ 1         │ 2.5 MB   │
│                                                │ image │ linux/riscv64   │ 1         │ 1.9 MB   │
│                                                │ image │ linux/s390x     │ 1         │ 2.0 MB   │
│                                                │ image │ unknown/unknown │ 1         │ 2.0 kB   │
│                                                │ image │ unknown/unknown │ 1         │ 2.0 kB   │
│                                                │ image │ unknown/unknown │ 1         │ 2.0 kB   │
│                                                │ image │ unknown/unknown │ 1         │ 3.2 kB   │
│                                                │ image │ unknown/unknown │ 1         │ 2.0 kB   │
│                                                │ image │ unknown/unknown │ 1         │ 2.0 kB   │
│                                                │ image │ unknown/unknown │ 1         │ 2.0 kB   │
│                                                │ image │ unknown/unknown │ 1         │ 2.0 kB   │
├────────────────────────────────────────────────┼───────┼─────────────────┼───────────┼──────────┤
│ store-path: /some-path/store                                    │       │                 │     Total │  17.3 MB │
│ store-id: b6f26c6d-9a47-4ed2-810f-4e64144b5dec │       │                 │           │          │
└────────────────────────────────────────────────┴───────┴─────────────────┴───────────┴──────────┘

./hauler store serve registry
[...]

# pull image with rewrite to local registry
cat registries.yaml 
---
mirrors:
  "*":
    endpoint:
      - "localhost:5000"
        
        
./hauler store add image library/busybox:stable --registries-file-path registries.yaml
2026-08-24 13:49:37 INF adding image [library/busybox:stable] to the store
2026-08-24 13:49:37 WRN pulling content over plain HTTP [localhost:5000]
2026-08-24 13:49:38 INF rewriting [localhost:5000/library/busybox:stable] to [index.docker.io/library/busybox:stable]
2026-08-24 13:49:38 INF ✓ added localhost:5000/library/busybox:stable (17 layers, 17 MB, 1.1s)


```

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

**Additional Context:**

We are using Rancher Hauler to sync container images and Helm charts to our airgapped registry. We are then customizing the imported assets (e.g. by building wrapper charts with additional resources and additional configuration). Additionally, we are building custom container images and Helm charts. We want to use Hauler in our airgapped environment to generate a haul that is based on the previously imported and also custom assets. The biggest challenge doing this, was the fact, that the Helm charts sometimes still reference public container images like `quay.io/argoproj/argocd:v3.5.0` that need a rewrite to our internal registry for building the haul. In RKE2 we solve this topic using the registries.yaml described in https://docs.rke2.io/install/private_registry using containerd rewrites.

Further context: https://github.com/hauler-dev/hauler/pull/715

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
