### PR TITLE
https registry auth fix

### DIFF
--- a/pkg/artifacts/chart/auth_test.go
+++ b/pkg/artifacts/chart/auth_test.go
@@ -1,0 +1,37 @@
+package chart
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/authn"
+)
+
+type staticKeychain struct{}
+
+func (staticKeychain) Resolve(authn.Resource) (authn.Authenticator, error) {
+	return authn.FromConfig(authn.AuthConfig{Username: "user", Password: "password"}), nil
+}
+
+func TestResolveRepoCredentials(t *testing.T) {
+	original := chartKeychain
+	chartKeychain = staticKeychain{}
+	t.Cleanup(func() { chartKeychain = original })
+
+	username, password, err := resolveRepoCredentials("https://my.registry.com/charts")
+	if err != nil {
+		t.Fatalf("resolveRepoCredentials: %v", err)
+	}
+	if username != "user" || password != "password" {
+		t.Fatalf("credentials = (%q, %q), want (user, password)", username, password)
+	}
+}
+
+func TestResolveRepoCredentialsIgnoresNonURL(t *testing.T) {
+	username, password, err := resolveRepoCredentials("charts")
+	if err != nil {
+		t.Fatalf("resolveRepoCredentials: %v", err)
+	}
+	if username != "" || password != "" {
+		t.Fatalf("credentials = (%q, %q), want empty credentials", username, password)
+	}
+}

--- a/pkg/artifacts/chart/chart.go
+++ b/pkg/artifacts/chart/chart.go
@@ -15,6 +15,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/google/go-containerregistry/pkg/authn"
+	goname "github.com/google/go-containerregistry/pkg/name"
 	gv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/partial"
 	gtypes "github.com/google/go-containerregistry/pkg/v1/types"
@@ -31,9 +33,37 @@ import (
 )
 
 var (
-	_        artifacts.OCI = (*Chart)(nil)
-	settings               = cli.New()
+	_             artifacts.OCI  = (*Chart)(nil)
+	settings                     = cli.New()
+	chartKeychain authn.Keychain = authn.DefaultKeychain
 )
+
+// resolveRepoCredentials bridges Docker credentials (including those written
+// by `hauler login`) to Helm's legacy HTTP chart-repository downloader. Helm's
+// OCI client reads the Docker keychain itself, but the legacy downloader only
+// knows about ChartPathOptions.Username and Password.
+func resolveRepoCredentials(repoURL string) (string, string, error) {
+	u, err := url.Parse(repoURL)
+	if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+		return "", "", nil
+	}
+	reg, err := goname.NewRegistry(u.Host)
+	if err != nil {
+		return "", "", fmt.Errorf("parsing chart repository host %q: %w", u.Host, err)
+	}
+	auth, err := chartKeychain.Resolve(reg)
+	if err != nil {
+		return "", "", fmt.Errorf("resolving chart repository credentials for %q: %w", u.Host, err)
+	}
+	if auth == authn.Anonymous {
+		return "", "", nil
+	}
+	config, err := auth.Authorization()
+	if err != nil {
+		return "", "", fmt.Errorf("reading chart repository credentials for %q: %w", u.Host, err)
+	}
+	return config.Username, config.Password, nil
+}
 
 // chart implements the oci interface for chart api objects... api spec values are stored into the name, repo, and version fields
 type Chart struct {
@@ -76,6 +106,14 @@ func NewChart(name string, opts *action.ChartPathOptions) (*Chart, error) {
 	if registry.IsOCI(opts.RepoURL) {
 		chartRef = opts.RepoURL + "/" + name
 	} else if isUrl(opts.RepoURL) { // oci protocol registers as a valid url
+		if client.ChartPathOptions.Username == "" && client.ChartPathOptions.Password == "" {
+			username, password, err := resolveRepoCredentials(opts.RepoURL)
+			if err != nil {
+				return nil, err
+			}
+			client.ChartPathOptions.Username = username
+			client.ChartPathOptions.Password = password
+		}
 		client.ChartPathOptions.RepoURL = opts.RepoURL
 	} else { // handles cases like grafana and loki
 		chartRef = opts.RepoURL + "/" + name


### PR DESCRIPTION
  - [x] Commit(s) and code follow the repositories guidelines.
  - [x] Test(s) have been added or updated to support these change(s).
  - [ ] Doc(s) have been added or updated to support these change(s).

  <!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

  **Associated Links:**

  - None

  **Types of Changes:**

  - Bugfix

  **Proposed Changes:**

  - Fix authentication for legacy HTTPS Helm chart repositories.
  - Resolve credentials stored by `hauler login` through the Docker credential keychain.
  - Pass resolved credentials to Helm’s legacy chart downloader.
  - Preserve explicitly provided chart credentials.
  - Leave OCI registry authentication behavior unchanged.

  **Verification/Testing of Changes:**

  - Run:

    ```sh
    go test ./pkg/artifacts/chart

  - Verify that credentials from hauler login are resolved for:

    https://my.registry.com/charts

  - Confirm that non-URL/local chart sources do not attempt credential resolution.

  Additional Context:

  - Helm’s legacy HTTP chart downloader does not automatically use Docker credential-store entries.
  - hauler login previously stored credentials successfully, but those credentials were not passed to Helm when downloading charts from legacy HTTPS
    repositories.

  - Added focused tests for Docker credential resolution and non-URL handling.