### PR TITLE
added rpm/deb media types and serving of repodata

### DIFF
--- a/cmd/hauler/cli/store.go
+++ b/cmd/hauler/cli/store.go
@@ -264,7 +264,7 @@ func addStoreSave(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Comman
 func addStoreInfo(rso *flags.StoreRootOpts, ro *flags.CliRootOpts) *cobra.Command {
 	o := &flags.InfoOpts{StoreRootOpts: rso}
 
-	var allowedValues = []string{"image", "chart", "file", "sigs", "atts", "sbom", "referrer", "all"}
+	var allowedValues = []string{"image", "chart", "file", "rpm", "deb", "sigs", "atts", "sbom", "referrer", "all"}
 
 	cmd := &cobra.Command{
 		Use:     "info",

--- a/cmd/hauler/cli/store/info.go
+++ b/cmd/hauler/cli/store/info.go
@@ -595,6 +595,12 @@ func newItem(s *store.Layout, desc ocispec.Descriptor, m ocispec.Manifest, plat 
 		return item{}
 	}
 
+	if ctype == "file" {
+		if pkgType := packageFileType(refName); pkgType != "" {
+			ctype = pkgType
+		}
+	}
+
 	if o.TypeFilter != "all" && ctype != o.TypeFilter {
 		return item{}
 	}
@@ -638,6 +644,22 @@ func resolveCtype(desc ocispec.Descriptor, configMediaType string) string {
 		ctype = "referrer"
 	}
 	return ctype
+}
+
+// packageFileType refines a "file" ctype into "rpm" or "deb" when refName's stored filename has that extension, or returns "" to leave it as a plain file.
+func packageFileType(refName string) string {
+	repo := refName
+	if i := strings.LastIndex(repo, ":"); i >= 0 {
+		repo = repo[:i]
+	}
+	switch {
+	case strings.HasSuffix(strings.ToLower(repo), ".rpm"):
+		return "rpm"
+	case strings.HasSuffix(strings.ToLower(repo), ".deb"):
+		return "deb"
+	default:
+		return ""
+	}
 }
 
 // fallbackItem builds a synthetic failure row directly from desc's index

--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -17,6 +17,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"hauler.dev/go/hauler/v2/internal/flags"
+	"hauler.dev/go/hauler/v2/internal/repodata"
 	"hauler.dev/go/hauler/v2/internal/server"
 	"hauler.dev/go/hauler/v2/pkg/log"
 	"hauler.dev/go/hauler/v2/pkg/store"
@@ -157,6 +158,14 @@ func ServeFilesCmd(ctx context.Context, o *flags.ServeFilesOpts, s *store.Layout
 		return err
 	}
 
+	if o.GenerateRepodata {
+		rpmCount, debCount, err := prepareRepodata(o.RootDir)
+		if err != nil {
+			return err
+		}
+		l.Infof("generated repodata for [%d] rpm and [%d] deb package(s)", rpmCount, debCount)
+	}
+
 	f, err := server.NewFile(ctx, *o)
 	if err != nil {
 		return err
@@ -175,4 +184,54 @@ func ServeFilesCmd(ctx context.Context, o *flags.ServeFilesOpts, s *store.Layout
 	}
 
 	return nil
+}
+
+// prepareRepodata moves top-level .rpm/.deb files under rootDir into their own rpms/ and debs/ subdirectories and generates each package manager's repo metadata there.
+func prepareRepodata(rootDir string) (rpmCount, debCount int, err error) {
+	entries, err := os.ReadDir(rootDir)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+
+		lower := strings.ToLower(e.Name())
+		switch {
+		case strings.HasSuffix(lower, ".rpm"):
+			if err := moveInto(rootDir, e.Name(), "rpms"); err != nil {
+				return 0, 0, err
+			}
+			rpmCount++
+		case strings.HasSuffix(lower, ".deb"):
+			if err := moveInto(rootDir, e.Name(), "debs"); err != nil {
+				return 0, 0, err
+			}
+			debCount++
+		}
+	}
+
+	if rpmCount > 0 {
+		if err := repodata.GenerateRPMRepo(filepath.Join(rootDir, "rpms")); err != nil {
+			return 0, 0, fmt.Errorf("generating rpm repodata: %w", err)
+		}
+	}
+	if debCount > 0 {
+		if err := repodata.GenerateDebRepo(filepath.Join(rootDir, "debs")); err != nil {
+			return 0, 0, fmt.Errorf("generating deb repodata: %w", err)
+		}
+	}
+
+	return rpmCount, debCount, nil
+}
+
+// moveInto relocates rootDir/name into rootDir/subdir/name, creating subdir if needed.
+func moveInto(rootDir, name, subdir string) error {
+	destDir := filepath.Join(rootDir, subdir)
+	if err := os.MkdirAll(destDir, 0o755); err != nil {
+		return err
+	}
+	return os.Rename(filepath.Join(rootDir, name), filepath.Join(destDir, name))
 }

--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -224,7 +224,36 @@ func prepareRepodata(rootDir string) (rpmCount, debCount int, err error) {
 		}
 	}
 
-	return rpmCount, debCount, nil
+	// Report the repo's total package count, not just what moved this run, since a
+	// restart with no new top-level files leaves earlier runs' packages in place.
+	rpmTotal, err := countPackages(filepath.Join(rootDir, "rpms"), ".rpm")
+	if err != nil {
+		return 0, 0, err
+	}
+	debTotal, err := countPackages(filepath.Join(rootDir, "debs"), ".deb")
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return rpmTotal, debTotal, nil
+}
+
+// countPackages counts files with ext directly under dir, or 0 if dir doesn't exist yet.
+func countPackages(dir, ext string) (int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	count := 0
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(strings.ToLower(e.Name()), ext) {
+			count++
+		}
+	}
+	return count, nil
 }
 
 // moveInto relocates rootDir/name into rootDir/subdir/name, creating subdir if needed.

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.35.1
+	github.com/sassoftware/go-rpmutils v0.4.0
 	github.com/sigstore/cosign/v3 v3.1.3
 	github.com/sigstore/sigstore v1.10.9
 	github.com/sirupsen/logrus v1.10.2
@@ -33,6 +34,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v4 v4.2.4
 	k8s.io/apimachinery v0.37.0
+	pault.ag/go/debian v0.21.0
 )
 
 require (
@@ -56,6 +58,7 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/BurntSushi/toml v1.6.0 // indirect
+	github.com/DataDog/zstd v1.5.5 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
@@ -205,6 +208,7 @@ require (
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d // indirect
 	github.com/klauspost/compress v1.19.2 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
@@ -299,6 +303,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/xlab/treeprint v1.2.0 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
@@ -358,6 +363,7 @@ require (
 	k8s.io/kubectl v0.37.0 // indirect
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd // indirect
 	oras.land/oras-go/v2 v2.6.2 // indirect
+	pault.ag/go/topsort v0.1.1 // indirect
 	sigs.k8s.io/controller-runtime v0.24.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
+github.com/DataDog/zstd v1.5.5 h1:oWf5W7GtOLgp6bciQYDmhHHjdhYkALu6S/5Ni9ZgSvQ=
+github.com/DataDog/zstd v1.5.5/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
@@ -615,6 +617,8 @@ github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/X
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d h1:RnWZeH8N8KXfbwMTex/KKMYMj0FJRCF6tQubUuQ02GM=
+github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d/go.mod h1:phT/jsRPBAEqjAibu1BurrabCBNTYiVI+zbmyCZJY6Q=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
 github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
@@ -809,6 +813,8 @@ github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDc
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/sassoftware/go-rpmutils v0.4.0 h1:ojND82NYBxgwrV+mX1CWsd5QJvvEZTKddtCdFLPWhpg=
+github.com/sassoftware/go-rpmutils v0.4.0/go.mod h1:3goNWi7PGAT3/dlql2lv3+MSN5jNYPjT5mVcQcIsYzI=
 github.com/sassoftware/relic/v8 v8.2.0 h1:9/L4S4I6an/JsPNhmcTpqfiOIsLb/iJaePZD1xR+ulE=
 github.com/sassoftware/relic/v8 v8.2.0/go.mod h1:pZy7hLT9WCOKPonV8G/fplvtBLOZd6/kWtKqeHR6nKc=
 github.com/secure-systems-lab/go-securesystemslib v0.11.0 h1:iuCR9kcMFD4QurdKrGvPLoKZLv9YvwPYVr0473BdtFs=
@@ -932,6 +938,8 @@ github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMc
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
+github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
@@ -1347,6 +1355,10 @@ k8s.io/utils v0.0.0-20260626114624-be93311217bd h1:Ea7fgQ5we8Y9T0OX5o0dAHzQOBRI0
 k8s.io/utils v0.0.0-20260626114624-be93311217bd/go.mod h1:xDxuJ0whA3d0I4mf/C4ppKHxXynQ+fxnkmQH0vTHnuk=
 oras.land/oras-go/v2 v2.6.2 h1:N04RXngAp1LJKTG6ifz3xHPipasEkWr+hFmInja5YKo=
 oras.land/oras-go/v2 v2.6.2/go.mod h1:PlTtg4JTDJkDe8yVHpM2wz7/YDc00GVas+i4jAW2TZ4=
+pault.ag/go/debian v0.21.0 h1:6Q+7oNe3HtNf28BVErD7Zic1XN74lJvjQqzDN7C9i5g=
+pault.ag/go/debian v0.21.0/go.mod h1:/SJrietiBUQJECZOzLMbMwz6eKkbvheD8Z3wN7wmzEA=
+pault.ag/go/topsort v0.1.1 h1:L0QnhUly6LmTv0e3DEzbN2q6/FGgAcQvaEw65S53Bg4=
+pault.ag/go/topsort v0.1.1/go.mod h1:r1kc/L0/FZ3HhjezBIPaNVhkqv8L0UJ9bxRuHRVZ0q4=
 pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
 pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/internal/flags/serve.go
+++ b/internal/flags/serve.go
@@ -21,7 +21,7 @@ func (o *ServeRegistryOpts) AddFlags(cmd *cobra.Command) {
 	f := cmd.Flags()
 
 	f.IntVarP(&o.Port, "port", "p", consts.DefaultRegistryPort, "(Optional) Set the port to use for incoming connections")
-	f.StringVar(&o.RootDir, "directory", consts.DefaultRegistryRootDir, "(Optional) Directory to use for backend. Defaults to $PWD/registry")
+	f.StringVar(&o.RootDir, "directory", consts.DefaultRegistryRootDir, "(Optional) Directory to use for backend, defaults to $PWD/registry")
 	f.StringVarP(&o.ConfigFile, "config", "c", "", "(Optional) Location of config file (overrides all flags)")
 	f.BoolVar(&o.ReadOnly, "readonly", true, "(Optional) Run the registry as readonly")
 
@@ -34,9 +34,10 @@ func (o *ServeRegistryOpts) AddFlags(cmd *cobra.Command) {
 type ServeFilesOpts struct {
 	*StoreRootOpts
 
-	Port    int
-	Timeout int
-	RootDir string
+	Port             int
+	Timeout          int
+	RootDir          string
+	GenerateRepodata bool
 
 	TLSCert string
 	TLSKey  string
@@ -47,7 +48,8 @@ func (o *ServeFilesOpts) AddFlags(cmd *cobra.Command) {
 
 	f.IntVarP(&o.Port, "port", "p", consts.DefaultFileserverPort, "(Optional) Set the port to use for incoming connections")
 	f.IntVar(&o.Timeout, "timeout", consts.DefaultFileserverTimeout, "(Optional) Timeout duration for HTTP Requests in seconds for both reads/writes")
-	f.StringVar(&o.RootDir, "directory", consts.DefaultFileserverRootDir, "(Optional) Directory to use for backend. Defaults to $PWD/fileserver")
+	f.StringVar(&o.RootDir, "directory", consts.DefaultFileserverRootDir, "(Optional) Directory to use for backend, defaults to $PWD/fileserver")
+	f.BoolVar(&o.GenerateRepodata, "generate-repodata", false, "(EXPERIMENTAL) (Optional) Generate rpm and deb repository metadata, served under rpms/ and debs/")
 
 	f.StringVar(&o.TLSCert, "tls-cert", "", "(Optional) Location of the TLS Certificate to use for server authenication")
 	f.StringVar(&o.TLSKey, "tls-key", "", "(Optional) Location of the TLS Key to use for server authenication")

--- a/internal/repodata/deb.go
+++ b/internal/repodata/deb.go
@@ -1,0 +1,166 @@
+package repodata
+
+import (
+	"crypto/md5"
+	"crypto/sha1"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	debpkg "pault.ag/go/debian/deb"
+)
+
+const (
+	debSuite     = "stable"
+	debComponent = "main"
+)
+
+// GenerateDebRepo scans dir for top-level .deb files and writes the dists/<suite>/<component>/binary-<arch>/ tree apt needs to consume dir as a repo.
+func GenerateDebRepo(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	byArch := map[string][]debStanza{}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".deb") {
+			continue
+		}
+		stanza, err := buildDebStanza(filepath.Join(dir, e.Name()), e.Name())
+		if err != nil {
+			return fmt.Errorf("reading deb package [%s]: %w", e.Name(), err)
+		}
+		byArch[stanza.arch] = append(byArch[stanza.arch], stanza)
+	}
+	if len(byArch) == 0 {
+		return nil
+	}
+
+	distDir := filepath.Join(dir, "dists", debSuite)
+	archs := make([]string, 0, len(byArch))
+	type releaseEntry struct {
+		path string
+		sum  checksums
+	}
+	var releaseEntries []releaseEntry
+
+	for arch, stanzas := range byArch {
+		archs = append(archs, arch)
+		sort.Slice(stanzas, func(i, j int) bool { return stanzas[i].filename < stanzas[j].filename })
+
+		binDir := filepath.Join(distDir, debComponent, "binary-"+arch)
+		if err := os.MkdirAll(binDir, 0o755); err != nil {
+			return err
+		}
+
+		var sb strings.Builder
+		for _, s := range stanzas {
+			sb.WriteString(s.text)
+			sb.WriteString("\n")
+		}
+		packages := sb.String()
+
+		packagesPath := filepath.Join(binDir, "Packages")
+		if err := os.WriteFile(packagesPath, []byte(packages), 0o644); err != nil {
+			return err
+		}
+		// Release lives at distDir, so its checksum entries are relative to distDir, not dir.
+		relPath, err := filepath.Rel(distDir, packagesPath)
+		if err != nil {
+			return err
+		}
+		sum, err := writeGzip(filepath.Join(binDir, "Packages.gz"), []byte(packages))
+		if err != nil {
+			return err
+		}
+		gzRelPath, err := filepath.Rel(distDir, filepath.Join(binDir, "Packages.gz"))
+		if err != nil {
+			return err
+		}
+
+		rawChecksum, rawSize, err := sha256File(packagesPath)
+		if err != nil {
+			return err
+		}
+		releaseEntries = append(releaseEntries,
+			releaseEntry{path: relPath, sum: checksums{rawChecksum: rawChecksum, rawSize: rawSize}},
+			releaseEntry{path: gzRelPath, sum: checksums{rawChecksum: sum.gzChecksum, rawSize: sum.gzSize}},
+		)
+	}
+	sort.Strings(archs)
+
+	var rel strings.Builder
+	fmt.Fprintf(&rel, "Origin: hauler\n")
+	fmt.Fprintf(&rel, "Label: hauler\n")
+	fmt.Fprintf(&rel, "Suite: %s\n", debSuite)
+	fmt.Fprintf(&rel, "Codename: %s\n", debSuite)
+	fmt.Fprintf(&rel, "Architectures: %s\n", strings.Join(archs, " "))
+	fmt.Fprintf(&rel, "Components: %s\n", debComponent)
+	fmt.Fprintf(&rel, "Date: %s\n", time.Now().UTC().Format(time.RFC1123))
+	fmt.Fprintf(&rel, "SHA256:\n")
+	sort.Slice(releaseEntries, func(i, j int) bool { return releaseEntries[i].path < releaseEntries[j].path })
+	for _, e := range releaseEntries {
+		fmt.Fprintf(&rel, " %s %d %s\n", e.sum.rawChecksum, e.sum.rawSize, filepath.ToSlash(e.path))
+	}
+
+	return os.WriteFile(filepath.Join(distDir, "Release"), []byte(rel.String()), 0o644)
+}
+
+// debStanza holds one Packages-file entry along with the architecture it was built for, so a package's control file is only opened and parsed once.
+type debStanza struct {
+	arch     string
+	filename string
+	text     string
+}
+
+// buildDebStanza reproduces filename's embedded control stanza (in its original field order) with the Filename/Size/MD5sum/SHA1/SHA256 fields real apt repos add appended.
+func buildDebStanza(path, filename string) (debStanza, error) {
+	d, closer, err := debpkg.LoadFile(path)
+	if err != nil {
+		return debStanza{}, err
+	}
+	defer closer()
+
+	md5sum, sha1sum, sha256sum, size, err := debHashes(path)
+	if err != nil {
+		return debStanza{}, err
+	}
+
+	var sb strings.Builder
+	for _, key := range d.Control.Paragraph.Order {
+		fmt.Fprintf(&sb, "%s: %s\n", key, d.Control.Paragraph.Values[key])
+	}
+	fmt.Fprintf(&sb, "Filename: %s\n", filename)
+	fmt.Fprintf(&sb, "Size: %d\n", size)
+	fmt.Fprintf(&sb, "MD5sum: %s\n", md5sum)
+	fmt.Fprintf(&sb, "SHA1: %s\n", sha1sum)
+	fmt.Fprintf(&sb, "SHA256: %s\n", sha256sum)
+
+	return debStanza{arch: d.Control.Architecture.String(), filename: filename, text: sb.String()}, nil
+}
+
+func debHashes(path string) (md5sum, sha1sum, sha256sum string, size int64, err error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", "", "", 0, err
+	}
+	defer f.Close()
+
+	mh := md5.New()
+	sh1 := sha1.New()
+	sh256 := sha256.New()
+
+	n, err := io.Copy(io.MultiWriter(mh, sh1, sh256), f)
+	if err != nil {
+		return "", "", "", 0, err
+	}
+
+	return hex.EncodeToString(mh.Sum(nil)), hex.EncodeToString(sh1.Sum(nil)), hex.EncodeToString(sh256.Sum(nil)), n, nil
+}

--- a/internal/repodata/deb_test.go
+++ b/internal/repodata/deb_test.go
@@ -1,0 +1,144 @@
+package repodata
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newDebFixture builds a minimal, real ar(1)-format .deb file with the given control stanza fields, in order, and returns its bytes.
+func newDebFixture(t *testing.T, order []string, fields map[string]string) []byte {
+	t.Helper()
+
+	var control strings.Builder
+	for _, key := range order {
+		fmt.Fprintf(&control, "%s: %s\n", key, fields[key])
+	}
+
+	controlTarGz := newTarGz(t, map[string]string{"./control": control.String()})
+	dataTarGz := newTarGz(t, map[string]string{"./usr/share/doc/pkg/README": "hello\n"})
+
+	var buf bytes.Buffer
+	buf.WriteString("!<arch>\n")
+	writeArEntry(t, &buf, "debian-binary", []byte("2.0\n"))
+	writeArEntry(t, &buf, "control.tar.gz", controlTarGz)
+	writeArEntry(t, &buf, "data.tar.gz", dataTarGz)
+
+	return buf.Bytes()
+}
+
+func writeArEntry(t *testing.T, buf *bytes.Buffer, name string, data []byte) {
+	t.Helper()
+
+	header := fmt.Sprintf("%-16s%-12d%-6d%-6d%-8s%-10d`\n", name, 0, 0, 0, "100644", len(data))
+	if len(header) != 60 {
+		t.Fatalf("ar header for %s is %d bytes, want 60", name, len(header))
+	}
+	buf.WriteString(header)
+	buf.Write(data)
+	if len(data)%2 != 0 {
+		buf.WriteByte('\n')
+	}
+}
+
+func newTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(zw)
+
+	for name, content := range files {
+		hdr := &tar.Header{Name: name, Mode: 0o644, Size: int64(len(content))}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("failed to write tar header for %s: %v", name, err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatalf("failed to write tar content for %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("failed to close tar writer: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("failed to close gzip writer: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
+func TestGenerateDebRepo(t *testing.T) {
+	dir := t.TempDir()
+
+	order := []string{"Package", "Version", "Architecture", "Maintainer", "Description"}
+	fields := map[string]string{
+		"Package":      "hello",
+		"Version":      "1.0-1",
+		"Architecture": "amd64",
+		"Maintainer":   "Test <test@example.com>",
+		"Description":  "a test package",
+	}
+	debBytes := newDebFixture(t, order, fields)
+	if err := os.WriteFile(filepath.Join(dir, "hello_1.0-1_amd64.deb"), debBytes, 0o644); err != nil {
+		t.Fatalf("failed to write deb fixture: %v", err)
+	}
+
+	if err := GenerateDebRepo(dir); err != nil {
+		t.Fatalf("GenerateDebRepo failed: %v", err)
+	}
+
+	packagesPath := filepath.Join(dir, "dists", "stable", "main", "binary-amd64", "Packages")
+	packagesBytes, err := os.ReadFile(packagesPath)
+	if err != nil {
+		t.Fatalf("failed to read Packages: %v", err)
+	}
+	packages := string(packagesBytes)
+	if !containsAll(packages,
+		"Package: hello",
+		"Version: 1.0-1",
+		"Architecture: amd64",
+		"Filename: hello_1.0-1_amd64.deb",
+		"SHA256:",
+		"MD5sum:",
+	) {
+		t.Errorf("Packages missing expected content: %s", packages)
+	}
+
+	releasePath := filepath.Join(dir, "dists", "stable", "Release")
+	releaseBytes, err := os.ReadFile(releasePath)
+	if err != nil {
+		t.Fatalf("failed to read Release: %v", err)
+	}
+	release := string(releaseBytes)
+	if !containsAll(release, "Suite: stable", "Architectures: amd64", "Components: main") {
+		t.Errorf("Release missing expected content: %s", release)
+	}
+
+	// Release's checksum paths must be relative to its own directory (dists/stable/), not to the repo root, or a real apt client double-joins "dists/stable/" onto them and 404s.
+	if !strings.Contains(release, " main/binary-amd64/Packages\n") {
+		t.Errorf("Release entry for Packages is not relative to dists/stable/: %s", release)
+	}
+	if strings.Contains(release, "dists/stable/main/binary-amd64/Packages") {
+		t.Errorf("Release entry is relative to the repo root instead of dists/stable/: %s", release)
+	}
+}
+
+func TestGenerateDebRepo_NoDebFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("failed to write notes.txt: %v", err)
+	}
+
+	if err := GenerateDebRepo(dir); err != nil {
+		t.Fatalf("GenerateDebRepo failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "dists")); !os.IsNotExist(err) {
+		t.Error("expected no dists directory when no .deb files are present")
+	}
+}

--- a/internal/repodata/rpm.go
+++ b/internal/repodata/rpm.go
@@ -1,0 +1,401 @@
+package repodata
+
+import (
+	"compress/gzip"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	rpmutils "github.com/sassoftware/go-rpmutils"
+)
+
+type rpmVersion struct {
+	Epoch string `xml:"epoch,attr"`
+	Ver   string `xml:"ver,attr"`
+	Rel   string `xml:"rel,attr"`
+}
+
+type rpmChecksum struct {
+	Type  string `xml:"type,attr"`
+	Pkgid string `xml:"pkgid,attr"`
+	Value string `xml:",chardata"`
+}
+
+type rpmTime struct {
+	File  int64 `xml:"file,attr"`
+	Build int64 `xml:"build,attr"`
+}
+
+type rpmSize struct {
+	Package   int64 `xml:"package,attr"`
+	Installed int64 `xml:"installed,attr"`
+	Archive   int64 `xml:"archive,attr"`
+}
+
+type rpmLocation struct {
+	Href string `xml:"href,attr"`
+}
+
+type rpmDepEntry struct {
+	Name  string `xml:"name,attr"`
+	Flags string `xml:"flags,attr,omitempty"`
+	Epoch string `xml:"epoch,attr,omitempty"`
+	Ver   string `xml:"ver,attr,omitempty"`
+	Rel   string `xml:"rel,attr,omitempty"`
+}
+
+type rpmDepList struct {
+	Entries []rpmDepEntry `xml:"rpm:entry"`
+}
+
+type rpmHeaderRange struct {
+	Start int `xml:"start,attr"`
+	End   int `xml:"end,attr"`
+}
+
+type rpmFormat struct {
+	License     string         `xml:"rpm:license"`
+	Vendor      string         `xml:"rpm:vendor"`
+	Group       string         `xml:"rpm:group"`
+	Buildhost   string         `xml:"rpm:buildhost"`
+	SourceRPM   string         `xml:"rpm:sourcerpm,omitempty"`
+	HeaderRange rpmHeaderRange `xml:"rpm:header-range"`
+	Provides    *rpmDepList    `xml:"rpm:provides,omitempty"`
+	Requires    *rpmDepList    `xml:"rpm:requires,omitempty"`
+}
+
+type rpmPackage struct {
+	Type        string      `xml:"type,attr"`
+	Name        string      `xml:"name"`
+	Arch        string      `xml:"arch"`
+	Version     rpmVersion  `xml:"version"`
+	Checksum    rpmChecksum `xml:"checksum"`
+	Summary     string      `xml:"summary"`
+	Description string      `xml:"description"`
+	Packager    string      `xml:"packager"`
+	URL         string      `xml:"url"`
+	Time        rpmTime     `xml:"time"`
+	Size        rpmSize     `xml:"size"`
+	Location    rpmLocation `xml:"location"`
+	Format      rpmFormat   `xml:"format"`
+}
+
+type rpmMetadata struct {
+	XMLName  xml.Name     `xml:"metadata"`
+	Xmlns    string       `xml:"xmlns,attr"`
+	XmlnsRpm string       `xml:"xmlns:rpm,attr"`
+	Packages int          `xml:"packages,attr"`
+	Package  []rpmPackage `xml:"package"`
+}
+
+type repomdData struct {
+	Type         string `xml:"type,attr"`
+	Checksum     string `xml:"checksum"`
+	OpenChecksum string `xml:"open-checksum"`
+	Location     struct {
+		Href string `xml:"href,attr"`
+	} `xml:"location"`
+	Timestamp int64 `xml:"timestamp"`
+	Size      int64 `xml:"size"`
+	OpenSize  int64 `xml:"open-size"`
+}
+
+type repomd struct {
+	XMLName  xml.Name     `xml:"repomd"`
+	Xmlns    string       `xml:"xmlns,attr"`
+	XmlnsRpm string       `xml:"xmlns:rpm,attr"`
+	Revision int64        `xml:"revision"`
+	Data     []repomdData `xml:"data"`
+}
+
+// GenerateRPMRepo scans dir for top-level .rpm files and writes a repodata/ directory next to them, so dnf/yum/zypper can consume dir as a repo.
+func GenerateRPMRepo(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	var pkgs []rpmPackage
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(strings.ToLower(e.Name()), ".rpm") {
+			continue
+		}
+		pkg, err := buildRPMPackage(filepath.Join(dir, e.Name()), e.Name())
+		if err != nil {
+			return fmt.Errorf("reading rpm package [%s]: %w", e.Name(), err)
+		}
+		pkgs = append(pkgs, *pkg)
+	}
+	if len(pkgs) == 0 {
+		return nil
+	}
+
+	sort.Slice(pkgs, func(i, j int) bool { return pkgs[i].Location.Href < pkgs[j].Location.Href })
+
+	meta := rpmMetadata{
+		Xmlns:    "http://linux.duke.edu/metadata/common",
+		XmlnsRpm: "http://linux.duke.edu/metadata/rpm",
+		Packages: len(pkgs),
+		Package:  pkgs,
+	}
+
+	primaryXML, err := xml.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return err
+	}
+	primaryXML = append([]byte(xml.Header), primaryXML...)
+
+	repodataDir := filepath.Join(dir, "repodata")
+	if err := os.MkdirAll(repodataDir, 0o755); err != nil {
+		return err
+	}
+
+	primaryGzPath := filepath.Join(repodataDir, "primary.xml.gz")
+	sums, err := writeGzip(primaryGzPath, primaryXML)
+	if err != nil {
+		return err
+	}
+
+	rmd := repomd{
+		Xmlns:    "http://linux.duke.edu/metadata/repo",
+		XmlnsRpm: "http://linux.duke.edu/metadata/rpm",
+		Revision: time.Now().Unix(),
+		Data: []repomdData{
+			{
+				Type:         "primary",
+				Checksum:     sums.gzChecksum,
+				OpenChecksum: sums.rawChecksum,
+				Timestamp:    time.Now().Unix(),
+				Size:         sums.gzSize,
+				OpenSize:     sums.rawSize,
+			},
+		},
+	}
+	rmd.Data[0].Location.Href = "repodata/primary.xml.gz"
+
+	repomdXML, err := xml.MarshalIndent(rmd, "", "  ")
+	if err != nil {
+		return err
+	}
+	repomdXML = append([]byte(xml.Header), repomdXML...)
+
+	return os.WriteFile(filepath.Join(repodataDir, "repomd.xml"), repomdXML, 0o644)
+}
+
+func buildRPMPackage(path, filename string) (*rpmPackage, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	hdr, err := rpmutils.ReadHeader(f)
+	if err != nil {
+		return nil, err
+	}
+
+	nevra, err := hdr.GetNEVRA()
+	if err != nil {
+		return nil, err
+	}
+
+	fileChecksum, fileSize, err := sha256File(path)
+	if err != nil {
+		return nil, err
+	}
+
+	summary, _ := hdr.GetString(rpmutils.SUMMARY)
+	description, _ := hdr.GetString(rpmutils.DESCRIPTION)
+	packager, _ := hdr.GetString(rpmutils.PACKAGER)
+	url, _ := hdr.GetString(rpmutils.URL)
+	license, _ := hdr.GetString(rpmutils.LICENSE)
+	vendor, _ := hdr.GetString(rpmutils.VENDOR)
+	group, _ := hdr.GetString(rpmutils.GROUP)
+	buildhost, _ := hdr.GetString(rpmutils.BUILDHOST)
+	sourceRPM, _ := hdr.GetString(rpmutils.SOURCERPM)
+	buildTime, _ := hdr.GetInt(rpmutils.BUILDTIME)
+
+	installedSize, _ := hdr.InstalledSize()
+
+	rng := hdr.GetRange()
+
+	epoch := nevra.Epoch
+	if epoch == "" {
+		epoch = "0"
+	}
+
+	pkg := &rpmPackage{
+		Type: "rpm",
+		Name: nevra.Name,
+		Arch: nevra.Arch,
+		Version: rpmVersion{
+			Epoch: epoch,
+			Ver:   nevra.Version,
+			Rel:   nevra.Release,
+		},
+		Checksum: rpmChecksum{
+			Type:  "sha256",
+			Pkgid: "YES",
+			Value: fileChecksum,
+		},
+		Summary:     summary,
+		Description: description,
+		Packager:    packager,
+		URL:         url,
+		Time: rpmTime{
+			File:  int64(buildTime),
+			Build: int64(buildTime),
+		},
+		Size: rpmSize{
+			Package:   fileSize,
+			Installed: installedSize,
+			Archive:   installedSize,
+		},
+		Location: rpmLocation{Href: filename},
+		Format: rpmFormat{
+			License:     license,
+			Vendor:      vendor,
+			Group:       group,
+			Buildhost:   buildhost,
+			SourceRPM:   sourceRPM,
+			HeaderRange: rpmHeaderRange{Start: rng.Start, End: rng.End},
+			Provides:    depList(hdr, rpmutils.PROVIDENAME, rpmutils.PROVIDEVERSION, rpmutils.PROVIDEFLAGS),
+			Requires:    depList(hdr, rpmutils.REQUIRENAME, rpmutils.REQUIREVERSION, rpmutils.REQUIREFLAGS),
+		},
+	}
+
+	return pkg, nil
+}
+
+// depList builds a <rpm:provides>/<rpm:requires> entry list from an RPM header's parallel name/version/flags tag arrays.
+func depList(hdr *rpmutils.RpmHeader, nameTag, verTag, flagsTag int) *rpmDepList {
+	names, _ := hdr.GetStrings(nameTag)
+	if len(names) == 0 {
+		return nil
+	}
+	vers, _ := hdr.GetStrings(verTag)
+	flags, _ := hdr.GetInts(flagsTag)
+
+	entries := make([]rpmDepEntry, 0, len(names))
+	for i, name := range names {
+		e := rpmDepEntry{Name: name}
+		var ver string
+		if i < len(vers) {
+			ver = vers[i]
+		}
+		var flag int
+		if i < len(flags) {
+			flag = flags[i]
+		}
+		if ver != "" {
+			e.Ver = ver
+			e.Flags = senseFlagsToString(flag)
+			if epoch, v, rel, ok := splitEVR(ver); ok {
+				e.Epoch = epoch
+				e.Ver = v
+				e.Rel = rel
+			}
+		}
+		entries = append(entries, e)
+	}
+	return &rpmDepList{Entries: entries}
+}
+
+// senseFlagsToString maps RPM's RPMSENSE_* bitmask to primary.xml's flags attribute values.
+func senseFlagsToString(flags int) string {
+	less := flags&rpmutils.RPMSENSE_LESS != 0
+	greater := flags&rpmutils.RPMSENSE_GREATER != 0
+	equal := flags&rpmutils.RPMSENSE_EQUAL != 0
+
+	switch {
+	case less && equal:
+		return "LE"
+	case greater && equal:
+		return "GE"
+	case equal:
+		return "EQ"
+	case less:
+		return "LT"
+	case greater:
+		return "GT"
+	default:
+		return ""
+	}
+}
+
+// splitEVR splits a dependency version string of the form "[epoch:]version[-release]" into its parts.
+func splitEVR(evr string) (epoch, ver, rel string, ok bool) {
+	epoch = "0"
+	rest := evr
+	if i := strings.Index(rest, ":"); i >= 0 {
+		epoch = rest[:i]
+		rest = rest[i+1:]
+	}
+	if i := strings.LastIndex(rest, "-"); i >= 0 {
+		ver, rel = rest[:i], rest[i+1:]
+	} else {
+		ver = rest
+	}
+	return epoch, ver, rel, ver != ""
+}
+
+type checksums struct {
+	rawChecksum string
+	rawSize     int64
+	gzChecksum  string
+	gzSize      int64
+}
+
+// writeGzip gzip-compresses data to path and returns sha256 checksums and sizes of both the raw and compressed forms.
+func writeGzip(path string, data []byte) (checksums, error) {
+	rawSum := sha256.Sum256(data)
+
+	f, err := os.Create(path)
+	if err != nil {
+		return checksums{}, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	zw := gzip.NewWriter(io.MultiWriter(f, h))
+	if _, err := zw.Write(data); err != nil {
+		return checksums{}, err
+	}
+	if err := zw.Close(); err != nil {
+		return checksums{}, err
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		return checksums{}, err
+	}
+
+	return checksums{
+		rawChecksum: hex.EncodeToString(rawSum[:]),
+		rawSize:     int64(len(data)),
+		gzChecksum:  hex.EncodeToString(h.Sum(nil)),
+		gzSize:      info.Size(),
+	}, nil
+}
+
+func sha256File(path string) (string, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer f.Close()
+
+	h := sha256.New()
+	n, err := io.Copy(h, f)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(h.Sum(nil)), n, nil
+}

--- a/internal/repodata/rpm_test.go
+++ b/internal/repodata/rpm_test.go
@@ -1,0 +1,145 @@
+package repodata
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const rpmStringType = 6
+
+// newRPMFixture builds a minimal, real RPM file with just the four tags GetNEVRA requires (name/version/release/arch) and returns its bytes.
+func newRPMFixture(t *testing.T, name, version, release, arch string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	// Lead: magic, major/minor, type, archnum, 66-byte name, osnum, signature_type, 16 bytes reserved.
+	buf.Write([]byte{0xED, 0xAB, 0xEE, 0xDB})
+	buf.Write([]byte{3, 0})
+	binary.Write(&buf, binary.BigEndian, uint16(0))
+	binary.Write(&buf, binary.BigEndian, uint16(1))
+	nameField := make([]byte, 66)
+	copy(nameField, name+"-"+version+"-"+release)
+	buf.Write(nameField)
+	binary.Write(&buf, binary.BigEndian, uint16(1))
+	binary.Write(&buf, binary.BigEndian, uint16(5))
+	buf.Write(make([]byte, 16))
+
+	// Empty signature header: no digest tag means ReadHeader skips hash verification entirely.
+	writeRPMHeaderIntro(&buf, 0, 0)
+
+	// General header: the four tags GetNEVRA requires, in the order it reads them.
+	tags := []struct {
+		tag   int32
+		value string
+	}{
+		{1000, name},    // NAME
+		{1001, version}, // VERSION
+		{1002, release}, // RELEASE
+		{1022, arch},    // ARCH
+	}
+
+	var data bytes.Buffer
+	type tagEntry struct {
+		tag, offset int32
+	}
+	var entries []tagEntry
+	for _, tg := range tags {
+		entries = append(entries, tagEntry{tag: tg.tag, offset: int32(data.Len())})
+		data.WriteString(tg.value)
+		data.WriteByte(0)
+	}
+
+	writeRPMHeaderIntro(&buf, len(entries), data.Len())
+	for _, e := range entries {
+		binary.Write(&buf, binary.BigEndian, e.tag)
+		binary.Write(&buf, binary.BigEndian, int32(rpmStringType))
+		binary.Write(&buf, binary.BigEndian, e.offset)
+		binary.Write(&buf, binary.BigEndian, int32(1))
+	}
+	buf.Write(data.Bytes())
+
+	return buf.Bytes()
+}
+
+// writeRPMHeaderIntro writes an RPM header's 16-byte intro: magic, reserved, entry count, and data blob size.
+func writeRPMHeaderIntro(buf *bytes.Buffer, entries, dataSize int) {
+	binary.Write(buf, binary.BigEndian, uint32(0x8eade801))
+	binary.Write(buf, binary.BigEndian, uint32(0))
+	binary.Write(buf, binary.BigEndian, uint32(entries))
+	binary.Write(buf, binary.BigEndian, uint32(dataSize))
+}
+
+func TestGenerateRPMRepo(t *testing.T) {
+	dir := t.TempDir()
+	rpmBytes := newRPMFixture(t, "simple", "1.0.1", "1", "i386")
+	if err := os.WriteFile(filepath.Join(dir, "simple-1.0.1-1.i386.rpm"), rpmBytes, 0o644); err != nil {
+		t.Fatalf("failed to write rpm fixture: %v", err)
+	}
+
+	if err := GenerateRPMRepo(dir); err != nil {
+		t.Fatalf("GenerateRPMRepo failed: %v", err)
+	}
+
+	repomdPath := filepath.Join(dir, "repodata", "repomd.xml")
+	repomdBytes, err := os.ReadFile(repomdPath)
+	if err != nil {
+		t.Fatalf("failed to read repomd.xml: %v", err)
+	}
+	if !containsAll(string(repomdBytes), "repodata/primary.xml.gz", "<checksum>", "<open-checksum>") {
+		t.Errorf("repomd.xml missing expected content: %s", repomdBytes)
+	}
+
+	primaryGzPath := filepath.Join(dir, "repodata", "primary.xml.gz")
+	f, err := os.Open(primaryGzPath)
+	if err != nil {
+		t.Fatalf("failed to open primary.xml.gz: %v", err)
+	}
+	defer f.Close()
+
+	zr, err := gzip.NewReader(f)
+	if err != nil {
+		t.Fatalf("primary.xml.gz is not valid gzip: %v", err)
+	}
+	defer zr.Close()
+
+	primaryBytes, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("failed to decompress primary.xml.gz: %v", err)
+	}
+	primary := string(primaryBytes)
+
+	if !containsAll(primary, "<name>simple</name>", "<arch>i386</arch>", `ver="1.0.1"`, `rel="1"`, "simple-1.0.1-1.i386.rpm") {
+		t.Errorf("primary.xml missing expected package metadata: %s", primary)
+	}
+}
+
+func TestGenerateRPMRepo_NoRPMFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatalf("failed to write notes.txt: %v", err)
+	}
+
+	if err := GenerateRPMRepo(dir); err != nil {
+		t.Fatalf("GenerateRPMRepo failed: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "repodata")); !os.IsNotExist(err) {
+		t.Error("expected no repodata directory when no .rpm files are present")
+	}
+}
+
+func containsAll(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- Addresses -> https://github.com/hauler-dev/hauler/issues/387

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- Added `--generate-repodata` to `hauler store serve fileserver`, which detects any `.rpm`/`.deb` files already present in the fileserver root, reorganizes them into `rpms/` and `debs/` subdirectories, and generates the repository metadata `dnf`/`yum`/`zypper`, and `apt` each expect there
- `hauler store info` now shows types of `rpm` and `deb` for these files (detected from the stored filename), instead of the generic `file` type, and `--type rpm`/`--type deb` filtering works
- New `internal/repodata` package generates real, valid metadata in pure Go, with no shelling out to `createrepo`/`dpkg-scanpackages`: `repodata/primary.xml.gz` + `repomd.xml` for rpm/zypper (via `go-rpmutils`), and `dists/<suite>/main/binary-<arch>/Packages(.gz)` + `Release` for apt (via `pault.ag/go/debian`)
- Added unit tests for both generators, each building a real, valid package file

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- N/A

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A