### PR TITLE
normalize containerd ref for create manifest

### DIFF
--- a/cmd/hauler/cli/store/create_manifest.go
+++ b/cmd/hauler/cli/store/create_manifest.go
@@ -105,13 +105,17 @@ func CreateManifestCmd(ctx context.Context, o *flags.CreateManifestOpts, s *stor
 		if fullRef, isImage := desc.Annotations[consts.ContainerdImageNameKey]; isImage {
 			name := fullRef
 			rewrite := ""
-			if orig, ok := desc.Annotations[consts.OriginalRefAnnotation]; ok && orig != "" && orig != fullRef {
+			if orig, ok := desc.Annotations[consts.OriginalRefAnnotation]; ok && orig != "" &&
+				reference.NormalizeContainerd(orig) != reference.NormalizeContainerd(fullRef) {
 				// The current ref differs from what was captured at the initial add,
 				// meaning --rewrite changed it since. Recover the original, pullable
 				// name and reapply the same rewrite so a resync reproduces this exact
 				// store layout. If there's no annotation at all (a store from before
 				// this was tracked) or it matches fullRef (never rewritten), fullRef
-				// is already the right, pullable name.
+				// is already the right, pullable name. The comparison normalizes both
+				// to containerd's canonical form first, so a purely cosmetic Docker Hub
+				// difference (e.g. index.docker.io vs docker.io) is not mistaken for a
+				// rewrite.
 				rewrite = fullRef
 				name = orig
 			}

--- a/cmd/hauler/cli/store/create_manifest_test.go
+++ b/cmd/hauler/cli/store/create_manifest_test.go
@@ -8,6 +8,9 @@ import (
 
 	"hauler.dev/go/hauler/v2/internal/flags"
 	v1 "hauler.dev/go/hauler/v2/pkg/apis/hauler.cattle.io/v1"
+	"hauler.dev/go/hauler/v2/pkg/consts"
+
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 // newCreateManifestOpts returns a CreateManifestOpts writing to a fresh file
@@ -107,6 +110,68 @@ func TestCreateManifestCmd_ImageWithRewrite(t *testing.T) {
 	// recreates this exact layout.
 	if !strings.Contains(content, "rewrite: "+host+"/newrepo/img:v2") {
 		t.Errorf("expected rewrite %q in manifest, got:\n%s", host+"/newrepo/img:v2", content)
+	}
+}
+
+// TestCreateManifestCmd_ImageDockerHubNormalizationNoRewrite covers the case
+// where an image was added via a Docker Hub ref: the store records the original,
+// pullable ref as "index.docker.io/library/..." while the containerd lookup name
+// is normalized to "docker.io/library/...". These differ only by Docker Hub
+// registry normalization, not a --rewrite, so the manifest must recover the
+// image with no rewrite field rather than treating the normalized form as a
+// rewrite target.
+func TestCreateManifestCmd_ImageDockerHubNormalizationNoRewrite(t *testing.T) {
+	ctx := newTestContext(t)
+	host, rOpts := newLocalhostRegistry(t)
+	seedImage(t, host, "library/busybox", "v1", rOpts...)
+
+	s := newTestStore(t)
+	rso := defaultRootOpts(s.Root)
+	ro := defaultCliOpts()
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/library/busybox:v1"}, "", false, rso, ro, "", "", false); err != nil {
+		t.Fatalf("storeImage: %v", err)
+	}
+
+	// Rewrite the stored image's annotations to the exact pair a real Docker Hub
+	// add produces (see writeImage in pkg/store): the original ref keeps the
+	// pre-normalization "index.docker.io" host while the containerd name is the
+	// normalized "docker.io" form. The digest is untouched, so the blobs stay
+	// valid. This is the state we want CreateManifestCmd to treat as un-rewritten.
+	const (
+		origRef       = "index.docker.io/library/busybox:v1"
+		containerdRef = "docker.io/library/busybox:v1"
+	)
+	matched, err := s.OCI.UpdateAnnotations(
+		func(d ocispec.Descriptor) bool {
+			_, isImage := d.Annotations[consts.ContainerdImageNameKey]
+			return isImage
+		},
+		func(a map[string]string) {
+			a[consts.OriginalRefAnnotation] = origRef
+			a[consts.ContainerdImageNameKey] = containerdRef
+		},
+	)
+	if err != nil {
+		t.Fatalf("UpdateAnnotations: %v", err)
+	}
+	if matched != 1 {
+		t.Fatalf("expected to update exactly 1 image descriptor, updated %d", matched)
+	}
+
+	o := newCreateManifestOpts(t, rso)
+	if err := CreateManifestCmd(ctx, o, s); err != nil {
+		t.Fatalf("CreateManifestCmd: %v", err)
+	}
+
+	content := readManifest(t, o.Output)
+	// The image is recovered under its containerd (docker.io) name...
+	if !strings.Contains(content, "name: "+containerdRef) {
+		t.Errorf("expected image name %q in manifest, got:\n%s", containerdRef, content)
+	}
+	// ...and no rewrite is emitted, since index.docker.io vs docker.io is pure
+	// Docker Hub normalization, not an actual --rewrite.
+	if strings.Contains(content, "rewrite:") {
+		t.Errorf("did not expect a rewrite field for a Docker Hub normalization-only difference, got:\n%s", content)
 	}
 }
 


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [x] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

-

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature enhancement: given recent changes in #746 , add normalization to containerd so index.docker.io to docker.io (with no other changes) is not mistakenly marked as a rewrite by create manifest 

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- use reference.NormalizeContainerd on both original ref and annotation and full reference in store

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- hauler store add image nginx
- hauler store info
- hauler store create manifest
- observe no unnecessary rewrite from index.docker.io to docker.io

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

-
