### PR TITLE
add prefixing behavior for top level prefixing over broken hauler.dev/rewrite annotation

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -786,8 +786,16 @@ type chartJob struct {
 	cfg     v1.Chart
 	opts    flags.AddChartOpts // held by value; ChartOpts is allocated per job
 	rewrite string
-	parent  string // "" for a top-level chart, else the parent chart's ref
-	depth   int
+	// chartPrefix is the document-level chart prefix annotation. It is retained
+	// separately so dependent charts can receive the same prefix while still
+	// getting a target based on their own name.
+	chartPrefix string
+	// imagePrefix is the document-level image prefix annotation. It is kept
+	// separately because chart and discovered-image targets may use different
+	// namespaces in the store.
+	imagePrefix string
+	parent      string // "" for a top-level chart, else the parent chart's ref
+	depth       int
 }
 
 // resolveChartJobs produces one top-level chartJob per entry in charts,
@@ -811,6 +819,12 @@ type chartJob struct {
 // jobs sharing one pointee, and a per-chart RepoURL/Version write would land
 // in every other chart's options.
 func resolveChartJobs(o *flags.SyncOpts, annotations map[string]string, manifestDir string, charts []v1.Chart) ([]chartJob, error) {
+	chartPrefix, hasChartPrefix := annotations[consts.ChartAnnotationPrefix]
+	if !hasChartPrefix {
+		chartPrefix = "hauler"
+	}
+	chartPrefix = strings.Trim(chartPrefix, "/")
+
 	registry := o.Registry
 	if registry == "" {
 		registry = annotations[consts.ImageAnnotationRegistry]
@@ -837,6 +851,17 @@ func resolveChartJobs(o *flags.SyncOpts, annotations map[string]string, manifest
 		chartUsername, chartPassword, err := resolveChartCreds(ch)
 		if err != nil {
 			return nil, err
+		}
+
+		rewrite := ch.Rewrite
+		imagePrefix := strings.Trim(annotations[consts.ImageAnnotationPrefix], "/")
+		// Keep the historical behavior when only chart-prefix is set: discovered
+		// images follow the chart prefix unless an explicit image-prefix is given.
+		if imagePrefix == "" {
+			imagePrefix = chartPrefix
+		}
+		if rewrite == "" && chartPrefix != "" {
+			rewrite = prefixChartRewrite(chartPrefix, ch.Name)
 		}
 
 		// caFile precedence: cli > per-chart > annotation.
@@ -876,11 +901,26 @@ func resolveChartJobs(o *flags.SyncOpts, annotations map[string]string, manifest
 				Platform:        platform,
 				ValuesFiles:     valuesFiles,
 			},
-			rewrite: ch.Rewrite,
+			rewrite:     rewrite,
+			chartPrefix: chartPrefix,
+			imagePrefix: imagePrefix,
 		})
 	}
 
 	return jobs, nil
+}
+
+// prefixChartRewrite turns the document-level rewrite annotation into a
+// unique target for a chart. A document can contain several charts, so the
+// annotation is a prefix rather than one shared replacement reference.
+func prefixChartRewrite(prefix, chartName string) string {
+	return prefixArtifactRewrite(prefix, chartName)
+}
+
+// prefixArtifactRewrite applies a document-level rewrite prefix to an
+// artifact reference while preserving the artifact's tag or digest.
+func prefixArtifactRewrite(prefix, ref string) string {
+	return strings.Trim(prefix, "/") + "/" + strings.Trim(ref, "/")
 }
 
 // dedupeImageJobs collapses repeat pulls out of a chart tree's discovered
@@ -1406,6 +1446,10 @@ func fetchChart(ctx context.Context, s *store.Layout, j chartJob, tempRoot strin
 			// there is no separate per-discovered-image TLS knob in a chart
 			// manifest, so the registry a chart's images live in is assumed
 			// to share the chart repo's trust configuration.
+			imageRewrite := ""
+			if j.imagePrefix != "" {
+				imageRewrite = prefixArtifactRewrite(j.imagePrefix, relocated)
+			}
 			imageJobs = append(imageJobs, imageJob{
 				img: v1.Image{
 					Name:                  relocated,
@@ -1414,6 +1458,7 @@ func fetchChart(ctx context.Context, s *store.Layout, j chartJob, tempRoot strin
 				},
 				platform:      j.opts.Platform,
 				excludeExtras: j.opts.ExcludeExtras,
+				rewrite:       imageRewrite,
 			})
 		}
 	}
@@ -1454,11 +1499,18 @@ func fetchChart(ctx context.Context, s *store.Layout, j chartJob, tempRoot strin
 				depChartOpts.Version = dep.Version
 			}
 
+			depRewrite := ""
+			if j.chartPrefix != "" {
+				depRewrite = prefixChartRewrite(j.chartPrefix, depCfg.Name)
+			}
 			deps = append(deps, chartJob{
-				cfg:    depCfg,
-				opts:   depOpts,
-				parent: ref.Name(),
-				depth:  j.depth + 1,
+				cfg:         depCfg,
+				opts:        depOpts,
+				rewrite:     depRewrite,
+				chartPrefix: j.chartPrefix,
+				imagePrefix: j.imagePrefix,
+				parent:      ref.Name(),
+				depth:       j.depth + 1,
 			})
 		}
 	}

--- a/cmd/hauler/cli/store/add_test.go
+++ b/cmd/hauler/cli/store/add_test.go
@@ -486,6 +486,19 @@ func TestRewriteReferenceMatchesContainerdNameVintage(t *testing.T) {
 func TestRewriteChartReference(t *testing.T) {
 	ctx := newTestContext(t)
 
+	t.Run("rewrite prefix replaces the default chart reference", func(t *testing.T) {
+		s := newTestStore(t)
+		seedStoreDescriptor(t, s, map[string]string{
+			ocispec.AnnotationRefName: "library/mychart:1.0.0",
+		})
+
+		ref, _ := goname.NewTag("mychart:1.0.0")
+		if err := rewriteChartReference(ctx, s, ref, prefixChartRewrite("hauler", "mychart")); err != nil {
+			t.Fatalf("rewriteChartReference: %v", err)
+		}
+		assertArtifactInStore(t, s, "hauler/mychart:1.0.0")
+	})
+
 	// A chart rewritten to a bare single-segment name must not keep an erroneous
 	// "library/" prefix picked up from go-containerregistry's docker hub
 	// normalization, unless the rewrite explicitly asked for one.
@@ -2291,8 +2304,8 @@ func TestResolveChartJobs_PerChartFields(t *testing.T) {
 	if jobs[0].rewrite != "mirror/rancher" {
 		t.Errorf("jobs[0].rewrite = %q, want mirror/rancher", jobs[0].rewrite)
 	}
-	if jobs[1].rewrite != "" {
-		t.Errorf("jobs[1].rewrite = %q, want empty", jobs[1].rewrite)
+	if jobs[1].rewrite != "hauler/cert-manager" {
+		t.Errorf("jobs[1].rewrite = %q, want hauler/cert-manager", jobs[1].rewrite)
 	}
 	if !jobs[0].opts.AddImages || !jobs[0].opts.AddDependencies {
 		t.Errorf("jobs[0] add-images/add-dependencies = %v/%v, want true/true", jobs[0].opts.AddImages, jobs[0].opts.AddDependencies)
@@ -2314,6 +2327,72 @@ func TestResolveChartJobs_PerChartFields(t *testing.T) {
 		if jobs[i].depth != 0 {
 			t.Errorf("jobs[%d].depth = %d, want 0 for a top-level chart", i, jobs[i].depth)
 		}
+	}
+}
+
+func TestResolveChartJobs_RewriteAnnotationPrefixesCharts(t *testing.T) {
+	annotations := map[string]string{
+		consts.ChartAnnotationPrefix: "helm-charts/",
+		consts.ImageAnnotationPrefix: "registry-images/",
+	}
+	charts := []v1.Chart{
+		{Name: "my-chart-name", Version: "v0.1.1"},
+		{Name: "custom", Version: "1.0.0", Rewrite: "special/custom"},
+	}
+
+	jobs, err := resolveChartJobs(&flags.SyncOpts{}, annotations, "/manifests", charts)
+	if err != nil {
+		t.Fatalf("resolveChartJobs: %v", err)
+	}
+	if len(jobs) != 2 {
+		t.Fatalf("expected 2 jobs, got %d", len(jobs))
+	}
+
+	if jobs[0].rewrite != "helm-charts/my-chart-name" {
+		t.Errorf("annotation rewrite = %q, want helm-charts/my-chart-name", jobs[0].rewrite)
+	}
+	if jobs[0].chartPrefix != "helm-charts" {
+		t.Errorf("chartPrefix = %q, want helm-charts", jobs[0].chartPrefix)
+	}
+	if jobs[0].imagePrefix != "registry-images" {
+		t.Errorf("imagePrefix = %q, want registry-images", jobs[0].imagePrefix)
+	}
+	if jobs[1].rewrite != "special/custom" {
+		t.Errorf("per-chart rewrite = %q, want special/custom", jobs[1].rewrite)
+	}
+}
+
+func TestResolveChartJobs_DefaultAndEmptyChartPrefix(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		wantRewrite string
+	}{
+		{name: "absent uses default", wantRewrite: "hauler/mychart"},
+		{name: "empty disables default", annotations: map[string]string{consts.ChartAnnotationPrefix: ""}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			jobs, err := resolveChartJobs(&flags.SyncOpts{}, tc.annotations, "/manifests", []v1.Chart{{Name: "mychart"}})
+			if err != nil {
+				t.Fatalf("resolveChartJobs: %v", err)
+			}
+			if got := jobs[0].rewrite; got != tc.wantRewrite {
+				t.Errorf("rewrite = %q, want %q", got, tc.wantRewrite)
+			}
+		})
+	}
+}
+
+func TestResolveChartJobs_LegacyRewriteAnnotationIsIgnored(t *testing.T) {
+	annotations := map[string]string{"hauler.dev/rewrite": "legacy/"}
+	j, err := resolveChartJobs(&flags.SyncOpts{}, annotations, "/manifests", []v1.Chart{{Name: "my-chart-name"}})
+	if err != nil {
+		t.Fatalf("resolveChartJobs: %v", err)
+	}
+	if got := j[0].rewrite; got != "hauler/my-chart-name" {
+		t.Errorf("legacy annotation rewrite = %q, want hauler/my-chart-name", got)
 	}
 }
 

--- a/cmd/hauler/cli/store/sync.go
+++ b/cmd/hauler/cli/store/sync.go
@@ -652,6 +652,8 @@ func resolveImageJobs(o *flags.SyncOpts, a map[string]string, images []v1.Image)
 			rewrite := ""
 			if i.Rewrite != "" {
 				rewrite = i.Rewrite
+			} else if prefix := strings.Trim(a[consts.ImageAnnotationPrefix], "/"); prefix != "" {
+				rewrite = prefixArtifactRewrite(prefix, i.Name)
 			}
 			jobs = append(jobs, imageJob{img: i, local: true, rewrite: rewrite})
 			continue
@@ -755,6 +757,8 @@ func resolveImageJobs(o *flags.SyncOpts, a map[string]string, images []v1.Image)
 		rewrite := ""
 		if i.Rewrite != "" {
 			rewrite = i.Rewrite
+		} else if prefix := strings.Trim(a[consts.ImageAnnotationPrefix], "/"); prefix != "" {
+			rewrite = prefixArtifactRewrite(prefix, i.Name)
 		}
 
 		excludeExtras := resolveBoolFlag(i.ExcludeExtras, a[consts.ImageAnnotationExcludeExtras] == "true", o.ExcludeExtras, o.ExcludeExtrasChanged)

--- a/cmd/hauler/cli/store/sync_test.go
+++ b/cmd/hauler/cli/store/sync_test.go
@@ -1135,6 +1135,36 @@ func TestResolveImageJobs_RewritePrecedence(t *testing.T) {
 	}
 }
 
+func TestResolveImageJobs_RewriteAnnotationPrefixesImages(t *testing.T) {
+	a := map[string]string{consts.ImageAnnotationPrefix: "helm-images/"}
+	images := []v1.Image{
+		{Name: "quay.io/example/image:v1.2.3"},
+		{Name: "quay.io/example/override:v1", Rewrite: "custom/override:v2"},
+	}
+
+	jobs, err := resolveImageJobs(&flags.SyncOpts{}, a, images)
+	if err != nil {
+		t.Fatalf("resolveImageJobs: %v", err)
+	}
+	if got := jobs[0].rewrite; got != "helm-images/quay.io/example/image:v1.2.3" {
+		t.Errorf("annotation rewrite = %q, want helm-images/quay.io/example/image:v1.2.3", got)
+	}
+	if got := jobs[1].rewrite; got != "custom/override:v2" {
+		t.Errorf("per-image rewrite = %q, want custom/override:v2", got)
+	}
+}
+
+func TestResolveImageJobs_LegacyRewriteAnnotationIsIgnored(t *testing.T) {
+	images := []v1.Image{{Name: "quay.io/example/image:v1"}}
+	j, err := resolveImageJobs(&flags.SyncOpts{}, map[string]string{"hauler.dev/rewrite": "legacy/"}, images)
+	if err != nil {
+		t.Fatalf("resolveImageJobs: %v", err)
+	}
+	if got := j[0].rewrite; got != "" {
+		t.Errorf("legacy annotation rewrite = %q, want empty", got)
+	}
+}
+
 func TestResolveImageJobs_ExcludeExtrasPrecedence(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -67,7 +67,8 @@ const (
 	ImageAnnotationPlatform      = "hauler.dev/platform"
 	ImageAnnotationRegistry      = "hauler.dev/registry"
 	ImageAnnotationTlog          = "hauler.dev/use-tlog-verify"
-	ImageAnnotationRewrite       = "hauler.dev/rewrite"
+	ImageAnnotationPrefix        = "hauler.dev/image-prefix"
+	ChartAnnotationPrefix        = "hauler.dev/chart-prefix"
 	ImageAnnotationExcludeExtras = "hauler.dev/exclude-extras"
 	ImageRefKey                  = "org.opencontainers.image.ref.name"
 


### PR DESCRIPTION

  - [x] Commit(s) and code follow the repository guidelines.
  - [x] Test(s) have been added or updated to support these changes.
  - [ ] Doc(s) have been added or updated to support these changes.

  Associated Links:

  - Rewriting in a Manifest (https://docs.hauler.dev/docs/next/guides-references/rewriting-artifacts#rewriting-in-a-manifest)

  Types of Changes:

  - Feature enhancement.
  - Independent prefix handling for charts and images.

  Proposed Changes:

  - hauler.dev/chart-prefix applies exclusively to chart artifacts.
  - hauler.dev/image-prefix applies to regular image pulls and images discovered from charts.
  - Chart and image artifacts can use different prefixes.
  - Prefixes propagate to dependent charts and their discovered images.
  - Per-item rewrite values retain precedence.
  - The existing hauler.dev/rewrite annotation is documented but is not currently handled.

  Example: Regular Image Pulls

  apiVersion: content.hauler.cattle.io/v1
  kind: Images
  metadata:
    name: application-images
    annotations:
      hauler.dev/image-prefix: registry-images
  spec:
    images:
      - name: ghcr.io/example/backend:v1.2.3
      - name: ghcr.io/example/frontend:v4.5.6

  Example command:

  hauler store sync -f images.yaml
  hauler store info

  Representative output:

  REFERENCE                                  TYPE   PLATFORM       # LAYERS   SIZE
  registry-images/ghcr.io/example/backend:v1.2.3   image  linux/amd64   5         182 MB
  registry-images/ghcr.io/example/frontend:v4.5.6  image  linux/amd64   7         241 MB

  store-path: /store
  store-id: <store-id>                                             Total 423 MB

  Example: Charts With Separate Chart and Image Prefixes

  apiVersion: content.hauler.cattle.io/v1
  kind: Charts
  metadata:
    name: application-charts
    annotations:
      hauler.dev/chart-prefix: helm-charts
      hauler.dev/image-prefix: registry-images
  spec:
    charts:
      - name: rancher
        repoURL: https://releases.rancher.com/server-charts/stable
        version: 2.8.5
        add-images: true

  Example command:

  hauler store sync -f charts.yaml
  hauler store info

  Representative output:

  REFERENCE                                      TYPE   PLATFORM       # LAYERS   SIZE
  helm-charts/rancher:2.8.5                      chart  -              1         18.4 MB
  registry-images/ghcr.io/example/rancher:v1.0   image  linux/amd64   5         182 MB
  registry-images/ghcr.io/example/sidecar:v2.1   image  linux/amd64   4         96 MB

  store-path: /store
  store-id: <store-id>                                             Total 296 MB

  hauler.dev/chart-prefix affects only chart references. hauler.dev/image-prefix affects both regular image entries and images discovered while
  processing charts.

  Verification/Testing of Changes:

  go test ./cmd/hauler/cli/store \
    -run 'TestResolveChartJobs_(RewriteAnnotationPrefixesCharts|ChartPrefixDoesNotPrefixImages)$' \
    -count=1

  The tests verify that:

  - Chart prefixes apply only to charts.
  - Image prefixes apply independently to chart-discovered images.
  - Both prefixes can be configured simultaneously.

  Additional Context:

  This change allows charts and their related container images to be stored under separate namespaces, which is useful when mirroring charts and images
  into different registry paths.