### PR TITLE
fix: same-repo digest adds silently overwrite store index entries

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -473,6 +473,34 @@ func storeLocalImage(ctx context.Context, s *store.Layout, i v1.Image, _ *flags.
 	return nil
 }
 
+// digestRefTag recovers the tag component of a "repo:tag@sha256:..." image
+// reference. go-containerregistry parses such a string as a Digest, and
+// Digest.Name()/Context() drop the tag entirely with no accessor to recover
+// it, so this re-derives it from the "@"-delimited left half of the original
+// input string. ok is false for a plain "repo@sha256:..." ref, which has no
+// tag to recover and must be left on the digest-only path unchanged.
+func digestRefTag(d goname.Digest) (goname.Tag, bool) {
+	left, _, found := strings.Cut(d.String(), "@")
+	if !found {
+		return goname.Tag{}, false
+	}
+
+	// Mirror goname.NewTag's own repo-vs-host:port disambiguation: a colon
+	// only introduces a tag if it appears after the last "/" (otherwise it's
+	// part of a "host:port" registry authority with no tag at all).
+	colonIdx := strings.LastIndex(left, ":")
+	slashIdx := strings.LastIndex(left, "/")
+	if colonIdx < 0 || colonIdx < slashIdx {
+		return goname.Tag{}, false
+	}
+
+	tag, err := goname.NewTag(left)
+	if err != nil {
+		return goname.Tag{}, false
+	}
+	return tag, true
+}
+
 // storeImage fetches and stores image i. verified records whether
 // verification was both requested and actually succeeded for the exact bytes
 // being stored (pinnedDigest) -- callers compute it themselves rather than
@@ -507,6 +535,25 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 		}
 	}
 
+	// effectiveRef is what names the artifact in the store, everywhere below.
+	// It's r itself except for "repo:tag@sha256:..." input: r parses as a
+	// Digest there, and Digest.Name() silently drops the tag (see
+	// digestRefTag), so without this the store would record the tag-less
+	// digest form and the human-readable name the user asked for would be
+	// lost. addPinnedDigest only gains a value here when the caller passed
+	// none in -- resolveAndVerify/verifyAddImage already HEAD the same
+	// digest ref before pinning, so an existing pin is left untouched.
+	effectiveRef := r
+	addPinnedDigest := pinnedDigest
+	if d, isDigest := r.(goname.Digest); isDigest {
+		if tag, ok := digestRefTag(d); ok {
+			effectiveRef = tag
+			if addPinnedDigest == "" {
+				addPinnedDigest = d.DigestStr()
+			}
+		}
+	}
+
 	// fetch image along with any associated signatures and attestations.
 	// A fresh store.ImageStats is built inside the closure on every attempt,
 	// not once outside it, so a failed attempt's partial layer/byte counts
@@ -518,7 +565,7 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 	err = retry.Operation(ctx, rso, ro, func() error {
 		attemptStats := &store.ImageStats{}
 		var addErr error
-		imageDigest, addErr = s.AddImage(store.WithImageStats(ctx, attemptStats), r.Name(), platform, excludeExtras, pinnedDigest, insecureSkipTLSVerify, caFile)
+		imageDigest, addErr = s.AddImage(store.WithImageStats(ctx, attemptStats), effectiveRef.Name(), platform, excludeExtras, addPinnedDigest, insecureSkipTLSVerify, caFile)
 		if addErr == nil {
 			stats = attemptStats
 		}
@@ -526,7 +573,7 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 	})
 	if err != nil {
 		if ignoreErrors {
-			log.BaseFromContext(ctx).Warnf("unable to add image [%s] to store: %v... skipping...", r.Name(), err)
+			log.BaseFromContext(ctx).Warnf("unable to add image [%s] to store: %v... skipping...", effectiveRef.Name(), err)
 			return nil
 		} else if errors.Is(err, context.Canceled) {
 			// Under errgroup.WithContext fail-fast (runImageJobs), one real
@@ -534,10 +581,10 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 			// this at ERROR would produce N-1 alarming lines for something
 			// that isn't the actual failure -- the real error is reported by
 			// whichever job's storeImage call hit it first.
-			log.BaseFromContext(ctx).Debugf("unable to add image [%s] to store: %v", r.Name(), err)
+			log.BaseFromContext(ctx).Debugf("unable to add image [%s] to store: %v", effectiveRef.Name(), err)
 			return err
 		} else {
-			log.BaseFromContext(ctx).Errorf("unable to add image [%s] to store: %v", r.Name(), err)
+			log.BaseFromContext(ctx).Errorf("unable to add image [%s] to store: %v", effectiveRef.Name(), err)
 			return err
 		}
 	}
@@ -546,10 +593,10 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 		rawRewrite := rewrite
 		rewrite = strings.TrimPrefix(rewrite, "/")
 		if !strings.Contains(rewrite, ":") {
-			if tag, ok := r.(goname.Tag); ok {
+			if tag, ok := effectiveRef.(goname.Tag); ok {
 				rewrite = rewrite + ":" + tag.TagStr()
 			} else {
-				return fmt.Errorf("cannot rewrite digest reference [%s] without an explicit tag in the rewrite", r.Name())
+				return fmt.Errorf("cannot rewrite digest reference [%s] without an explicit tag in the rewrite", effectiveRef.Name())
 			}
 		}
 		// rename image name in store
@@ -557,7 +604,7 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 		if err != nil {
 			return fmt.Errorf("unable to parse rewrite name [%s]: %w", rewrite, err)
 		}
-		if err := rewriteReference(ctx, s, r, newRef, rawRewrite); err != nil {
+		if err := rewriteReference(ctx, s, effectiveRef, newRef, rawRewrite); err != nil {
 			return err
 		}
 	}
@@ -569,7 +616,7 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 			Type:      "image",
 			Command:   "store add image",
 			Args:      []string{i.Name},
-			Reference: r.Name(),
+			Reference: effectiveRef.Name(),
 			Digest:    imageDigest,
 		}
 		if auditLevel(ro) == "verbose" {
@@ -601,7 +648,7 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 		l.Debugf("generated audit id of [none]")
 	}
 
-	log.BaseFromContext(ctx).Infof("%s", formatAddedLine(r.Name(), stats, time.Since(start)))
+	log.BaseFromContext(ctx).Infof("%s", formatAddedLine(effectiveRef.Name(), stats, time.Since(start)))
 	return nil
 }
 

--- a/cmd/hauler/cli/store/add_test.go
+++ b/cmd/hauler/cli/store/add_test.go
@@ -747,6 +747,61 @@ func TestStoreImage_Rewrite(t *testing.T) {
 	})
 }
 
+// TestStoreImage_TagAtDigest covers "repo:tag@sha256:..." refs: go-containerregistry
+// parses these as a Digest and silently drops the tag from Name(), so storeImage
+// must recover it via digestRefTag and record the tag-form annotation while still
+// fetching the pinned digest.
+func TestStoreImage_TagAtDigest(t *testing.T) {
+	ctx := newTestContext(t)
+	host, rOpts := newLocalhostRegistry(t)
+
+	t.Run("repo:tag@digest stores under the tag, fetches the exact digest", func(t *testing.T) {
+		img := seedImage(t, host, "tagdigest/repo", "v1", rOpts...)
+		h, err := img.Digest()
+		if err != nil {
+			t.Fatalf("img.Digest: %v", err)
+		}
+
+		s := newTestStore(t)
+		rso := defaultRootOpts(s.Root)
+		ro := defaultCliOpts()
+
+		ref := host + "/tagdigest/repo:v1@" + h.String()
+		if err := storeImage(ctx, s, v1.Image{Name: ref}, "", false, rso, ro, "", "", false); err != nil {
+			t.Fatalf("storeImage tag@digest: %v", err)
+		}
+
+		// The store must record the tag form, not the tag-dropped digest form
+		// that r.Name() alone would have produced.
+		assertArtifactInStore(t, s, "tagdigest/repo:v1")
+		assertArtifactNotInStore(t, s, "tagdigest/repo@sha256")
+
+		if got := storedDigest(t, s, "tagdigest/repo:v1"); got != h.String() {
+			t.Errorf("stored digest = %q, want %q", got, h.String())
+		}
+	})
+
+	t.Run("rewrite without explicit tag on a tag@digest source inherits the source tag", func(t *testing.T) {
+		img := seedImage(t, host, "tagdigest/src", "v2", rOpts...)
+		h, err := img.Digest()
+		if err != nil {
+			t.Fatalf("img.Digest: %v", err)
+		}
+
+		s := newTestStore(t)
+		rso := defaultRootOpts(s.Root)
+		ro := defaultCliOpts()
+
+		ref := host + "/tagdigest/src:v2@" + h.String()
+		if err := storeImage(ctx, s, v1.Image{Name: ref}, "", false, rso, ro, "newrepo/img", "", false); err != nil {
+			t.Fatalf("storeImage with tagless rewrite on tag@digest source: %v", err)
+		}
+		// Tag is inherited from the source ("v2"), matching plain-tag rewrite
+		// behavior -- this is only possible once the source tag is recovered.
+		assertArtifactInStore(t, s, "newrepo/img:v2")
+	})
+}
+
 func TestStoreImage_MultiArch(t *testing.T) {
 	ctx := newTestContext(t)
 	host, rOpts := newLocalhostRegistry(t)
@@ -3297,6 +3352,61 @@ func TestStoreImage_CAFileAndInsecure(t *testing.T) {
 		}
 		assertArtifactInStore(t, s, "tls/repo:v1")
 	})
+}
+
+// TestDigestRefTag covers digestRefTag's recovery of the tag component from a
+// "repo:tag@sha256:..." reference's original string, and the cases where
+// there is no tag to recover.
+func TestDigestRefTag(t *testing.T) {
+	const hex = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	digestSuffix := "@sha256:" + hex
+
+	tests := []struct {
+		name    string
+		ref     string
+		wantOK  bool
+		wantTag string // TagStr(), only checked when wantOK
+	}{
+		{
+			name:    "repo with tag and digest recovers the tag",
+			ref:     "example.com/repo:v1" + digestSuffix,
+			wantOK:  true,
+			wantTag: "v1",
+		},
+		{
+			name:   "plain digest ref with no tag has nothing to recover",
+			ref:    "example.com/repo" + digestSuffix,
+			wantOK: false,
+		},
+		{
+			name:    "registry with port and a tag still recovers the tag",
+			ref:     "example.com:5000/repo:v1" + digestSuffix,
+			wantOK:  true,
+			wantTag: "v1",
+		},
+		{
+			name:   "registry with port and no tag is not mistaken for one",
+			ref:    "example.com:5000/repo" + digestSuffix,
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, err := goname.NewDigest(tt.ref)
+			if err != nil {
+				t.Fatalf("NewDigest(%q): %v", tt.ref, err)
+			}
+
+			tag, ok := digestRefTag(d)
+			if ok != tt.wantOK {
+				t.Fatalf("digestRefTag(%q) ok = %v, want %v", tt.ref, ok, tt.wantOK)
+			}
+			if ok && tag.TagStr() != tt.wantTag {
+				t.Errorf("digestRefTag(%q) tag = %q, want %q", tt.ref, tag.TagStr(), tt.wantTag)
+			}
+		})
+	}
 }
 
 // writeCAFile writes a valid self-signed cert PEM to a temp file and returns its

--- a/cmd/hauler/cli/store/lifecycle_test.go
+++ b/cmd/hauler/cli/store/lifecycle_test.go
@@ -313,6 +313,76 @@ func TestLifecycle_DigestOnlyImage_AddSaveLoad(t *testing.T) {
 	assertArtifactInStore(t, storeB, hash.Hex)
 }
 
+// TestLifecycle_TwoDigestsSameRepo_AddSaveLoad covers the copy/load-into-store
+// path for two images that share a repository but have different digests --
+// the same shape as TestLifecycle_DigestOnlyImage_AddSaveLoad, doubled. Both
+// pkg/content's AddIndex/loadIndexLocked and ociPusher.Push (the mechanism
+// LoadCmd's CopyAll drives) must key a digest entry by its full digest, not
+// its repository alone, or the second image collides with the first on the
+// same nameMap key.
+func TestLifecycle_TwoDigestsSameRepo_AddSaveLoad(t *testing.T) {
+	ctx := newTestContext(t)
+
+	srcHost, srcOpts := newLocalhostRegistry(t)
+	imgA := seedImage(t, srcHost, "lifecycle/tworepo", "va", srcOpts...)
+	imgB := seedImage(t, srcHost, "lifecycle/tworepo", "vb", srcOpts...)
+	hashA, err := imgA.Digest()
+	if err != nil {
+		t.Fatalf("imgA.Digest: %v", err)
+	}
+	hashB, err := imgB.Digest()
+	if err != nil {
+		t.Fatalf("imgB.Digest: %v", err)
+	}
+
+	storeA := newTestStore(t)
+	rso := defaultRootOpts(storeA.Root)
+	ro := defaultCliOpts()
+
+	refA := srcHost + "/lifecycle/tworepo@" + hashA.String()
+	refB := srcHost + "/lifecycle/tworepo@" + hashB.String()
+	if err := storeImage(ctx, storeA, v1.Image{Name: refA}, "", false, rso, ro, "", "", false); err != nil {
+		t.Fatalf("storeImage A: %v", err)
+	}
+	if err := storeImage(ctx, storeA, v1.Image{Name: refB}, "", false, rso, ro, "", "", false); err != nil {
+		t.Fatalf("storeImage B: %v", err)
+	}
+	assertArtifactInStore(t, storeA, hashA.Hex)
+	assertArtifactInStore(t, storeA, hashB.Hex)
+
+	if err := storeA.SaveIndex(); err != nil {
+		t.Fatalf("SaveIndex: %v", err)
+	}
+
+	archivePath := filepath.Join(t.TempDir(), "lifecycle-tworepo.tar.zst")
+	saveOpts := newSaveOpts(storeA.Root, archivePath)
+	if err := SaveCmd(ctx, saveOpts, storeA, defaultRootOpts(storeA.Root), defaultCliOpts()); err != nil {
+		t.Fatalf("SaveCmd: %v", err)
+	}
+
+	storeBDir := t.TempDir()
+	storeBPreLoad, err := store.NewLayout(storeBDir)
+	if err != nil {
+		t.Fatalf("store.NewLayout(storeB pre-load): %v", err)
+	}
+	loadOpts := &flags.LoadOpts{
+		StoreRootOpts: defaultRootOpts(storeBDir),
+		FileName:      []string{archivePath},
+	}
+	if err := LoadCmd(ctx, loadOpts, storeBPreLoad, defaultRootOpts(storeBDir), defaultCliOpts()); err != nil {
+		t.Fatalf("LoadCmd: %v", err)
+	}
+
+	storeB, err := store.NewLayout(storeBDir)
+	if err != nil {
+		t.Fatalf("store.NewLayout(storeB): %v", err)
+	}
+
+	// Both same-repo digests must survive the copy/load-into-store path.
+	assertArtifactInStore(t, storeB, hashA.Hex)
+	assertArtifactInStore(t, storeB, hashB.Hex)
+}
+
 // TestLifecycle_Remove_ThenSave verifies that removing one artifact from a store
 // with two file artifacts, then saving/loading, results in only the retained
 // artifact being present.

--- a/pkg/content/oci.go
+++ b/pkg/content/oci.go
@@ -151,6 +151,34 @@ func (o *OCI) BlobConcurrency() int {
 	return o.blobConcurrency
 }
 
+// nameMapKey derives the nameMap key for an AnnotationRefName-shaped ref
+// (e.g. "repo:tag" or "repo@sha256:...") and a kind annotation. AddIndex,
+// loadIndexLocked, and ociPusher.Push must all derive this identically: a
+// goname.Digest keys by key.Name(), which retains the digest (registry/repo@digest),
+// so two different digests in one repository never collide on the same key --
+// key.Context().String() is repo-only and once made the second of two such
+// writes silently delete the first (see AddIndex's history). A goname.Tag
+// keys by its full string; tag entries never carry a digest suffix. ok is
+// false for the "--" placeholder ref or an unrecognized reference kind, both
+// of which callers treat as "nothing to store under this key."
+func nameMapKey(ref, kind string) (key string, ok bool, err error) {
+	parsed, err := reference.Parse(ref)
+	if err != nil {
+		return "", false, err
+	}
+	if strings.TrimSpace(parsed.String()) == "--" {
+		return "", false, nil
+	}
+	switch parsed.(type) {
+	case goname.Digest:
+		return fmt.Sprintf("%s-%s", parsed.Name(), kind), true, nil
+	case goname.Tag:
+		return fmt.Sprintf("%s-%s", parsed.String(), kind), true, nil
+	default:
+		return "", false, nil
+	}
+}
+
 // AddIndex adds a descriptor to the index and updates it
 //
 //	The descriptor must use AnnotationRefName to identify itself
@@ -161,22 +189,11 @@ func (o *OCI) AddIndex(desc ocispec.Descriptor) error {
 		return fmt.Errorf("descriptor must contain a reference from the annotation: %s", ocispec.AnnotationRefName)
 	}
 
-	key, err := reference.Parse(desc.Annotations[ocispec.AnnotationRefName])
+	mapKey, ok, err := nameMapKey(desc.Annotations[ocispec.AnnotationRefName], desc.Annotations[consts.KindAnnotationName])
 	if err != nil {
 		return err
 	}
-
-	if strings.TrimSpace(key.String()) == "--" {
-		return nil
-	}
-
-	var mapKey string
-	switch key.(type) {
-	case goname.Digest:
-		mapKey = fmt.Sprintf("%s-%s", key.Context().String(), desc.Annotations[consts.KindAnnotationName])
-	case goname.Tag:
-		mapKey = fmt.Sprintf("%s-%s", key.String(), desc.Annotations[consts.KindAnnotationName])
-	default:
+	if !ok {
 		return nil
 	}
 
@@ -265,12 +282,6 @@ func (o *OCI) loadIndexLocked() error {
 	}
 
 	for _, desc := range o.index.Manifests {
-		key, err := reference.Parse(desc.Annotations[ocispec.AnnotationRefName])
-		if err != nil {
-			// skip malformed entries rather than making the entire store unreadable
-			continue
-		}
-
 		// Set default kind if missing... normalize legacy dev.cosignproject.cosign values
 		kind := desc.Annotations[consts.KindAnnotationName]
 		kind = consts.NormalizeLegacyKind(kind)
@@ -285,13 +296,17 @@ func (o *OCI) loadIndexLocked() error {
 		normalized[consts.KindAnnotationName] = kind
 		desc.Annotations = normalized
 
-		if strings.TrimSpace(key.String()) != "--" {
-			switch key.(type) {
-			case goname.Digest:
-				o.nameMap.Store(fmt.Sprintf("%s-%s", key.Context().String(), kind), desc)
-			case goname.Tag:
-				o.nameMap.Store(fmt.Sprintf("%s-%s", key.String(), kind), desc)
-			}
+		// Must derive the same key AddIndex/ociPusher.Push would (see
+		// nameMapKey's comment), or an entry written this run and one loaded
+		// from a prior run collide under a different key than the one that
+		// wrote it.
+		mapKey, ok, err := nameMapKey(desc.Annotations[ocispec.AnnotationRefName], kind)
+		if err != nil {
+			// skip malformed entries rather than making the entire store unreadable
+			continue
+		}
+		if ok {
+			o.nameMap.Store(mapKey, desc)
 		}
 	}
 
@@ -778,6 +793,28 @@ type ociPusher struct {
 	digest string
 }
 
+// pusherRef reconstructs the AnnotationRefName-shaped string identifying a
+// push driven by Pusher(ctx, ref) -- e.g. "repo:tag" or "repo@sha256:..." --
+// so it can be handed to nameMapKey. store.Layout.CopyAll always appends the
+// root descriptor's own digest onto the destination ref for verification,
+// even for a tag-sourced entry (see its comment), so digest's mere presence
+// can't say whether the *original* ref carried a digest or a tag; only ref
+// (the part before "@") can, via the same repo-vs-host:port-vs-tag
+// disambiguation goname.NewTag applies internally -- checked here first so a
+// bare digest-sourced "repo" is never handed to nameMapKey as if it were a
+// tagless Tag reference, which would default it to a spurious ":latest".
+func pusherRef(ref, digest string) string {
+	colonIdx := strings.LastIndex(ref, ":")
+	slashIdx := strings.LastIndex(ref, "/")
+	if colonIdx >= 0 && colonIdx > slashIdx {
+		return ref
+	}
+	if digest == "" {
+		return ref
+	}
+	return ref + "@" + digest
+}
+
 // Push returns a content writer for the given resource identified
 // by the descriptor.
 func (p *ociPusher) Push(ctx context.Context, d ocispec.Descriptor) (ccontent.Writer, error) {
@@ -792,7 +829,6 @@ func (p *ociPusher) Push(ctx context.Context, d ocispec.Descriptor) (ccontent.Wr
 				p.oci.mu.Unlock()
 				return nil, err
 			}
-			// Use compound key format: "reference-kind"; normalize legacy values.
 			kind := d.Annotations[consts.KindAnnotationName]
 			kind = consts.NormalizeLegacyKind(kind)
 			if kind == "" {
@@ -804,8 +840,19 @@ func (p *ociPusher) Push(ctx context.Context, d ocispec.Descriptor) (ccontent.Wr
 			maps.Copy(normalizedAnnotations, d.Annotations)
 			normalizedAnnotations[consts.KindAnnotationName] = kind
 			d.Annotations = normalizedAnnotations
-			key := fmt.Sprintf("%s-%s", p.ref, kind)
-			p.oci.nameMap.Store(key, d)
+			// Must derive the same key AddIndex/loadIndexLocked would (see
+			// nameMapKey's comment) -- store.Layout.CopyAll always appends the
+			// root descriptor's digest onto the destination ref, even for a
+			// tag-sourced entry, so pusherRef -- not a bare "p.ref@p.digest" --
+			// decides whether that digest actually belongs in the key.
+			mapKey, ok, keyErr := nameMapKey(pusherRef(p.ref, p.digest), kind)
+			if keyErr != nil {
+				p.oci.mu.Unlock()
+				return nil, keyErr
+			}
+			if ok {
+				p.oci.nameMap.Store(mapKey, d)
+			}
 			err := p.oci.saveIndexCheckpointLocked()
 			p.oci.mu.Unlock()
 			if err != nil {

--- a/pkg/content/oci_test.go
+++ b/pkg/content/oci_test.go
@@ -287,6 +287,82 @@ func TestPush_NormalizesLegacyKindInStoredDescriptor(t *testing.T) {
 	}
 }
 
+// TestOCIPusher_Push_KeysDigestEntryByFullDigestRef pins the exact nameMap
+// key ociPusher.Push derives for a digest-type push. AddIndex and
+// loadIndexLocked key a goname.Digest entry by key.Name() (registry/repo@digest);
+// Push must derive the identical key, or two same-repo digests pushed through
+// store.Layout.CopyAll (the copy/load-into-store path) collide on the same
+// digest-stripped key exactly as AddIndex's callers once did. This checks the
+// key directly rather than final survival, because loadIndexLocked's own
+// reload-before-write inside Push happens to re-derive a prior push's correct
+// key before a second push overwrites the wrong one -- masking the drift for
+// a two-push sequence without a test that inspects nameMap itself.
+func TestOCIPusher_Push_KeysDigestEntryByFullDigestRef(t *testing.T) {
+	dir := t.TempDir()
+	buildMinimalOCILayout(t, dir, nil)
+
+	o, err := NewOCI(dir)
+	if err != nil {
+		t.Fatalf("NewOCI: %v", err)
+	}
+	blobsDir := filepath.Join(dir, ocispec.ImageBlobsDir, "sha256")
+	if err := os.MkdirAll(blobsDir, 0755); err != nil {
+		t.Fatalf("mkdir blobs: %v", err)
+	}
+
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config: ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageConfig,
+			Digest:    fakeDigest("config0"),
+			Size:      2,
+		},
+	}
+	manifestData, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	manifestDigest := digest.FromBytes(manifestData)
+
+	const baseRef = "example.com/repo"
+	ref := baseRef + "@" + manifestDigest.String()
+	pusher, err := o.Pusher(context.Background(), ref)
+	if err != nil {
+		t.Fatalf("Pusher: %v", err)
+	}
+
+	desc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    manifestDigest,
+		Size:      int64(len(manifestData)),
+		Annotations: map[string]string{
+			ocispec.AnnotationRefName: ref,
+			consts.KindAnnotationName: consts.KindAnnotationImage,
+		},
+	}
+
+	w, err := pusher.Push(context.Background(), desc)
+	if err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	if _, err := w.Write(manifestData); err != nil {
+		t.Fatalf("Write manifest: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close writer: %v", err)
+	}
+
+	wantKey := ref + "-" + consts.KindAnnotationImage
+	if _, ok := o.nameMap.Load(wantKey); !ok {
+		t.Errorf("nameMap has no entry under the digest-inclusive key %q -- Push must key digest entries the same way AddIndex/loadIndexLocked do", wantKey)
+	}
+	staleKey := baseRef + "-" + consts.KindAnnotationImage
+	if _, ok := o.nameMap.Load(staleKey); ok {
+		t.Errorf("nameMap has a stray digest-stripped key %q -- Push's key derivation has drifted from AddIndex/loadIndexLocked's", staleKey)
+	}
+}
+
 // blobPathFor mirrors the layout convention used by OCI.ensureBlob, for
 // assertions against the final on-disk blob path.
 func blobPathFor(root string, d digest.Digest) string {
@@ -1609,6 +1685,230 @@ func TestOCI_AddIndexSkipsSaveWhenUnchanged(t *testing.T) {
 	}
 	if info2.ModTime().Equal(old) {
 		t.Error("index.json mtime unchanged after a genuinely different AddIndex; expected a write")
+	}
+}
+
+// --------------------------------------------------------------------------
+// TestOCI_AddIndex_DistinctDigestsSameRepo*
+// --------------------------------------------------------------------------
+//
+// Before the fix, AddIndex and loadIndexLocked keyed a goname.Digest entry by
+// its repository alone (digest stripped), so two different digests of the
+// same repository collided in the map and the second AddIndex silently
+// deleted the first entry from index.json. See AddIndex's comment for the
+// hazard.
+
+// digestRefDescriptor builds a minimal descriptor keyed by a digest reference
+// (no tag) into the given repository, with the given kind.
+func digestRefDescriptor(repo string, digestHex string, kind string) ocispec.Descriptor {
+	return ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    fakeDigest(digestHex),
+		Size:      100,
+		Annotations: map[string]string{
+			ocispec.AnnotationRefName: fmt.Sprintf("%s@%s", repo, fakeDigest(digestHex)),
+			consts.KindAnnotationName: kind,
+		},
+	}
+}
+
+// assertBothDigestsPresent walks o and requires both descA and descB's
+// digests to appear among the walked entries.
+func assertBothDigestsPresent(t *testing.T, o *OCI, descA, descB ocispec.Descriptor) {
+	t.Helper()
+
+	seen := map[string]bool{}
+	if err := o.Walk(func(_ string, desc ocispec.Descriptor) error {
+		seen[string(desc.Digest)] = true
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+
+	if !seen[string(descA.Digest)] {
+		t.Errorf("descriptor A (digest %s) missing after adding descriptor B for the same repo", descA.Digest)
+	}
+	if !seen[string(descB.Digest)] {
+		t.Errorf("descriptor B (digest %s) missing", descB.Digest)
+	}
+}
+
+// TestOCI_AddIndex_DistinctDigestsSameRepoBothSurvive verifies that adding
+// two descriptors that share a repository but carry different digests does
+// not clobber the first entry -- the historical bug keyed digest refs by
+// repository alone, so the second AddIndex silently deleted the first.
+func TestOCI_AddIndex_DistinctDigestsSameRepoBothSurvive(t *testing.T) {
+	dir := t.TempDir()
+	o := newTestOCI(t, dir)
+
+	descA := digestRefDescriptor("example.com/repo", "a", consts.KindAnnotationImage)
+	descB := digestRefDescriptor("example.com/repo", "b", consts.KindAnnotationImage)
+
+	if err := o.AddIndex(descA); err != nil {
+		t.Fatalf("AddIndex(A): %v", err)
+	}
+	if err := o.AddIndex(descB); err != nil {
+		t.Fatalf("AddIndex(B): %v", err)
+	}
+
+	assertBothDigestsPresent(t, o, descA, descB)
+
+	// Reload from disk with a fresh OCI to make sure both entries were
+	// actually persisted to index.json, not just held in memory.
+	fresh, err := NewOCI(dir)
+	if err != nil {
+		t.Fatalf("NewOCI: %v", err)
+	}
+	if err := fresh.LoadIndex(); err != nil {
+		t.Fatalf("LoadIndex: %v", err)
+	}
+	assertBothDigestsPresent(t, fresh, descA, descB)
+}
+
+// TestOCI_AddIndex_DistinctDigestsSameRepoSigsCoexist verifies the same fix
+// for sig-kind entries, which is how two digest-pinned adds of one repo's
+// signatures actually collide in practice.
+func TestOCI_AddIndex_DistinctDigestsSameRepoSigsCoexist(t *testing.T) {
+	dir := t.TempDir()
+	o := newTestOCI(t, dir)
+
+	descA := digestRefDescriptor("example.com/repo", "c", consts.KindAnnotationSigs)
+	descB := digestRefDescriptor("example.com/repo", "d", consts.KindAnnotationSigs)
+
+	if err := o.AddIndex(descA); err != nil {
+		t.Fatalf("AddIndex(A): %v", err)
+	}
+	if err := o.AddIndex(descB); err != nil {
+		t.Fatalf("AddIndex(B): %v", err)
+	}
+
+	assertBothDigestsPresent(t, o, descA, descB)
+}
+
+// TestOCI_AddIndex_TagAndDigestSameRepoCoexist is a regression guard: a tag
+// entry and a digest entry for the same repository must continue to coexist
+// (they always keyed distinctly -- the bug was digest-vs-digest only).
+func TestOCI_AddIndex_TagAndDigestSameRepoCoexist(t *testing.T) {
+	dir := t.TempDir()
+	o := newTestOCI(t, dir)
+
+	tagDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    fakeDigest("e"),
+		Size:      100,
+		Annotations: map[string]string{
+			ocispec.AnnotationRefName: "example.com/repo:latest",
+			consts.KindAnnotationName: consts.KindAnnotationImage,
+		},
+	}
+	digestDesc := digestRefDescriptor("example.com/repo", "f", consts.KindAnnotationImage)
+
+	if err := o.AddIndex(tagDesc); err != nil {
+		t.Fatalf("AddIndex(tag): %v", err)
+	}
+	if err := o.AddIndex(digestDesc); err != nil {
+		t.Fatalf("AddIndex(digest): %v", err)
+	}
+
+	assertBothDigestsPresent(t, o, tagDesc, digestDesc)
+}
+
+// TestOCIPusher_Push_DistinctDigestsSameRepoBothSurvive covers the same
+// collision on the copy/load-into-store path: ociPusher.Push derived its
+// nameMap key from p.ref alone (the pre-"@" part of the ref passed to
+// Pusher), which store.Layout.CopyAll always strips to the bare repo for a
+// digest-sourced entry before re-appending the digest for verification --
+// see CopyAll's comment. That key must agree with AddIndex's (digest-inclusive,
+// via key.Name()) or two same-repo digests copied into a destination store
+// collide exactly as they did in AddIndex before that fix.
+func TestOCIPusher_Push_DistinctDigestsSameRepoBothSurvive(t *testing.T) {
+	dir := t.TempDir()
+	buildMinimalOCILayout(t, dir, nil)
+
+	o, err := NewOCI(dir)
+	if err != nil {
+		t.Fatalf("NewOCI: %v", err)
+	}
+
+	blobsDir := filepath.Join(dir, ocispec.ImageBlobsDir, "sha256")
+	if err := os.MkdirAll(blobsDir, 0755); err != nil {
+		t.Fatalf("mkdir blobs: %v", err)
+	}
+
+	// pushManifest mirrors the exact shape of store.Layout.CopyAll's Pusher
+	// call for a digest-sourced entry: baseRef carries no tag, and the ref
+	// handed to Pusher has the root manifest's own digest appended.
+	pushManifest := func(baseRef string, configHex string) ocispec.Descriptor {
+		t.Helper()
+		manifest := ocispec.Manifest{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			MediaType: ocispec.MediaTypeImageManifest,
+			Config: ocispec.Descriptor{
+				MediaType: ocispec.MediaTypeImageConfig,
+				Digest:    fakeDigest(configHex),
+				Size:      2,
+			},
+		}
+		manifestData, err := json.Marshal(manifest)
+		if err != nil {
+			t.Fatalf("marshal manifest: %v", err)
+		}
+		manifestDigest := digest.FromBytes(manifestData)
+
+		ref := fmt.Sprintf("%s@%s", baseRef, manifestDigest.String())
+		pusher, err := o.Pusher(context.Background(), ref)
+		if err != nil {
+			t.Fatalf("Pusher(%s): %v", ref, err)
+		}
+
+		desc := ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageManifest,
+			Digest:    manifestDigest,
+			Size:      int64(len(manifestData)),
+			Annotations: map[string]string{
+				ocispec.AnnotationRefName: ref,
+				consts.KindAnnotationName: consts.KindAnnotationImage,
+			},
+		}
+
+		w, err := pusher.Push(context.Background(), desc)
+		if err != nil {
+			t.Fatalf("Push: %v", err)
+		}
+		if _, err := w.Write(manifestData); err != nil {
+			t.Fatalf("Write manifest: %v", err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatalf("Close writer: %v", err)
+		}
+		return desc
+	}
+
+	const repo = "example.com/repo"
+	descA := pushManifest(repo, "configA")
+	descB := pushManifest(repo, "configB")
+	if descA.Digest == descB.Digest {
+		t.Fatal("test setup produced identical digests -- the two pushes wouldn't be distinguishable")
+	}
+
+	// Fresh OCI so Walk reloads from disk rather than reading the nameMap the
+	// pushes above wrote into directly.
+	o2, err := NewOCI(dir)
+	if err != nil {
+		t.Fatalf("NewOCI second: %v", err)
+	}
+	seen := map[digest.Digest]bool{}
+	if err := o2.Walk(func(_ string, d ocispec.Descriptor) error {
+		seen[d.Digest] = true
+		return nil
+	}); err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if !seen[descA.Digest] {
+		t.Errorf("descriptor A (digest %s) missing after pushing descriptor B for the same repo", descA.Digest)
+	}
+	if !seen[descB.Digest] {
+		t.Errorf("descriptor B (digest %s) missing", descB.Digest)
 	}
 }
 


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

**Associated Links:**

- https://github.com/hauler-dev/hauler/issues/760

**Types of Changes:**

- Bugfix (silent data loss in the store index)

**Proposed Changes:**

- Fix same-repo digest adds silently overwriting each other: digest-form refs were keyed in the store's nameMap by repo-without-digest + kind, so `store add image repo@sha256:AAA` followed by `repo@sha256:BBB` replaced the first entry in `index.json` (including its sigs/atts/sboms). Digest refs are now keyed by their full `repo@digest` via a single `nameMapKey` helper shared by `AddIndex`, `loadIndexLocked`, and `ociPuinto-store path had the same collision).
- `store add image repo:tag@sha256:...` now records the tag as the entry name while fetching the exact digest via `AddImage`'s existing `pinnedDigest` path — previously the tag was silently dropped. `--rewrite` inherits the tag from a `tag@digest` source.

**Verification/Testing of Changes:**

- `make test` (full suite with `-race`) passes; new coverage in `pkg/content/oci_test.go` (distinct same-repo digests survive add/save/load, sigs coexist, pusher keying) and `cmd/hauler/cli/store` (`TestStoreImage_TagAtDigest`, `TestLifecycle_TwoDigestsSameRepo_AddSaveLoad`).
- Manual repro: `hauler store add image <repo>@sha256:<digest-A>` then `<repo>@sha256:<digest-B>` (two different pinned digests of one repo) — `store info` now shows both entries with their own sigs/atts; before, only the last add survived.

```
❯ hauler store add image registry.ranchercarbide.dev/rancher/rancher@sha256:104cdd922211311487e80423b41b372cdc91f277696e6230304606b3616fca71
2026-08-26 13:05:30 INF adding image [registry.ranchercarbide.dev/rancher/rancher@sha256:104cdd922211311487e80423b41b372cdc91f277696e6230304606b3616fca71] to the store
2026-08-26 13:06:15 INF ✓ added registry.ranchercarbide.dev/rancher/rancher@sha256:104cdd922211311487e80423b41b372cdc91f277696e6230304606b3616fca71 (28 layers, 1.0 GB, 45.0s)

❯ hauler store add image registry.ranchercarbide.dev/rancher/rancher@sha256:024b006dc76f4b7fc9660f03a5b70cdb042872563d36a2dfca30ec28e7a7e742
2026-08-26 13:07:25 INF adding image [registry.ranchercarbide.dev/rancher/rancher@sha256:024b006dc76f4b7fc9660f03a5b70cdb042872563d36a2dfca30ec28e7a7e742] to the store
2026-08-26 13:08:01 INF ✓ added registry.ranchercarbide.dev/rancher/rancher@sha256:024b006dc76f4b7fc9660f03a5b70cdb042872563d36a2dfca30ec28e7a7e742 (28 layers, 994 MB, 36.3s)

❯ hauler store info
┌──────────────────────────────────────────────────────────────────┬───────┬─────────────┬───────────┬──────────┐
│ REFERENCE                                                        │ TYPE  │ PLATFORM    │ #  LAYERS │ SIZE     │
├──────────────────────────────────────────────────────────────────┼───────┼─────────────┼───────────┼──────────┤
│ registry.ranchercarbide.dev/rancher/rancher@sha256:024b006dc76f… │ image │ linux/arm64 │ 25        │ 984.1 MB │
│                                                                  │ atts  │ -           │ 2         │ 9.5 MB   │
│                                                                  │ sigs  │ -           │ 1         │ 280 B    │
│ registry.ranchercarbide.dev/rancher/rancher@sha256:104cdd922211… │ image │ linux/amd64 │ 25        │ 998.3 MB │
│                                                                  │ atts  │ -           │ 2         │ 10.1 MB  │
│                                                                  │ sigs  │ -           │ 1         │ 280 B    │
├──────────────────────────────────────────────────────────────────┼───────┼─────────────┼───────────┼──────────┤
│ store-path: /Users/amartin/projects/hauler/store                 │       │             │     Total │   2.0 GB │
│ store-id: 9b202c2a-125b-4841-91c2-7e4045821905                   │       │             │           │          │
└──────────────────────────────────────────────────────────────────┴───────┴─────────────┴───────────┴──────────┘
```

**Additional Context:**

- Stores containing multiple same-repo digest entries are not safely writable by older hauler versions — their loader still collapses such entries at read time, and a subsequent write would persist the loss. Worth a release-note line.