### PR TITLE
adjust supporting artifact retrieval

### DIFF
--- a/cmd/hauler/cli/store/add.go
+++ b/cmd/hauler/cli/store/add.go
@@ -573,6 +573,14 @@ func storeImage(ctx context.Context, s *store.Layout, i v1.Image, platform strin
 	})
 	if err != nil {
 		if ignoreErrors {
+			var raErr *store.RelatedArtifactError
+			if errors.As(err, &raErr) {
+				// The image itself already landed in the store before the
+				// artifact probe failed; "unable to add image" would
+				// misreport what's actually there.
+				log.BaseFromContext(ctx).Warnf("image [%s] stored, but retrieving related artifacts failed: %v... continuing...", effectiveRef.Name(), err)
+				return nil
+			}
 			log.BaseFromContext(ctx).Warnf("unable to add image [%s] to store: %v... skipping...", effectiveRef.Name(), err)
 			return nil
 		} else if errors.Is(err, context.Canceled) {

--- a/cmd/hauler/cli/store/add_test.go
+++ b/cmd/hauler/cli/store/add_test.go
@@ -691,6 +691,40 @@ func TestStoreImage(t *testing.T) {
 	})
 }
 
+// TestStoreImageIgnoreErrorsRelatedArtifactWording verifies that when the
+// image itself lands in the store but a related-artifact probe fails (e.g. a
+// 401 on the cosign tag convention), --ignore-errors reports that the image
+// was stored -- not the generic "unable to add image ... skipping" wording,
+// which would misreport that nothing was written.
+func TestStoreImageIgnoreErrorsRelatedArtifactWording(t *testing.T) {
+	host, opts := artifactProbe401Registry(t)
+	seedImage(t, host, "repro/warn", "v1", opts...)
+
+	var buf bytes.Buffer
+	l := log.NewLogger(&buf)
+	ctx := l.WithContext(context.Background())
+
+	s := newTestStore(t)
+	rso, ro := defaultRootOpts(s.Root), defaultCliOpts()
+	ro.IgnoreErrors = true
+
+	img := v1.Image{Name: host + "/repro/warn:v1"}
+	if err := storeImage(ctx, s, img, "", false, rso, ro, "", "", false); err != nil {
+		t.Fatalf("storeImage with --ignore-errors returned error: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "stored, but") {
+		t.Fatalf("warning does not say the image was stored; got: %s", out)
+	}
+	if strings.Contains(out, "unable to add image") {
+		t.Fatalf("misleading 'unable to add image' still logged for a related-artifact failure; got: %s", out)
+	}
+
+	// The image itself must be in the store.
+	assertArtifactInStore(t, s, "repro/warn")
+}
+
 func TestStoreImage_Rewrite(t *testing.T) {
 	ctx := newTestContext(t)
 	host, rOpts := newLocalhostRegistry(t)

--- a/cmd/hauler/cli/store/copy.go
+++ b/cmd/hauler/cli/store/copy.go
@@ -48,10 +48,11 @@ func CopyCmd(ctx context.Context, o *flags.CopyOpts, s *store.Layout, targetRef 
 		// For directory targets, extract files and charts (not images)
 		err := s.Walk(func(reference string, desc ocispec.Descriptor) error {
 			// Skip cosign sig/att/sbom artifacts — they're registry-only metadata,
-			// not extractable as files or charts.
+			// not extractable as files or charts. SigKindExt matches both the
+			// plain kind (top-level artifact) and the subject-suffixed kind
+			// (per-platform artifact), so a child-subject sig is skipped too.
 			kind := desc.Annotations[consts.KindAnnotationName]
-			switch kind {
-			case consts.KindAnnotationSigs, consts.KindAnnotationAtts, consts.KindAnnotationSboms:
+			if _, ok := consts.SigKindExt(kind); ok {
 				l.Debugf("skipping cosign artifact [%s] for directory target", reference)
 				return nil
 			}
@@ -201,12 +202,6 @@ func CopyCmd(ctx context.Context, o *flags.CopyOpts, s *store.Layout, targetRef 
 			return err
 		}
 
-		sigExts := map[string]string{
-			consts.KindAnnotationSigs:  ".sig",
-			consts.KindAnnotationAtts:  ".att",
-			consts.KindAnnotationSboms: ".sbom",
-		}
-
 		var fatalErr error
 		err := s.Walk(func(reference string, desc ocispec.Descriptor) error {
 			if fatalErr != nil {
@@ -228,9 +223,17 @@ func CopyCmd(ctx context.Context, o *flags.CopyOpts, s *store.Layout, targetRef 
 			// image's manifest digest rather than using AnnotationRefName directly.
 			destRef := baseRef
 			kind := desc.Annotations[consts.KindAnnotationName]
-			if ext, isSigKind := sigExts[kind]; isSigKind {
-				if imgDigest, ok := refDigest[baseRef]; ok {
-					digestTag := strings.ReplaceAll(imgDigest, ":", "-")
+			if ext, isSigKind := consts.SigKindExt(kind); isSigKind {
+				// Prefer the subject recorded at add time -- a per-platform sig must
+				// land on its own subject's tag, not the top-level index's. Old
+				// archives predate the annotation and only ever hold top-level
+				// artifacts, so the pre-pass map remains correct for them.
+				subject := desc.Annotations[consts.SubjectDigestAnnotation]
+				if subject == "" {
+					subject = refDigest[baseRef]
+				}
+				if subject != "" {
+					digestTag := strings.ReplaceAll(subject, ":", "-")
 					repo := repoFromBaseRef(baseRef)
 					destRef = repo + ":" + digestTag + ext
 				}

--- a/cmd/hauler/cli/store/copy_test.go
+++ b/cmd/hauler/cli/store/copy_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	goname "github.com/google/go-containerregistry/pkg/name"
+	gcrv1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	digest "github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -248,6 +249,83 @@ func TestCopyCmd_Registry_SigTagDerivation(t *testing.T) {
 	}
 	if _, err := remote.Get(sigRef, dstOpts...); err != nil {
 		t.Errorf("sig not found at expected tag %s in target registry: %v", sigTag, err)
+	}
+}
+
+// TestCopyRegistryRoutesPlatformSigs seeds a multi-arch index whose amd64
+// child carries its own cosign sig distinct from the index-level sig (the
+// registry.k8s.io/csi-attacher shape), stores it, copies to a second
+// registry, and verifies BOTH sigs land on their own subject's cosign tag
+// rather than the child sig being dropped or misrouted to the index's tag.
+func TestCopyRegistryRoutesPlatformSigs(t *testing.T) {
+	ctx := newTestContext(t)
+
+	srcHost, srcOpts := newLocalhostRegistry(t)
+	dstHost, dstOpts := newTestRegistry(t)
+	idxDigest, childDigest := seedMultiArchWithPlatformSig(t, srcHost, "repro/multi", "v1", srcOpts...)
+
+	s := newTestStore(t)
+	rso := defaultRootOpts(s.Root)
+	ro := defaultCliOpts()
+	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/repro/multi:v1"}, "", false, rso, ro, "", "", false); err != nil {
+		t.Fatalf("storeImage: %v", err)
+	}
+
+	o := &flags.CopyOpts{StoreRootOpts: rso, PlainHTTP: true}
+	if err := CopyCmd(ctx, o, s, "registry://"+dstHost, ro); err != nil {
+		t.Fatalf("CopyCmd: %v", err)
+	}
+
+	for _, d := range []gcrv1.Hash{idxDigest, childDigest} {
+		sigRef, err := goname.NewTag(dstHost+"/repro/multi:"+strings.ReplaceAll(d.String(), ":", "-")+".sig", goname.Insecure)
+		if err != nil {
+			t.Fatalf("goname.NewTag: %v", err)
+		}
+		if _, err := remote.Head(sigRef, dstOpts...); err != nil {
+			t.Errorf("sig for subject %s not found at destination %s: %v", d, sigRef, err)
+		}
+	}
+}
+
+// TestCopyRegistryOldFormatSigFallback verifies that a store entry with a
+// plain sig kind and no subject annotation -- the shape an archive written
+// before the subject annotation was introduced would still carry -- still
+// routes via the refDigest pre-pass map rather than being dropped.
+func TestCopyRegistryOldFormatSigFallback(t *testing.T) {
+	ctx := newTestContext(t)
+
+	srcHost, srcOpts := newLocalhostRegistry(t)
+	dstHost, dstOpts := newTestRegistry(t)
+
+	baseImg := seedImage(t, srcHost, "repro/old", "v1", srcOpts...)
+	seedCosignV2Artifacts(t, srcHost, "repro/old", baseImg, srcOpts...)
+
+	s := newTestStore(t)
+	rso := defaultRootOpts(s.Root)
+	ro := defaultCliOpts()
+	if err := storeImage(ctx, s, v1.Image{Name: srcHost + "/repro/old:v1"}, "", false, rso, ro, "", "", false); err != nil {
+		t.Fatalf("storeImage: %v", err)
+	}
+
+	// Simulate an old-format archive: strip the subject annotation from every
+	// sig-kind entry, mimicking a store written by an older hauler.
+	stripSubjectAnnotations(t, s)
+
+	o := &flags.CopyOpts{StoreRootOpts: rso, PlainHTTP: true}
+	if err := CopyCmd(ctx, o, s, "registry://"+dstHost, ro); err != nil {
+		t.Fatalf("CopyCmd: %v", err)
+	}
+
+	d, err := baseImg.Digest()
+	if err != nil {
+		t.Fatalf("baseImg.Digest: %v", err)
+	}
+	sigRef, err := goname.NewTag(dstHost+"/repro/old:"+strings.ReplaceAll(d.String(), ":", "-")+".sig", goname.Insecure)
+	if err != nil {
+		t.Fatalf("goname.NewTag: %v", err)
+	}
+	if _, err := remote.Head(sigRef, dstOpts...); err != nil {
+		t.Errorf("old-format sig not routed via refDigest fallback: %v", err)
 	}
 }
 

--- a/cmd/hauler/cli/store/create_manifest.go
+++ b/cmd/hauler/cli/store/create_manifest.go
@@ -91,8 +91,9 @@ func CreateManifestCmd(ctx context.Context, o *flags.CreateManifestOpts, s *stor
 		}
 
 		kind := desc.Annotations[consts.KindAnnotationName]
+		_, isCosignArtifact := consts.SigKindExt(kind)
 		switch {
-		case kind == consts.KindAnnotationSigs, kind == consts.KindAnnotationAtts, kind == consts.KindAnnotationSboms:
+		case isCosignArtifact:
 			// cosign-related artifacts are rediscovered automatically when the
 			// parent image is re-added, so they don't need their own entry.
 			return nil

--- a/cmd/hauler/cli/store/create_manifest_test.go
+++ b/cmd/hauler/cli/store/create_manifest_test.go
@@ -79,6 +79,41 @@ func TestCreateManifestCmd_Image(t *testing.T) {
 	}
 }
 
+// TestCreateManifestCmd_SuffixedSigKindSkipped confirms a subject-suffixed sig kind
+// ("dev.hauler/sigs/<hex>", written for a multi-arch image's child manifest) is
+// skipped like the plain form rather than falling through to the
+// ContainerdImageNameKey branch and being emitted as a second, duplicate image
+// entry -- the synthetic descriptor below carries the same ContainerdImageNameKey
+// as the real image specifically to catch that fallthrough.
+func TestCreateManifestCmd_SuffixedSigKindSkipped(t *testing.T) {
+	ctx := newTestContext(t)
+	host, rOpts := newLocalhostRegistry(t)
+	seedImage(t, host, "test/repo", "v1", rOpts...)
+
+	s := newTestStore(t)
+	rso := defaultRootOpts(s.Root)
+	ro := defaultCliOpts()
+	if err := storeImage(ctx, s, v1.Image{Name: host + "/test/repo:v1"}, "", false, rso, ro, "", "", false); err != nil {
+		t.Fatalf("storeImage: %v", err)
+	}
+
+	seedStoreDescriptor(t, s, map[string]string{
+		ocispec.AnnotationRefName:     "test/repo:v1",
+		consts.KindAnnotationName:     consts.KindAnnotationSigs + "/0123abcd",
+		consts.ContainerdImageNameKey: host + "/test/repo:v1",
+	})
+
+	o := newCreateManifestOpts(t, rso)
+	if err := CreateManifestCmd(ctx, o, s); err != nil {
+		t.Fatalf("CreateManifestCmd: %v", err)
+	}
+
+	content := readManifest(t, o.Output)
+	if got := strings.Count(content, "name: "+host+"/test/repo:v1"); got != 1 {
+		t.Errorf("expected exactly 1 image entry (suffixed sig kind must be skipped), got %d in:\n%s", got, content)
+	}
+}
+
 func TestCreateManifestCmd_ImageWithRewrite(t *testing.T) {
 	ctx := newTestContext(t)
 	host, rOpts := newLocalhostRegistry(t)

--- a/cmd/hauler/cli/store/extract.go
+++ b/cmd/hauler/cli/store/extract.go
@@ -104,8 +104,7 @@ func ExtractCmd(ctx context.Context, o *flags.ExtractOpts, s *store.Layout, ref 
 		// they are never extractable to disk. Skip them silently at debug level,
 		// mirroring the same guard in copy.go (directory-target path).
 		kind := desc.Annotations[consts.KindAnnotationName]
-		switch kind {
-		case consts.KindAnnotationSigs, consts.KindAnnotationAtts, consts.KindAnnotationSboms:
+		if _, ok := consts.SigKindExt(kind); ok {
 			l.Debugf("skipping cosign artifact [%s] for extract", reference)
 			return nil
 		}

--- a/cmd/hauler/cli/store/extract_test.go
+++ b/cmd/hauler/cli/store/extract_test.go
@@ -628,3 +628,46 @@ func TestExtractCmd_CosignArtifactsProduceNoContainerImageWarning(t *testing.T) 
 		t.Errorf("content mismatch: got %q, want %q", string(data), fileContent)
 	}
 }
+
+// TestExtractCmd_SuffixedSigKind_Skipped confirms a subject-suffixed sig kind
+// ("dev.hauler/sigs/<hex>", written for a multi-arch image's child manifest) is
+// skipped the same way as the plain form. The synthetic descriptor's digest has no
+// backing blob, so before the fix (an exact kind == consts.KindAnnotationSigs
+// comparison that misses the suffix) ExtractCmd would try to Fetch it and fail.
+func TestExtractCmd_SuffixedSigKind_Skipped(t *testing.T) {
+	var logBuf bytes.Buffer
+	ctx := newLogCaptureContext(&logBuf)
+	s := newTestStore(t)
+
+	fileContent := "suffixed-sig-filter test file content"
+	url := seedFileInHTTPServer(t, "suffixedsig.txt", fileContent)
+	if err := storeFile(ctx, s, v1.File{Path: url}, defaultCliOpts(), defaultRootOpts(s.Root)); err != nil {
+		t.Fatalf("storeFile: %v", err)
+	}
+
+	baseRef := "hauler/suffixedsig.txt:latest"
+	seedStoreDescriptor(t, s, map[string]string{
+		ocispec.AnnotationRefName:     baseRef,
+		consts.KindAnnotationName:     consts.KindAnnotationSigs + "/0123abcd",
+		consts.ContainerdImageNameKey: "registry.example.com/" + baseRef,
+	})
+
+	destDir := t.TempDir()
+	eo := &flags.ExtractOpts{
+		StoreRootOpts:  defaultRootOpts(s.Root),
+		DestinationDir: destDir,
+	}
+
+	if err := ExtractCmd(ctx, eo, s, baseRef); err != nil {
+		t.Fatalf("ExtractCmd: %v", err)
+	}
+
+	outPath := filepath.Join(destDir, "suffixedsig.txt")
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("expected extracted file at %s: %v", outPath, err)
+	}
+	if string(data) != fileContent {
+		t.Errorf("content mismatch: got %q, want %q", string(data), fileContent)
+	}
+}

--- a/cmd/hauler/cli/store/info.go
+++ b/cmd/hauler/cli/store/info.go
@@ -626,14 +626,15 @@ func resolveCtype(desc ocispec.Descriptor, configMediaType string) string {
 		ctype = "image"
 	}
 
-	switch {
-	case desc.Annotations[consts.KindAnnotationName] == consts.KindAnnotationSigs:
+	kind := desc.Annotations[consts.KindAnnotationName]
+	switch ext, _ := consts.SigKindExt(kind); {
+	case ext == ".sig":
 		ctype = "sigs"
-	case desc.Annotations[consts.KindAnnotationName] == consts.KindAnnotationAtts:
+	case ext == ".att":
 		ctype = "atts"
-	case desc.Annotations[consts.KindAnnotationName] == consts.KindAnnotationSboms:
+	case ext == ".sbom":
 		ctype = "sbom"
-	case strings.HasPrefix(desc.Annotations[consts.KindAnnotationName], consts.KindAnnotationReferrers):
+	case strings.HasPrefix(kind, consts.KindAnnotationReferrers):
 		ctype = "referrer"
 	}
 	return ctype

--- a/cmd/hauler/cli/store/info_test.go
+++ b/cmd/hauler/cli/store/info_test.go
@@ -179,6 +179,23 @@ func TestNewItem(t *testing.T) {
 			wantType:       "referrer",
 		},
 		{
+			// Suffixed form written for a multi-arch image's child manifest
+			// (nameMapKey's <ref>-<kind> stays unique per subject); must label
+			// the same as the plain "KindAnnotationSigs → sigs" case above.
+			name:           "KindAnnotationSigs suffixed → sigs",
+			configMedia:    consts.DockerConfigJSON,
+			kindAnnotation: consts.KindAnnotationSigs + "/0123abcd",
+			typeFilter:     "all",
+			wantType:       "sigs",
+		},
+		{
+			name:           "KindAnnotationSboms suffixed → sbom",
+			configMedia:    consts.DockerConfigJSON,
+			kindAnnotation: consts.KindAnnotationSboms + "/0123abcd",
+			typeFilter:     "all",
+			wantType:       "sbom",
+		},
+		{
 			name:        "TypeFilter:image with chart → empty item",
 			configMedia: consts.ChartConfigMediaType,
 			typeFilter:  "image",

--- a/cmd/hauler/cli/store/remove.go
+++ b/cmd/hauler/cli/store/remove.go
@@ -23,14 +23,15 @@ import (
 // does: from the manifest's config media type, since AddArtifact stores every non-image-command
 // artifact (files, charts) under the same "kind" annotation and can't distinguish them
 func artifactType(ctx context.Context, s *store.Layout, desc ocispec.Descriptor) string {
-	switch {
-	case desc.Annotations[consts.KindAnnotationName] == consts.KindAnnotationSigs:
+	kind := desc.Annotations[consts.KindAnnotationName]
+	switch ext, _ := consts.SigKindExt(kind); {
+	case ext == ".sig":
 		return "sigs"
-	case desc.Annotations[consts.KindAnnotationName] == consts.KindAnnotationAtts:
+	case ext == ".att":
 		return "atts"
-	case desc.Annotations[consts.KindAnnotationName] == consts.KindAnnotationSboms:
+	case ext == ".sbom":
 		return "sbom"
-	case strings.HasPrefix(desc.Annotations[consts.KindAnnotationName], consts.KindAnnotationReferrers):
+	case strings.HasPrefix(kind, consts.KindAnnotationReferrers):
 		return "referrer"
 	case desc.MediaType == consts.OCIImageIndexSchema, desc.MediaType == consts.DockerManifestListSchema2:
 		return "image"

--- a/cmd/hauler/cli/store/remove_test.go
+++ b/cmd/hauler/cli/store/remove_test.go
@@ -8,6 +8,7 @@ import (
 
 	"hauler.dev/go/hauler/v2/internal/flags"
 	v1 "hauler.dev/go/hauler/v2/pkg/apis/hauler.cattle.io/v1"
+	"hauler.dev/go/hauler/v2/pkg/consts"
 )
 
 // --------------------------------------------------------------------------
@@ -69,6 +70,30 @@ func TestFormatReference(t *testing.T) {
 				t.Errorf("formatReference(%q) = %q, want %q", tc.ref, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestArtifactTypeSuffixedKinds confirms artifactType classifies subject-suffixed
+// cosign kinds ("dev.hauler/sigs/<hex>", etc, written for a multi-arch child
+// manifest so nameMapKey's <ref>-<kind> stays unique) the same as their plain form,
+// since it drove `store remove`'s audit-log Type field via an exact-match switch
+// that missed the suffix before consts.SigKindExt was adopted here.
+func TestArtifactTypeSuffixedKinds(t *testing.T) {
+	ctx := newTestContext(t)
+	s := newTestStore(t)
+	cases := []struct {
+		kind string
+		want string
+	}{
+		{consts.KindAnnotationSigs + "/0123abcd", "sigs"},
+		{consts.KindAnnotationAtts + "/0123abcd", "atts"},
+		{consts.KindAnnotationSboms + "/0123abcd", "sbom"},
+	}
+	for _, c := range cases {
+		desc := ocispec.Descriptor{Annotations: map[string]string{consts.KindAnnotationName: c.kind}}
+		if got := artifactType(ctx, s, desc); got != c.want {
+			t.Errorf("artifactType(kind=%q) = %q, want %q", c.kind, got, c.want)
+		}
 	}
 }
 

--- a/cmd/hauler/cli/store/save_test.go
+++ b/cmd/hauler/cli/store/save_test.go
@@ -326,6 +326,55 @@ func TestWriteContainerdIndexes(t *testing.T) {
 	}
 }
 
+// TestWriteContainerdIndexesDropsSuffixedArtifactKinds pins writeContainerdIndexes'
+// exact kind == KindAnnotationImage/KindAnnotationIndex filter against subject-suffixed
+// cosign kinds ("dev.hauler/sigs/<hex>", written for a multi-arch image's child
+// manifest): the filter already drops them with no code change, since a suffixed
+// kind can never equal either exact match, but this is the compatibility contract
+// for `store save --containerd` -- its index.json is the one containerd actually
+// imports, so a regression here would leak sig/att/sbom entries into a real import.
+func TestWriteContainerdIndexesDropsSuffixedArtifactKinds(t *testing.T) {
+	s := newTestStore(t)
+	seedStoreDescriptor(t, s, map[string]string{
+		consts.KindAnnotationName:     consts.KindAnnotationImage,
+		ocispec.AnnotationRefName:     "repro/ctrd:v1",
+		consts.ContainerdImageNameKey: "example.com/repro/ctrd:v1",
+	})
+	seedStoreDescriptor(t, s, map[string]string{
+		consts.KindAnnotationName:     consts.KindAnnotationSigs + "/0123abcd",
+		ocispec.AnnotationRefName:     "repro/ctrd:v1",
+		consts.ContainerdImageNameKey: "example.com/repro/ctrd:v1",
+	})
+	if err := s.SaveIndex(); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := t.TempDir()
+	dropped, err := writeContainerdIndexes(s.Root, outDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dropped != 1 {
+		t.Fatalf("dropped = %d, want 1 (the suffixed sig entry)", dropped)
+	}
+	data, err := os.ReadFile(filepath.Join(outDir, ocispec.ImageIndexFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var idx ocispec.Index
+	if err := json.Unmarshal(data, &idx); err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range idx.Manifests {
+		if _, ok := consts.SigKindExt(d.Annotations[consts.KindAnnotationName]); ok {
+			t.Fatalf("containerd sidecar index contains artifact entry with kind %q", d.Annotations[consts.KindAnnotationName])
+		}
+	}
+	if len(idx.Manifests) != 1 {
+		t.Fatalf("sidecar index has %d entries, want 1 (the image)", len(idx.Manifests))
+	}
+}
+
 // TestWriteDefaultIndex covers the default-mode (non-`--containerd`) archive
 // index rewrite added for #744 fix 1: every descriptor is kept (unlike
 // writeContainerdIndexes' filtered rewrite), but io.containerd.image.name

--- a/cmd/hauler/cli/store/testhelpers_test.go
+++ b/cmd/hauler/cli/store/testhelpers_test.go
@@ -505,6 +505,67 @@ func seedCosignV2Artifacts(t *testing.T, host, repo string, baseImg gcrv1.Image,
 	}
 }
 
+// seedMultiArchWithPlatformSig publishes a two-platform index at repo:tag,
+// plus cosign v2 sigs for BOTH the index digest and the amd64 child digest --
+// the registry.k8s.io/csi-attacher shape from the community report. Duplicated
+// from pkg/store's test package (store_test.go) because that file lives in
+// package store_test and cannot be imported by this package's tests.
+func seedMultiArchWithPlatformSig(t *testing.T, host, repo, tag string, opts ...remote.Option) (idxDigest, childDigest gcrv1.Hash) {
+	t.Helper()
+	amd64Img, err := random.Image(512, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	arm64Img, err := random.Image(512, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{Add: amd64Img, Descriptor: gcrv1.Descriptor{Platform: &gcrv1.Platform{OS: "linux", Architecture: "amd64"}}},
+		mutate.IndexAddendum{Add: arm64Img, Descriptor: gcrv1.Descriptor{Platform: &gcrv1.Platform{OS: "linux", Architecture: "arm64"}}},
+	)
+	ref, err := goname.NewTag(host+"/"+repo+":"+tag, goname.Insecure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.WriteIndex(ref, idx, opts...); err != nil {
+		t.Fatal(err)
+	}
+	idxDigest, err = idx.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childDigest, err = amd64Img.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []gcrv1.Hash{idxDigest, childDigest} {
+		sigTag := strings.ReplaceAll(d.String(), ":", "-") + ".sig"
+		seedImage(t, host, repo, sigTag, opts...)
+	}
+	return idxDigest, childDigest
+}
+
+// stripSubjectAnnotations removes consts.SubjectDigestAnnotation from every
+// sig/att/sbom-kind descriptor in the store, simulating an archive written by
+// a hauler version that predates the subject annotation. UpdateAnnotations
+// applies the mutation and persists the index itself -- Walk only ever hands
+// callbacks a snapshot copy of a descriptor's annotations, so mutating one in
+// place there would silently no-op.
+func stripSubjectAnnotations(t *testing.T, s *store.Layout) {
+	t.Helper()
+	match := func(d ocispec.Descriptor) bool {
+		_, ok := consts.SigKindExt(d.Annotations[consts.KindAnnotationName])
+		return ok
+	}
+	apply := func(ann map[string]string) {
+		delete(ann, consts.SubjectDigestAnnotation)
+	}
+	if _, err := s.OCI.UpdateAnnotations(match, apply); err != nil {
+		t.Fatalf("stripSubjectAnnotations: %v", err)
+	}
+}
+
 // seedOCI11Referrer pushes a synthetic OCI 1.1 / cosign v3 Sigstore bundle manifest
 // whose subject field points at baseImg. The in-process registry auto-registers it in
 // the referrers index so remote.Referrers returns it.

--- a/cmd/hauler/cli/store/testhelpers_test.go
+++ b/cmd/hauler/cli/store/testhelpers_test.go
@@ -165,6 +165,28 @@ func newTestRegistry(t *testing.T) (host string, remoteOpts []remote.Option) {
 	return host, remoteOpts
 }
 
+// artifactProbe401Registry serves images normally but returns 401 for cosign
+// tag-convention probes and the OCI referrers endpoint, so a caller can
+// exercise the path where the image itself lands in the store but a
+// related-artifact probe fails. Duplicated from pkg/store/store_test.go --
+// that package's test helpers aren't reachable from this one.
+func artifactProbe401Registry(t *testing.T) (string, []remote.Option) {
+	t.Helper()
+	inner := registry.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		if strings.Contains(p, "/referrers/") ||
+			strings.HasSuffix(p, ".sig") || strings.HasSuffix(p, ".att") || strings.HasSuffix(p, ".sbom") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		inner.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	return host, []remote.Option{remote.WithTransport(srv.Client().Transport)}
+}
+
 // recordingHandler records the path of every request it serves before
 // delegating. Concurrent handlers append to the same slice, so every method
 // takes mu.

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -1,6 +1,9 @@
 package consts
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	// container media types
@@ -83,6 +86,12 @@ const (
 	// URL or absolute local path.
 	OriginalRefAnnotation = "hauler.dev/original-ref"
 
+	// SubjectDigestAnnotation records, on a sig/att/sbom/referrer index entry, the
+	// full digest ("sha256:<hex>") of the manifest the artifact belongs to. Copy
+	// derives the cosign destination tag from it; without it a per-platform sig
+	// would be routed to the top-level index's tag.
+	SubjectDigestAnnotation = "hauler.dev/subject-digest"
+
 	// cosign keyless validation options
 	ImageAnnotationCertIdentity                 = "hauler.dev/certificate-identity"
 	ImageAnnotationCertIdentityRegexp           = "hauler.dev/certificate-identity-regexp"
@@ -153,3 +162,21 @@ const (
 )
 
 var FileExcludePattern = fmt.Sprintf(`^%s/[.\-_]`, DefaultNamespace)
+
+// SigKindExt maps a cosign artifact kind to its tag-convention extension.
+// Kinds come in two shapes: plain ("dev.hauler/sigs") for an image's own
+// top-level artifact, and subject-suffixed ("dev.hauler/sigs/<hex>") for a
+// child manifest of a multi-arch index -- the suffix keeps nameMapKey's
+// <ref>-<kind> unique when one image carries artifacts for several subjects.
+func SigKindExt(kind string) (string, bool) {
+	for base, ext := range map[string]string{
+		KindAnnotationSigs:  ".sig",
+		KindAnnotationAtts:  ".att",
+		KindAnnotationSboms: ".sbom",
+	} {
+		if kind == base || strings.HasPrefix(kind, base+"/") {
+			return ext, true
+		}
+	}
+	return "", false
+}

--- a/pkg/consts/consts_test.go
+++ b/pkg/consts/consts_test.go
@@ -1,0 +1,34 @@
+package consts_test
+
+import (
+	"testing"
+
+	"hauler.dev/go/hauler/v2/pkg/consts"
+)
+
+func TestSigKindExt(t *testing.T) {
+	cases := []struct {
+		kind string
+		ext  string
+		ok   bool
+	}{
+		{consts.KindAnnotationSigs, ".sig", true},
+		{consts.KindAnnotationAtts, ".att", true},
+		{consts.KindAnnotationSboms, ".sbom", true},
+		{consts.KindAnnotationSigs + "/0123abcd", ".sig", true},
+		{consts.KindAnnotationAtts + "/0123abcd", ".att", true},
+		{consts.KindAnnotationSboms + "/0123abcd", ".sbom", true},
+		{consts.KindAnnotationImage, "", false},
+		{consts.KindAnnotationIndex, "", false},
+		{consts.KindAnnotationReferrers + "/0123abcd", "", false},
+		// A kind that merely shares the prefix string without the "/" separator
+		// must not match: "dev.hauler/sigsX" is not a sig kind.
+		{consts.KindAnnotationSigs + "X", "", false},
+	}
+	for _, c := range cases {
+		ext, ok := consts.SigKindExt(c.kind)
+		if ext != c.ext || ok != c.ok {
+			t.Errorf("SigKindExt(%q) = (%q, %t), want (%q, %t)", c.kind, ext, ok, c.ext, c.ok)
+		}
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +19,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/daemon"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	ggcrtransport "github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
@@ -560,30 +563,75 @@ func (l *Layout) writeIndex(ctx context.Context, annotationRef goname.Reference,
 	return l.OCI.AddIndex(desc)
 }
 
+// isNotFound reports whether err is a definitive "artifact absent" registry
+// response: HTTP 404, or error code MANIFEST_UNKNOWN / NAME_UNKNOWN. Only
+// these may be treated as "unsigned image" -- a 401/403/429/5xx or timeout is
+// a failed retrieval, and swallowing it produces a silently incomplete store
+// indistinguishable from an unsigned one.
+func isNotFound(err error) bool {
+	var terr *ggcrtransport.Error
+	if !errors.As(err, &terr) {
+		return false
+	}
+	if terr.StatusCode == http.StatusNotFound {
+		return true
+	}
+	for _, diag := range terr.Errors {
+		if diag.Code == ggcrtransport.ManifestUnknownErrorCode || diag.Code == ggcrtransport.NameUnknownErrorCode {
+			return true
+		}
+	}
+	return false
+}
+
+// RelatedArtifactError reports a failure retrieving a sig/att/sbom/referrer
+// for an image that itself was already stored. Callers use errors.As to word
+// their messages accurately -- the image is in the store; the run failed on
+// its supply-chain artifacts.
+type RelatedArtifactError struct {
+	Ref     string // base image ref
+	Kind    string // dev.hauler kind being retrieved
+	Subject string // subject digest ("sha256:<hex>")
+	Err     error
+}
+
+func (e *RelatedArtifactError) Error() string {
+	return fmt.Sprintf("retrieving %s for %s (subject %s): %v", e.Kind, e.Ref, e.Subject, e.Err)
+}
+
+func (e *RelatedArtifactError) Unwrap() error { return e.Err }
+
 // saveReferrers discovers and saves OCI 1.1 referrers for the image identified by ref/hash --
 // cosign v3 new-bundle-format sigs/attestations stored via the subject field, as opposed to the
-// legacy sha256-<hex>.sig/.att/.sbom tag convention. Missing referrers and fetch errors are
-// logged at debug level and silently skipped.
+// legacy sha256-<hex>.sig/.att/.sbom tag convention.
 func (l *Layout) saveReferrers(ctx context.Context, ref goname.Reference, hash v1.Hash, alreadySaved map[string]bool, opts ...remote.Option) error {
 	log := zerolog.Ctx(ctx)
 
 	imageDigestRef, err := goname.NewDigest(ref.Context().String() + "@" + hash.String())
 	if err != nil {
-		log.Debug().Err(err).Msgf("saveReferrers: could not construct digest ref for %s", ref.Name())
-		return nil
+		return fmt.Errorf("saveReferrers: constructing digest ref for %s: %w", ref.Name(), err)
 	}
 
+	// In ggcr v0.22.0, absent referrers never error: the API endpoint tolerates
+	// 404/400/406 via the tag-schema fallback, and a missing fallback tag yields
+	// empty.Index, nil. So any error here is a real failure; isNotFound is
+	// defense in depth against a future ggcr version that surfaces 404 directly.
 	idx, err := remote.Referrers(imageDigestRef, opts...)
 	if err != nil {
-		// Most registries that don't support the referrers API return 404; not an error.
-		log.Debug().Err(err).Msgf("no OCI referrers found for %s@%s", ref.Name(), hash)
-		return nil
+		if isNotFound(err) {
+			log.Debug().Err(err).Msgf("no OCI referrers found for %s@%s", ref.Name(), hash)
+			return nil
+		}
+		return &RelatedArtifactError{Ref: ref.Name(), Kind: consts.KindAnnotationReferrers, Subject: hash.String(), Err: err}
 	}
 
 	idxManifest, err := idx.IndexManifest()
 	if err != nil {
-		log.Debug().Err(err).Msgf("saveReferrers: could not read referrers index for %s", ref.Name())
-		return nil
+		if isNotFound(err) {
+			log.Debug().Err(err).Msgf("saveReferrers: could not read referrers index for %s", ref.Name())
+			return nil
+		}
+		return &RelatedArtifactError{Ref: ref.Name(), Kind: consts.KindAnnotationReferrers, Subject: hash.String(), Err: err}
 	}
 
 	for _, referrerDesc := range idxManifest.Manifests {
@@ -595,8 +643,12 @@ func (l *Layout) saveReferrers(ctx context.Context, ref goname.Reference, hash v
 
 		img, err := remote.Image(digestRef, opts...)
 		if err != nil {
-			log.Debug().Err(err).Msgf("saveReferrers: could not fetch referrer manifest %s", referrerDesc.Digest)
-			continue
+			if isNotFound(err) {
+				// A listed-but-404 referrer is a registry race, not a real failure.
+				log.Debug().Err(err).Msgf("saveReferrers: could not fetch referrer manifest %s", referrerDesc.Digest)
+				continue
+			}
+			return &RelatedArtifactError{Ref: ref.Name(), Kind: consts.KindAnnotationReferrers, Subject: hash.String(), Err: err}
 		}
 
 		// Skip referrers already saved via the cosign tag convention to avoid duplicates.
@@ -619,8 +671,9 @@ func (l *Layout) saveReferrers(ctx context.Context, ref goname.Reference, hash v
 }
 
 // saveRelatedArtifacts discovers and saves cosign-compatible signature, attestation, and SBOM
-// artifacts for the image identified by ref/hash, skipping missing ones silently. Returns the
-// set of saved manifest digest strings so saveReferrers can skip duplicates exposed via both paths.
+// artifacts for the image identified by ref/hash, skipping only definitively-absent ones (see
+// isNotFound). Returns the set of saved manifest digest strings so saveReferrers can skip
+// duplicates exposed via both paths.
 func (l *Layout) saveRelatedArtifacts(ctx context.Context, ref goname.Reference, hash v1.Hash, opts ...remote.Option) (map[string]bool, error) {
 	saved := make(map[string]bool)
 
@@ -643,8 +696,11 @@ func (l *Layout) saveRelatedArtifacts(ctx context.Context, ref goname.Reference,
 		}
 		img, err := remote.Image(artifactRef, opts...)
 		if err != nil {
-			// Artifact doesn't exist at this registry; skip silently.
-			continue
+			if isNotFound(err) {
+				// Definitive absence -- the common unsigned case.
+				continue
+			}
+			return saved, &RelatedArtifactError{Ref: ref.Name(), Kind: r.kind, Subject: hash.String(), Err: err}
 		}
 		if err := l.writeImage(ctx, ref, img, r.kind, ""); err != nil {
 			return saved, fmt.Errorf("saving %s for %s: %w", r.kind, ref.Name(), err)

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	ggcrtransport "github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/static"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/google/uuid"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -289,6 +290,10 @@ func (l *Layout) AddImage(ctx context.Context, ref string, platform string, excl
 	}
 
 	var imageDigest v1.Hash
+	// Non-nil only for the full-index path below; collectSubjectDigests walks
+	// it to probe every child manifest for cosign artifacts. Left nil for the
+	// platform-filtered and single-arch paths, which stay single-subject.
+	var savedIdx v1.ImageIndex
 
 	if idx, idxErr := desc.ImageIndex(); idxErr == nil && platform == "" {
 		// Multi-arch image with no platform filter: save the full index.
@@ -296,9 +301,10 @@ func (l *Layout) AddImage(ctx context.Context, ref string, platform string, excl
 		if err != nil {
 			return "", fmt.Errorf("getting index digest for %q: %w", ref, err)
 		}
-		if err := l.writeIndex(ctx, parsedRef, idx, consts.KindAnnotationIndex); err != nil {
+		if err := l.writeIndex(ctx, parsedRef, idx, consts.KindAnnotationIndex, ""); err != nil {
 			return "", err
 		}
+		savedIdx = idx
 	} else {
 		// Single-platform image, or the caller requested a specific platform.
 		//
@@ -321,17 +327,34 @@ func (l *Layout) AddImage(ctx context.Context, ref string, platform string, excl
 		if err != nil {
 			return "", fmt.Errorf("getting image digest for %q: %w", ref, err)
 		}
-		if err := l.writeImage(ctx, parsedRef, img, consts.KindAnnotationImage, ""); err != nil {
+		if err := l.writeImage(ctx, parsedRef, img, consts.KindAnnotationImage, "", ""); err != nil {
 			return "", err
 		}
 	}
 
 	if !excludeExtras {
-		savedDigests, err := l.saveRelatedArtifacts(ctx, parsedRef, imageDigest, allOpts...)
-		if err != nil {
-			return "", err
+		// One subject for a single-platform store; the index digest plus every
+		// child manifest for a full multi-arch store. Serial on purpose: sync
+		// already parallelizes across images, and serial probing bounds
+		// rate-limit bursts against one registry.
+		subjects := []v1.Hash{imageDigest}
+		if savedIdx != nil {
+			var err error
+			subjects, err = collectSubjectDigests(savedIdx)
+			if err != nil {
+				return "", err
+			}
 		}
-		return imageDigest.String(), l.saveReferrers(ctx, parsedRef, imageDigest, savedDigests, allOpts...)
+		saved := make(map[string]bool)
+		for i, subject := range subjects {
+			topLevel := i == 0
+			if err := l.saveRelatedArtifacts(ctx, parsedRef, subject, topLevel, saved, allOpts...); err != nil {
+				return "", err
+			}
+			if err := l.saveReferrers(ctx, parsedRef, subject, saved, allOpts...); err != nil {
+				return "", err
+			}
+		}
 	}
 	return imageDigest.String(), nil
 }
@@ -358,7 +381,7 @@ func (l *Layout) AddLocalImage(ctx context.Context, ref string) (string, error) 
 		return "", fmt.Errorf("getting image digest for %q: %w", ref, err)
 	}
 
-	if err := l.writeImage(ctx, parsedRef, img, consts.KindAnnotationImage, ""); err != nil {
+	if err := l.writeImage(ctx, parsedRef, img, consts.KindAnnotationImage, "", ""); err != nil {
 		return "", err
 	}
 	return d.String(), nil
@@ -439,8 +462,9 @@ func (l *Layout) writeImageBlobs(ctx context.Context, img v1.Image) error {
 
 // writeImage writes all blobs for img and adds a descriptor entry to the OCI index with the
 // given annotationRef and kind. containerdName overrides the io.containerd.image.name annotation;
-// if empty it defaults to annotationRef.Name().
-func (l *Layout) writeImage(ctx context.Context, annotationRef goname.Reference, img v1.Image, kind string, containerdName string) error {
+// if empty it defaults to annotationRef.Name(). A non-empty subjectDigest records the base
+// image's digest this artifact is a sig/att/sbom/referrer of; empty omits the annotation.
+func (l *Layout) writeImage(ctx context.Context, annotationRef goname.Reference, img v1.Image, kind string, containerdName string, subjectDigest string) error {
 	if err := l.writeImageBlobs(ctx, img); err != nil {
 		return err
 	}
@@ -482,7 +506,54 @@ func (l *Layout) writeImage(ctx context.Context, annotationRef goname.Reference,
 			consts.OriginalRefAnnotation: originalRef,
 		},
 	}
+	if subjectDigest != "" {
+		desc.Annotations[consts.SubjectDigestAnnotation] = subjectDigest
+	}
 	return l.OCI.AddIndex(desc)
+}
+
+// collectSubjectDigests returns the index's own digest followed by every
+// manifest digest reachable through it, nested indexes included, deduplicated.
+// Buildx attestation-manifest children (unknown/unknown) are included on
+// purpose: "every manifest in the index" is the contract, and excluding them
+// would miss artifacts attached to them.
+func collectSubjectDigests(idx v1.ImageIndex) ([]v1.Hash, error) {
+	var out []v1.Hash
+	seen := make(map[v1.Hash]bool)
+	var walk func(v1.ImageIndex) error
+	walk = func(ix v1.ImageIndex) error {
+		d, err := ix.Digest()
+		if err != nil {
+			return fmt.Errorf("getting index digest: %w", err)
+		}
+		if seen[d] {
+			return nil
+		}
+		seen[d] = true
+		out = append(out, d)
+
+		manifest, err := ix.IndexManifest()
+		if err != nil {
+			return fmt.Errorf("getting index manifest: %w", err)
+		}
+		for _, child := range manifest.Manifests {
+			if childIdx, err := ix.ImageIndex(child.Digest); err == nil {
+				if err := walk(childIdx); err != nil {
+					return err
+				}
+				continue
+			}
+			if !seen[child.Digest] {
+				seen[child.Digest] = true
+				out = append(out, child.Digest)
+			}
+		}
+		return nil
+	}
+	if err := walk(idx); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // writeIndexBlobs recursively writes all child image blobs for an image index to the store's blob
@@ -520,8 +591,10 @@ func (l *Layout) writeIndexBlobs(ctx context.Context, idx v1.ImageIndex) error {
 }
 
 // writeIndex writes all blobs for an image index (including all child platform images) and adds
-// a descriptor entry to the OCI index with the given annotationRef and kind.
-func (l *Layout) writeIndex(ctx context.Context, annotationRef goname.Reference, idx v1.ImageIndex, kind string) error {
+// a descriptor entry to the OCI index with the given annotationRef and kind. subjectDigest follows
+// the same rule as writeImage's -- OCI 1.1 permits subject on image indexes too, so a referrer can
+// itself be an index.
+func (l *Layout) writeIndex(ctx context.Context, annotationRef goname.Reference, idx v1.ImageIndex, kind string, subjectDigest string) error {
 	if err := l.writeIndexBlobs(ctx, idx); err != nil {
 		return err
 	}
@@ -559,6 +632,9 @@ func (l *Layout) writeIndex(ctx context.Context, annotationRef goname.Reference,
 			// survives even if a later --rewrite overwrites the annotations above.
 			consts.OriginalRefAnnotation: annotationRef.Name(),
 		},
+	}
+	if subjectDigest != "" {
+		desc.Annotations[consts.SubjectDigestAnnotation] = subjectDigest
 	}
 	return l.OCI.AddIndex(desc)
 }
@@ -601,13 +677,13 @@ func (e *RelatedArtifactError) Error() string {
 
 func (e *RelatedArtifactError) Unwrap() error { return e.Err }
 
-// saveReferrers discovers and saves OCI 1.1 referrers for the image identified by ref/hash --
+// saveReferrers discovers and saves OCI 1.1 referrers for the image identified by ref/subject --
 // cosign v3 new-bundle-format sigs/attestations stored via the subject field, as opposed to the
 // legacy sha256-<hex>.sig/.att/.sbom tag convention.
-func (l *Layout) saveReferrers(ctx context.Context, ref goname.Reference, hash v1.Hash, alreadySaved map[string]bool, opts ...remote.Option) error {
+func (l *Layout) saveReferrers(ctx context.Context, ref goname.Reference, subject v1.Hash, alreadySaved map[string]bool, opts ...remote.Option) error {
 	log := zerolog.Ctx(ctx)
 
-	imageDigestRef, err := goname.NewDigest(ref.Context().String() + "@" + hash.String())
+	imageDigestRef, err := goname.NewDigest(ref.Context().String() + "@" + subject.String())
 	if err != nil {
 		return fmt.Errorf("saveReferrers: constructing digest ref for %s: %w", ref.Name(), err)
 	}
@@ -619,10 +695,10 @@ func (l *Layout) saveReferrers(ctx context.Context, ref goname.Reference, hash v
 	idx, err := remote.Referrers(imageDigestRef, opts...)
 	if err != nil {
 		if isNotFound(err) {
-			log.Debug().Err(err).Msgf("no OCI referrers found for %s@%s", ref.Name(), hash)
+			log.Debug().Err(err).Msgf("no OCI referrers found for %s@%s", ref.Name(), subject)
 			return nil
 		}
-		return &RelatedArtifactError{Ref: ref.Name(), Kind: consts.KindAnnotationReferrers, Subject: hash.String(), Err: err}
+		return &RelatedArtifactError{Ref: ref.Name(), Kind: consts.KindAnnotationReferrers, Subject: subject.String(), Err: err}
 	}
 
 	idxManifest, err := idx.IndexManifest()
@@ -631,7 +707,7 @@ func (l *Layout) saveReferrers(ctx context.Context, ref goname.Reference, hash v
 			log.Debug().Err(err).Msgf("saveReferrers: could not read referrers index for %s", ref.Name())
 			return nil
 		}
-		return &RelatedArtifactError{Ref: ref.Name(), Kind: consts.KindAnnotationReferrers, Subject: hash.String(), Err: err}
+		return &RelatedArtifactError{Ref: ref.Name(), Kind: consts.KindAnnotationReferrers, Subject: subject.String(), Err: err}
 	}
 
 	for _, referrerDesc := range idxManifest.Manifests {
@@ -639,16 +715,6 @@ func (l *Layout) saveReferrers(ctx context.Context, ref goname.Reference, hash v
 		if err != nil {
 			log.Debug().Err(err).Msgf("saveReferrers: could not construct digest ref for referrer %s", referrerDesc.Digest)
 			continue
-		}
-
-		img, err := remote.Image(digestRef, opts...)
-		if err != nil {
-			if isNotFound(err) {
-				// A listed-but-404 referrer is a registry race, not a real failure.
-				log.Debug().Err(err).Msgf("saveReferrers: could not fetch referrer manifest %s", referrerDesc.Digest)
-				continue
-			}
-			return &RelatedArtifactError{Ref: ref.Name(), Kind: consts.KindAnnotationReferrers, Subject: hash.String(), Err: err}
 		}
 
 		// Skip referrers already saved via the cosign tag convention to avoid duplicates.
@@ -661,24 +727,58 @@ func (l *Layout) saveReferrers(ctx context.Context, ref goname.Reference, hash v
 
 		// Embed the referrer manifest digest in the kind annotation so that multiple
 		// referrers for the same base image each get a unique entry in the OCI index.
+		//
+		// OCI 1.1 permits subject on image indexes too, and Descriptor.Image() on
+		// an index digest doesn't fail cleanly: ggcr v0.22.0 silently resolves it
+		// to whichever child matches the default platform when one exists,
+		// mis-storing the referrer as an unrelated child manifest, and only
+		// errors when no child matches. Branch on the descriptor's declared type
+		// instead of trusting Image() to fail on an index.
 		kind := consts.KindAnnotationReferrers + "/" + referrerDesc.Digest.Hex
-		if err := l.writeImage(ctx, ref, img, kind, ""); err != nil {
-			return fmt.Errorf("saving OCI referrer %s for %s: %w", referrerDesc.Digest, ref.Name(), err)
+		switch referrerDesc.MediaType {
+		case types.OCIImageIndex, types.DockerManifestList:
+			refIdx, err := remote.Index(digestRef, opts...)
+			if err != nil {
+				if isNotFound(err) {
+					log.Debug().Err(err).Msgf("saveReferrers: referrer index %s vanished", referrerDesc.Digest)
+					continue
+				}
+				return &RelatedArtifactError{Ref: ref.Name(), Kind: kind, Subject: subject.String(), Err: err}
+			}
+			if err := l.writeIndex(ctx, ref, refIdx, kind, subject.String()); err != nil {
+				return fmt.Errorf("saving OCI referrer index %s for %s: %w", referrerDesc.Digest, ref.Name(), err)
+			}
+		case types.OCIManifestSchema1, types.DockerManifestSchema2:
+			img, err := remote.Image(digestRef, opts...)
+			if err != nil {
+				if isNotFound(err) {
+					log.Debug().Err(err).Msgf("saveReferrers: referrer manifest %s vanished", referrerDesc.Digest)
+					continue
+				}
+				return &RelatedArtifactError{Ref: ref.Name(), Kind: kind, Subject: subject.String(), Err: err}
+			}
+			if err := l.writeImage(ctx, ref, img, kind, "", subject.String()); err != nil {
+				return fmt.Errorf("saving OCI referrer %s for %s: %w", referrerDesc.Digest, ref.Name(), err)
+			}
+		default:
+			log.Warn().Msgf("skipping referrer %s for %s: unsupported media type %q", referrerDesc.Digest, ref.Name(), referrerDesc.MediaType)
+			continue
 		}
 		log.Debug().Msgf("saved OCI referrer %s (%s) for %s", referrerDesc.Digest, string(referrerDesc.ArtifactType), ref.Name())
 	}
 	return nil
 }
 
-// saveRelatedArtifacts discovers and saves cosign-compatible signature, attestation, and SBOM
-// artifacts for the image identified by ref/hash, skipping only definitively-absent ones (see
-// isNotFound). Returns the set of saved manifest digest strings so saveReferrers can skip
-// duplicates exposed via both paths.
-func (l *Layout) saveRelatedArtifacts(ctx context.Context, ref goname.Reference, hash v1.Hash, opts ...remote.Option) (map[string]bool, error) {
-	saved := make(map[string]bool)
-
-	// Cosign tag convention: "sha256:hexvalue" → "sha256-hexvalue.sig" / ".att" / ".sbom"
-	tagPrefix := strings.ReplaceAll(hash.String(), ":", "-")
+// saveRelatedArtifacts probes the cosign tag convention for subject and stores
+// whatever exists. topLevel selects the kind shape: plain for the stored
+// artifact's own digest, subject-suffixed for a child manifest of a multi-arch
+// index -- two artifacts with the same ref and plain kind would collide in
+// nameMapKey's <ref>-<kind> and the second AddIndex would silently replace the
+// first. saved is shared across all subjects of one AddImage call so a
+// manifest reachable via both the tag convention and the Referrers API is
+// stored once.
+func (l *Layout) saveRelatedArtifacts(ctx context.Context, ref goname.Reference, subject v1.Hash, topLevel bool, saved map[string]bool, opts ...remote.Option) error {
+	tagPrefix := strings.ReplaceAll(subject.String(), ":", "-")
 
 	related := []struct {
 		tag  string
@@ -697,19 +797,22 @@ func (l *Layout) saveRelatedArtifacts(ctx context.Context, ref goname.Reference,
 		img, err := remote.Image(artifactRef, opts...)
 		if err != nil {
 			if isNotFound(err) {
-				// Definitive absence -- the common unsigned case.
 				continue
 			}
-			return saved, &RelatedArtifactError{Ref: ref.Name(), Kind: r.kind, Subject: hash.String(), Err: err}
+			return &RelatedArtifactError{Ref: ref.Name(), Kind: r.kind, Subject: subject.String(), Err: err}
 		}
-		if err := l.writeImage(ctx, ref, img, r.kind, ""); err != nil {
-			return saved, fmt.Errorf("saving %s for %s: %w", r.kind, ref.Name(), err)
+		kind := r.kind
+		if !topLevel {
+			kind = r.kind + "/" + subject.Hex
+		}
+		if err := l.writeImage(ctx, ref, img, kind, "", subject.String()); err != nil {
+			return fmt.Errorf("saving %s for %s: %w", kind, ref.Name(), err)
 		}
 		if d, err := img.Digest(); err == nil {
 			saved[d.String()] = true
 		}
 	}
-	return saved, nil
+	return nil
 }
 
 // parsePlatform parses a platform string in "os/arch[/variant]" format into a v1.Platform.

--- a/pkg/store/store_annotation_test.go
+++ b/pkg/store/store_annotation_test.go
@@ -37,7 +37,7 @@ func TestWriteImageNormalizesContainerdName(t *testing.T) {
 		t.Fatalf("ParseReference: %v", err)
 	}
 	// ref.Name() is "index.docker.io/library/busybox:v1"; the annotation must not be.
-	if err := l.writeImage(context.Background(), ref, img, consts.KindAnnotationImage, ""); err != nil {
+	if err := l.writeImage(context.Background(), ref, img, consts.KindAnnotationImage, "", ""); err != nil {
 		t.Fatalf("writeImage: %v", err)
 	}
 
@@ -100,7 +100,7 @@ func TestWriteIndexNormalizesContainerdName(t *testing.T) {
 		t.Fatalf("ParseReference: %v", err)
 	}
 	// ref.Name() is "index.docker.io/library/busybox@sha256:..."; the annotation must not be.
-	if err := l.writeIndex(context.Background(), ref, idx, consts.KindAnnotationIndex); err != nil {
+	if err := l.writeIndex(context.Background(), ref, idx, consts.KindAnnotationIndex, ""); err != nil {
 		t.Fatalf("writeIndex: %v", err)
 	}
 
@@ -181,7 +181,7 @@ func TestWriteImageAnnotationRefNameIsRegistryless(t *testing.T) {
 			}
 			// containerdName "" mirrors AddImage (store.go), which lets writeImage
 			// derive both annotations from ref.
-			if err := l.writeImage(context.Background(), ref, img, consts.KindAnnotationImage, ""); err != nil {
+			if err := l.writeImage(context.Background(), ref, img, consts.KindAnnotationImage, "", ""); err != nil {
 				t.Fatalf("writeImage: %v", err)
 			}
 

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -990,4 +992,101 @@ func TestAddImage_OriginalRefAnnotation(t *testing.T) {
 			t.Errorf("expected the index artifact to have OriginalRefAnnotation=%q, none found", wantOriginalRef)
 		}
 	})
+}
+
+// artifactProbe401Registry serves images normally but returns 401 for cosign
+// tag-convention probes and the OCI referrers endpoint.
+func artifactProbe401Registry(t *testing.T) (string, []remote.Option) {
+	t.Helper()
+	inner := registry.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		if strings.Contains(p, "/referrers/") ||
+			strings.HasSuffix(p, ".sig") || strings.HasSuffix(p, ".att") || strings.HasSuffix(p, ".sbom") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		inner.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	return host, []remote.Option{remote.WithTransport(srv.Client().Transport)}
+}
+
+func TestAddImageArtifactProbe401Fails(t *testing.T) {
+	host, opts := artifactProbe401Registry(t)
+	seedImage(t, host, "repro/api", "v1", opts...)
+	s := newTestStore(t)
+
+	_, err := s.AddImage(context.Background(), host+"/repro/api:v1", "", false, "", false, "", opts...)
+	if err == nil {
+		t.Fatal("AddImage succeeded despite 401 on artifact probes; want RelatedArtifactError")
+	}
+	var raErr *store.RelatedArtifactError
+	if !errors.As(err, &raErr) {
+		t.Fatalf("error %v is not a *store.RelatedArtifactError", err)
+	}
+}
+
+func TestAddImageArtifactProbe404Succeeds(t *testing.T) {
+	// The plain test registry has no sig tags and no referrers: every probe
+	// 404s, which must remain "unsigned image", not an error.
+	host, opts := newTestRegistry(t)
+	seedImage(t, host, "repro/absent", "v1", opts...)
+	s := newTestStore(t)
+
+	if _, err := s.AddImage(context.Background(), host+"/repro/absent:v1", "", false, "", false, "", opts...); err != nil {
+		t.Fatalf("AddImage failed on 404-only probes: %v", err)
+	}
+}
+
+func TestIsNotFoundClassification(t *testing.T) {
+	// Exercised through the exported surface: a 500-returning registry must
+	// fail AddImage the same way 401 does.
+	inner := registry.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ".sig") {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		inner.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	opts := []remote.Option{remote.WithTransport(srv.Client().Transport)}
+	seedImage(t, host, "repro/err500", "v1", opts...)
+	s := newTestStore(t)
+
+	if _, err := s.AddImage(context.Background(), host+"/repro/err500:v1", "", false, "", false, "", opts...); err == nil {
+		t.Fatal("AddImage succeeded despite 500 on sig probe")
+	}
+}
+
+// TestAddImageReferrersEndpoint401Fails exercises referrer-error propagation
+// independently of the cosign tag probes (which 404 against the inner
+// registry): ggcr v0.22.0's fetchReferrers allows 404/400/406 through to the
+// tag fallback but propagates a 401 as *transport.Error.
+func TestAddImageReferrersEndpoint401Fails(t *testing.T) {
+	inner := registry.New()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/referrers/") {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		inner.ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	host := strings.TrimPrefix(srv.URL, "http://")
+	opts := []remote.Option{remote.WithTransport(srv.Client().Transport)}
+	seedImage(t, host, "repro/ref401", "v1", opts...)
+	s := newTestStore(t)
+
+	_, err := s.AddImage(context.Background(), host+"/repro/ref401:v1", "", false, "", false, "", opts...)
+	if err == nil {
+		t.Fatal("AddImage succeeded despite 401 on the referrers endpoint")
+	}
+	var raErr *store.RelatedArtifactError
+	if !errors.As(err, &raErr) {
+		t.Fatalf("error %v is not a *store.RelatedArtifactError", err)
+	}
 }

--- a/pkg/store/store_test.go
+++ b/pkg/store/store_test.go
@@ -256,6 +256,26 @@ func findRefKeyByKind(t *testing.T, s *store.Layout, ref, kind string) string {
 	return key
 }
 
+// descriptorForKey walks the store's index and returns the descriptor stored
+// under the given nameMap key (as returned by findRefKey/findRefKeyByKind).
+func descriptorForKey(t *testing.T, s *store.Layout, key string) ocispec.Descriptor {
+	t.Helper()
+	var out ocispec.Descriptor
+	found := false
+	if err := s.Walk(func(reference string, desc ocispec.Descriptor) error {
+		if reference == key {
+			out, found = desc, true
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatalf("key %q not found in store", key)
+	}
+	return out
+}
+
 // readManifestBlob reads and parses an OCI manifest from the store's blob directory.
 func readManifestBlob(t *testing.T, root string, d digest.Digest) ocispec.Manifest {
 	t.Helper()
@@ -829,6 +849,77 @@ func seedImage(t *testing.T, host, repo, tag string, opts ...remote.Option) v1.I
 	return img
 }
 
+// seedMultiArchWithPlatformSig publishes a two-platform index at repo:tag,
+// plus cosign v2 sigs for BOTH the index digest and the amd64 child digest --
+// the registry.k8s.io/csi-attacher shape from the community report.
+func seedMultiArchWithPlatformSig(t *testing.T, host, repo, tag string, opts ...remote.Option) (idxDigest, childDigest v1.Hash) {
+	t.Helper()
+	amd64Img, err := random.Image(512, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	arm64Img, err := random.Image(512, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	idx := mutate.AppendManifests(empty.Index,
+		mutate.IndexAddendum{Add: amd64Img, Descriptor: v1.Descriptor{Platform: &v1.Platform{OS: "linux", Architecture: "amd64"}}},
+		mutate.IndexAddendum{Add: arm64Img, Descriptor: v1.Descriptor{Platform: &v1.Platform{OS: "linux", Architecture: "arm64"}}},
+	)
+	ref, err := goname.NewTag(host+"/"+repo+":"+tag, goname.Insecure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.WriteIndex(ref, idx, opts...); err != nil {
+		t.Fatal(err)
+	}
+	idxDigest, err = idx.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	childDigest, err = amd64Img.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, d := range []v1.Hash{idxDigest, childDigest} {
+		sigTag := strings.ReplaceAll(d.String(), ":", "-") + ".sig"
+		seedImage(t, host, repo, sigTag, opts...)
+	}
+	return idxDigest, childDigest
+}
+
+// TestAddImageMultiArchStoresPlatformSigs proves that a multi-arch pull
+// probes every child manifest for cosign artifacts, not just the index
+// digest -- registries that sign each platform image individually (e.g.
+// registry.k8s.io/csi-attacher) previously had their per-platform sigs
+// silently dropped.
+func TestAddImageMultiArchStoresPlatformSigs(t *testing.T) {
+	host, opts := newTestRegistry(t)
+	idxDigest, childDigest := seedMultiArchWithPlatformSig(t, host, "repro/multi", "v1", opts...)
+	s := newTestStore(t)
+
+	if _, err := s.AddImage(context.Background(), host+"/repro/multi:v1", "", false, "", false, "", opts...); err != nil {
+		t.Fatal(err)
+	}
+
+	// Index sig: plain kind, subject = index digest. AnnotationRefName carries
+	// the full tagged ref (see writeImage), not the bare repo path.
+	topKey := findRefKeyByKind(t, s, "repro/multi:v1", consts.KindAnnotationSigs)
+	topDesc := descriptorForKey(t, s, topKey)
+	if got := topDesc.Annotations[consts.SubjectDigestAnnotation]; got != idxDigest.String() {
+		t.Fatalf("top-level sig subject = %q, want %q", got, idxDigest.String())
+	}
+
+	// Platform sig: suffixed kind, subject = child digest. Both entries must
+	// coexist -- the pre-fix behavior was the second overwriting the first.
+	childKind := consts.KindAnnotationSigs + "/" + childDigest.Hex
+	childKey := findRefKeyByKind(t, s, "repro/multi:v1", childKind)
+	childDesc := descriptorForKey(t, s, childKey)
+	if got := childDesc.Annotations[consts.SubjectDigestAnnotation]; got != childDigest.String() {
+		t.Fatalf("platform sig subject = %q, want %q", got, childDigest.String())
+	}
+}
+
 // TestAddImagePinnedDigestIgnoresMovedTag proves the TOCTOU fix: once a caller
 // pins the digest it verified, a tag that moves to different content between
 // verification and the fetch cannot substitute its bytes into the store.
@@ -1059,6 +1150,94 @@ func TestIsNotFoundClassification(t *testing.T) {
 
 	if _, err := s.AddImage(context.Background(), host+"/repro/err500:v1", "", false, "", false, "", opts...); err == nil {
 		t.Fatal("AddImage succeeded despite 500 on sig probe")
+	}
+}
+
+// TestAddImageSubjectAnnotationOnArtifacts verifies that a top-level cosign
+// tag-convention artifact (here, a .sig) is stored with
+// consts.SubjectDigestAnnotation recording the base image's digest.
+func TestAddImageSubjectAnnotationOnArtifacts(t *testing.T) {
+	host, opts := newTestRegistry(t)
+	img := seedImage(t, host, "repro/subj", "v1", opts...)
+	d, err := img.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Seed a cosign v2 sig for the image's own digest (top-level subject).
+	sigTag := strings.ReplaceAll(d.String(), ":", "-") + ".sig"
+	seedImage(t, host, "repro/subj", sigTag, opts...)
+
+	s := newTestStore(t)
+	if _, err := s.AddImage(context.Background(), host+"/repro/subj:v1", "", false, "", false, "", opts...); err != nil {
+		t.Fatal(err)
+	}
+
+	// AnnotationRefName carries the full tagged ref (see writeImage), not the
+	// bare repo path.
+	key := findRefKeyByKind(t, s, "repro/subj:v1", consts.KindAnnotationSigs)
+	desc := descriptorForKey(t, s, key)
+	if got := desc.Annotations[consts.SubjectDigestAnnotation]; got != d.String() {
+		t.Fatalf("subject annotation = %q, want %q", got, d.String())
+	}
+}
+
+// TestAddImageIndexTypedReferrer verifies that an OCI 1.1 referrer whose
+// manifest is itself an image index (rather than a single-platform image)
+// is stored correctly with the subject annotation -- the strict error
+// semantics from Task 2 must not turn the index-vs-image branch into a
+// failed pull.
+func TestAddImageIndexTypedReferrer(t *testing.T) {
+	host, opts := newTestRegistry(t)
+	baseImg := seedImage(t, host, "repro/idxref", "v1", opts...)
+	baseDigest, err := baseImg.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseSize, err := baseImg.Size()
+	if err != nil {
+		t.Fatal(err)
+	}
+	baseMT, err := baseImg.MediaType()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build an index referrer: an empty index whose manifest carries a
+	// subject descriptor pointing at the base image.
+	child, err := random.Image(64, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	refIdx := mutate.AppendManifests(empty.Index, mutate.IndexAddendum{Add: child})
+	withSubject := mutate.Subject(refIdx, v1.Descriptor{
+		MediaType: baseMT,
+		Digest:    baseDigest,
+		Size:      baseSize,
+	}).(v1.ImageIndex)
+	d, err := withSubject.Digest()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dref, err := goname.NewDigest(host+"/repro/idxref@"+d.String(), goname.Insecure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.WriteIndex(dref, withSubject, opts...); err != nil {
+		t.Fatal(err)
+	}
+
+	s := newTestStore(t)
+	if _, err := s.AddImage(context.Background(), host+"/repro/idxref:v1", "", false, "", false, "", opts...); err != nil {
+		t.Fatalf("AddImage failed on index-typed referrer: %v", err)
+	}
+
+	// The referrer must be stored under its referrers kind with the subject annotation.
+	// AnnotationRefName carries the full tagged ref (see writeImage), not the
+	// bare repo path.
+	key := findRefKeyByKind(t, s, "repro/idxref:v1", consts.KindAnnotationReferrers+"/"+d.Hex)
+	desc := descriptorForKey(t, s, key)
+	if got := desc.Annotations[consts.SubjectDigestAnnotation]; got != baseDigest.String() {
+		t.Fatalf("index referrer subject annotation = %q, want %q", got, baseDigest.String())
 	}
 }
 


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [ ] Doc(s) have been added or updated to support these change(s).

**Associated Links:**

- https://github.com/hauler-dev/hauler/issues/773
- https://github.com/hauler-dev/hauler/issues/774

**Types of Changes:**

- Behavior change

**Proposed Changes:**

- `store add image` / `store sync` now retrieve cosign signatures, attestations, SBOMs, and OCI referrers for **every** manifest in a multi-arch index, not just the top-level index digest. Each artifact records its subject digest (`hauler.dev/subject-digest` annotation; child-subject entries use `dev.hauler/sigs/<subject-hex>` kinds mirroring the existing referrers convention), and `store copy registry://` routes each one to its own `sha256-<subject>.sig` tag. Referrers that are OCI image indexes (permitted by OCI 1.1) are now stored correctly instead of being mis-resolved to a platform child.
- Artifact-retrieval errors are no longer silently treated as "artifact absent". Only a definitive not-found (HTTP 404, `MANIFEST_UNKNOWN`, `NAME_UNKNOWN`) is skipped; a 401/403/429/timeout/5xx now fails the image after the `--retries` budget. `--ignore-errors` downgrades to a warning that accurately reports the image was stored but artifact retrieval failed.
- Stores/archives from older hauler versions load, copy, extract, and serve identically (legacy tag-derivation fallback is test-pinned), and `store save --containerd`'s sidecar index still contains images only (regression-pinned).

**Before:**

```console
$ hauler store add image registry.k8s.io/sig-storage/csi-attacher@sha256:b9dc9a714a484ccdeeb6f86d88d4db9b7a5ecfc5a55da6db3a60bb3fa33c278a
$ hauler store info
# one sigs entry — the index signature only; the amd64 signature
# (sha256-41dc0a91...sig, verifiable via `oras resolve`) was never fetched.
# A 401/429/5xx during sig probing was silently ignored: exit 0, incomplete store.
```

After:
```console
$ hauler store add image registry.k8s.io/sig-storage/csi-attacher@sha256:b9dc9a714a484ccdeeb6f86d88d4db9b7a5ecfc5a55da6db3a60bb3fa33c278a
# index.json now carries the index signature plus one per platform manifest:
#   dev.hauler/sigs                      subject: sha256:b9dc9a71...  (index)
#   dev.hauler/sigs/41dc0a91...          subject: sha256:41dc0a91...  (amd64)
#   dev.hauler/sigs/<hex>                ... one per remaining platform (7 total)
# `store copy registry://` pushes each to its own sha256-<subject>.sig tag.
# A 401/429/5xx during retrieval now fails the run (unless --ignore-errors).
``` 

Verification/Testing of Changes:

- go test ./... -cover -race -covermode=atomic — full suite green; new coverage includes multi-arch sig discovery, per-subject copy routing, old-format fallback, error classification (401/404/429/500), index-typed referrers, and the containerd sidecar filter.
- Live repro of the report above: the store now contains the index signature and all 7 platform signatures, including the previously-missing amd64 sha256:41dc0a91....

Additional Context:

- Archives produced by this version should not be used with older hauler releases —  old versions don't recognize suffixed-kind entries and can push a signature manifest onto the image's own destination tag. However old→new is fully compatible.
- Runs against flaky/rate-limited registries that previously exited 0 with silently incomplete stores will now fail loudly; --retries and --ignore-errors are the escape hatches. Multi-arch probing also makes more registry requests per image (one set per manifest).