### PR TITLE
add haul chunk redundancy for automatic recovery

### DIFF
--- a/cmd/hauler/cli/store/save.go
+++ b/cmd/hauler/cli/store/save.go
@@ -144,6 +144,13 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, s *store.Layout, rso *flags
 		return err
 	}
 
+	if o.RedundancyPercent < 0 || o.RedundancyPercent > 100 {
+		return fmt.Errorf("--redundancy-percent must be between 0 and 100, received %d", o.RedundancyPercent)
+	}
+	if o.RedundancyPercent > 0 && o.ChunkSize == "" {
+		return fmt.Errorf("--redundancy-percent requires --chunk-size")
+	}
+
 	if o.ChunkSize != "" {
 		if o.ContainerdCompatibility == true {
 			l.Warnf("compatibility warning... stores split by chunk size must be imported using `hauler store load` to rejoin before import to containerd")
@@ -152,7 +159,13 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, s *store.Layout, rso *flags
 		if err != nil {
 			return err
 		}
-		chunks, err := archives.SplitArchive(ctx, absOutputfile, maxBytes)
+
+		var chunks []string
+		if o.RedundancyPercent > 0 {
+			chunks, err = archives.SplitArchiveRedundant(ctx, absOutputfile, maxBytes, o.RedundancyPercent)
+		} else {
+			chunks, err = archives.SplitArchive(ctx, absOutputfile, maxBytes)
+		}
 		if err != nil {
 			return err
 		}
@@ -176,9 +189,10 @@ func SaveCmd(ctx context.Context, o *flags.SaveOpts, s *store.Layout, rso *flags
 			e.System = &sys
 			e.Global = &g
 			e.Flags = map[string]any{
-				"platform":   o.Platform,
-				"containerd": o.ContainerdCompatibility,
-				"chunk-size": o.ChunkSize,
+				"platform":           o.Platform,
+				"containerd":         o.ContainerdCompatibility,
+				"chunk-size":         o.ChunkSize,
+				"redundancy-percent": o.RedundancyPercent,
 			}
 		}
 		if err := audit.Append(ro.HaulerDir, e); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1
+	github.com/klauspost/reedsolomon v1.14.2
 	github.com/mattn/go-isatty v0.0.24
 	github.com/mholt/archives v0.1.5
 	github.com/mitchellh/go-homedir v1.1.0
@@ -206,6 +207,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.19.2 // indirect
+	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
 	github.com/lann/ps v0.0.0-20150810152359-62de8c46ede0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -618,12 +618,13 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.19.2 h1:hMRETovs/pu/dVWN7zIT1PGG8t509MwT6bO7XSi26R8=
 github.com/klauspost/compress v1.19.2/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
-github.com/klauspost/cpuid v1.2.0 h1:NMpwD2G9JSFOE1/TJjGSo5zG7Yb2bTe7eq1jH+irmeE=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
+github.com/klauspost/reedsolomon v1.14.2 h1:SafJYwpBBQBI6amHUygcjxZjXeN2HpiENHQDwuPWCCQ=
+github.com/klauspost/reedsolomon v1.14.2/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=

--- a/internal/flags/save.go
+++ b/internal/flags/save.go
@@ -11,6 +11,7 @@ type SaveOpts struct {
 	Platform                string
 	ContainerdCompatibility bool
 	ChunkSize               string
+	RedundancyPercent       int
 }
 
 func (o *SaveOpts) AddFlags(cmd *cobra.Command) {
@@ -19,6 +20,7 @@ func (o *SaveOpts) AddFlags(cmd *cobra.Command) {
 	f.StringVarP(&o.FileName, "filename", "f", consts.DefaultHaulerArchiveName, "(Optional) Specify the name of outputted haul")
 	f.StringVarP(&o.Platform, "platform", "p", "", "(Optional) Specify the platform for runtime imports... i.e. linux/amd64 (unspecified implies all)")
 	f.BoolVar(&o.ContainerdCompatibility, "containerd", false, "(Optional) Enable import compatibility with containerd... filters index.json to image content, preserving the full index as a sidecar")
-	f.StringVar(&o.ChunkSize, "chunk-size", "", "(Optional) Split the output archive into chunks of the specified size (e.g. 1G, 500M, 2048M)")
+	f.StringVar(&o.ChunkSize, "chunk-size", "", "(Optional) Split the output archive into chunks of the specified size (i.e. 1G, 500M, 2048M)")
+	f.IntVar(&o.RedundancyPercent, "redundancy-percent", 0, "(EXPERIMENTAL) (Optional) Percentage of recovery data to embed across chunks for byte level redundancy (requires --chunk-size)")
 
 }

--- a/pkg/archives/redundancy.go
+++ b/pkg/archives/redundancy.go
@@ -145,6 +145,9 @@ func SplitArchiveRedundant(ctx context.Context, archivePath string, maxBytes int
 	}
 	parityShards := parityShardCount(dataShards, redundancyPercent)
 	totalShards := dataShards + parityShards
+	if totalShards > 256 {
+		return nil, fmt.Errorf("archive requires %d data and %d parity shards (%d total), which exceeds the 256 shard limit; use a larger --chunk-size or a lower --redundancy-percent", dataShards, parityShards, totalShards)
+	}
 
 	enc, err := reedsolomon.NewStream(dataShards, parityShards)
 	if err != nil {

--- a/pkg/archives/redundancy.go
+++ b/pkg/archives/redundancy.go
@@ -1,0 +1,419 @@
+package archives
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/klauspost/reedsolomon"
+	"hauler.dev/go/hauler/v2/pkg/log"
+)
+
+// redundancyMagic identifies a hauler redundant chunk, distinguishing it from the plain byte-range chunks SplitArchive produces when no redundancy is requested.
+var redundancyMagic = [8]byte{'H', 'A', 'U', 'L', 'R', 'S', 'F', '1'}
+
+const redundancyHeaderSize = 8 + 8 + 2 + 2 + 2 + 8 + 4
+
+// redundancyHeader is prepended to every shard file (data and parity alike) so a shard set can be reconstructed from whichever shards survive, with no separate manifest to lose or desync from the data.
+type redundancyHeader struct {
+	setID        [8]byte
+	dataShards   uint16
+	parityShards uint16
+	shardIndex   uint16
+	originalSize uint64
+	crc32        uint32
+}
+
+func (h redundancyHeader) encode() []byte {
+	buf := make([]byte, redundancyHeaderSize)
+	copy(buf[0:8], redundancyMagic[:])
+	copy(buf[8:16], h.setID[:])
+	binary.BigEndian.PutUint16(buf[16:18], h.dataShards)
+	binary.BigEndian.PutUint16(buf[18:20], h.parityShards)
+	binary.BigEndian.PutUint16(buf[20:22], h.shardIndex)
+	binary.BigEndian.PutUint64(buf[22:30], h.originalSize)
+	binary.BigEndian.PutUint32(buf[30:34], h.crc32)
+	return buf
+}
+
+// decodeRedundancyHeader parses buf as a redundancyHeader, returning ok=false (not an error) when buf doesn't start with the redundancy magic, since that just means the caller is looking at a plain, non-redundant chunk.
+func decodeRedundancyHeader(buf []byte) (h redundancyHeader, ok bool) {
+	if len(buf) < redundancyHeaderSize {
+		return redundancyHeader{}, false
+	}
+	if string(buf[0:8]) != string(redundancyMagic[:]) {
+		return redundancyHeader{}, false
+	}
+	copy(h.setID[:], buf[8:16])
+	h.dataShards = binary.BigEndian.Uint16(buf[16:18])
+	h.parityShards = binary.BigEndian.Uint16(buf[18:20])
+	h.shardIndex = binary.BigEndian.Uint16(buf[20:22])
+	h.originalSize = binary.BigEndian.Uint64(buf[22:30])
+	h.crc32 = binary.BigEndian.Uint32(buf[30:34])
+	return h, true
+}
+
+// readShardHeader reads and decodes just the header of the shard file at path, without reading its (potentially large) payload.
+func readShardHeader(path string) (redundancyHeader, bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return redundancyHeader{}, false, err
+	}
+	defer f.Close()
+
+	buf := make([]byte, redundancyHeaderSize)
+	if _, err := io.ReadFull(f, buf); err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return redundancyHeader{}, false, nil
+		}
+		return redundancyHeader{}, false, err
+	}
+	h, ok := decodeRedundancyHeader(buf)
+	return h, ok, nil
+}
+
+// shardPayloadReader opens path's shard payload, skipping past its header.
+func shardPayloadReader(path string) (*os.File, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := f.Seek(redundancyHeaderSize, io.SeekStart); err != nil {
+		f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+// verifyShardChecksum reports whether the shard payload at path matches h's recorded checksum.
+func verifyShardChecksum(path string, h redundancyHeader) (bool, error) {
+	f, err := shardPayloadReader(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	sum := crc32.NewIEEE()
+	if _, err := io.Copy(sum, f); err != nil {
+		return false, err
+	}
+	return sum.Sum32() == h.crc32, nil
+}
+
+// dataShardCount picks the number of data shards for an archive of archiveSize bytes given maxBytes per shard, capped at 256 (reedsolomon's own limit) and never fewer than 1.
+func dataShardCount(archiveSize, maxBytes int64) (int, error) {
+	if maxBytes <= 0 {
+		return 0, fmt.Errorf("maxBytes must be greater than zero, received %d", maxBytes)
+	}
+	n := (archiveSize + maxBytes - 1) / maxBytes
+	if n < 1 {
+		n = 1
+	}
+	if n > 256 {
+		return 0, fmt.Errorf("archive requires %d shards at %d bytes each, which exceeds the 256 shard limit; use a larger --chunk-size", n, maxBytes)
+	}
+	return int(n), nil
+}
+
+// parityShardCount derives how many parity shards to generate for dataShards at redundancyPercent, always at least 1 once redundancy is requested at all.
+func parityShardCount(dataShards, redundancyPercent int) int {
+	k := (dataShards*redundancyPercent + 99) / 100
+	if k < 1 {
+		k = 1
+	}
+	return k
+}
+
+// SplitArchiveRedundant splits the archive at archivePath, removing it afterward, into data and parity shards of at most maxBytes each such that any dataShards of the resulting chunks can reconstruct it.
+func SplitArchiveRedundant(ctx context.Context, archivePath string, maxBytes int64, redundancyPercent int) ([]string, error) {
+	l := log.FromContext(ctx)
+
+	info, err := os.Stat(archivePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to stat archive for splitting: %w", err)
+	}
+	archiveSize := info.Size()
+
+	dataShards, err := dataShardCount(archiveSize, maxBytes)
+	if err != nil {
+		return nil, err
+	}
+	parityShards := parityShardCount(dataShards, redundancyPercent)
+	totalShards := dataShards + parityShards
+
+	enc, err := reedsolomon.NewStream(dataShards, parityShards)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create redundancy encoder: %w", err)
+	}
+
+	var setID [8]byte
+	if _, err := rand.Read(setID[:]); err != nil {
+		return nil, fmt.Errorf("failed to generate set id: %w", err)
+	}
+
+	tempPaths := make([]string, totalShards)
+	tempFiles := make([]*os.File, totalShards)
+	cleanupTemps := func() {
+		for _, f := range tempFiles {
+			if f != nil {
+				f.Close()
+			}
+		}
+		for _, p := range tempPaths {
+			if p != "" {
+				os.Remove(p)
+			}
+		}
+	}
+	for i := 0; i < totalShards; i++ {
+		p := fmt.Sprintf("%s.redundancy.%03d.tmp", archivePath, i)
+		f, err := os.Create(p)
+		if err != nil {
+			cleanupTemps()
+			return nil, fmt.Errorf("failed to create temporary shard %d: %w", i, err)
+		}
+		tempPaths[i] = p
+		tempFiles[i] = f
+	}
+
+	src, err := os.Open(archivePath)
+	if err != nil {
+		cleanupTemps()
+		return nil, fmt.Errorf("failed to open archive for splitting: %w", err)
+	}
+
+	dataWriters := make([]io.Writer, dataShards)
+	for i := 0; i < dataShards; i++ {
+		dataWriters[i] = tempFiles[i]
+	}
+	splitErr := enc.Split(src, dataWriters, archiveSize)
+	src.Close()
+	if splitErr != nil {
+		cleanupTemps()
+		return nil, fmt.Errorf("failed to split archive into data shards: %w", splitErr)
+	}
+
+	dataReaders := make([]io.Reader, dataShards)
+	for i := 0; i < dataShards; i++ {
+		if _, err := tempFiles[i].Seek(0, io.SeekStart); err != nil {
+			cleanupTemps()
+			return nil, fmt.Errorf("failed to rewind data shard %d: %w", i, err)
+		}
+		dataReaders[i] = tempFiles[i]
+	}
+	parityWriters := make([]io.Writer, parityShards)
+	for i := 0; i < parityShards; i++ {
+		parityWriters[i] = tempFiles[dataShards+i]
+	}
+	if err := enc.Encode(dataReaders, parityWriters); err != nil {
+		cleanupTemps()
+		return nil, fmt.Errorf("failed to generate parity shards: %w", err)
+	}
+
+	for _, f := range tempFiles {
+		f.Close()
+	}
+
+	finalPaths := make([]string, totalShards)
+	for i := 0; i < totalShards; i++ {
+		finalPath := fmt.Sprintf("%s.%03d", archivePath, i+1)
+		if err := writeShardWithHeader(tempPaths[i], finalPath, redundancyHeader{
+			setID:        setID,
+			dataShards:   uint16(dataShards),
+			parityShards: uint16(parityShards),
+			shardIndex:   uint16(i),
+			originalSize: uint64(archiveSize),
+		}); err != nil {
+			cleanupTemps()
+			return nil, fmt.Errorf("failed to finalize shard %d: %w", i, err)
+		}
+		finalPaths[i] = finalPath
+	}
+	cleanupTemps()
+
+	if err := os.Remove(archivePath); err != nil {
+		return nil, fmt.Errorf("failed to remove original archive after splitting: %w", err)
+	}
+
+	l.Infof("split archive [%s] into %d data and %d parity shard(s)", filepath.Base(archivePath), dataShards, parityShards)
+	return finalPaths, nil
+}
+
+// writeShardWithHeader computes payloadPath's checksum, then writes h (with that checksum) followed by the payload to finalPath, removing payloadPath afterward.
+func writeShardWithHeader(payloadPath, finalPath string, h redundancyHeader) error {
+	payload, err := os.Open(payloadPath)
+	if err != nil {
+		return err
+	}
+	sum := crc32.NewIEEE()
+	if _, err := io.Copy(sum, payload); err != nil {
+		payload.Close()
+		return err
+	}
+	h.crc32 = sum.Sum32()
+
+	if _, err := payload.Seek(0, io.SeekStart); err != nil {
+		payload.Close()
+		return err
+	}
+
+	out, err := os.Create(finalPath)
+	if err != nil {
+		payload.Close()
+		return err
+	}
+	if _, err := out.Write(h.encode()); err != nil {
+		payload.Close()
+		out.Close()
+		return err
+	}
+	_, copyErr := io.Copy(out, payload)
+	payload.Close()
+	closeErr := out.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	return os.Remove(payloadPath)
+}
+
+// isRedundantChunkSet peeks at matches (a chunk set already grouped by JoinChunks) and reports the shared header if they're redundant shards rather than plain byte-range chunks.
+func isRedundantChunkSet(matches []string) (redundancyHeader, bool, error) {
+	for _, m := range matches {
+		h, ok, err := readShardHeader(m)
+		if err != nil {
+			return redundancyHeader{}, false, err
+		}
+		if ok {
+			return h, true, nil
+		}
+	}
+	return redundancyHeader{}, false, nil
+}
+
+// reconstructAndJoin reassembles the original archive in tempDir from a chunk set already identified as redundant, transparently repairing any missing or corrupted shards from parity before joining.
+func reconstructAndJoin(ctx context.Context, matches []string, tempDir, joinedName string, header redundancyHeader) (string, error) {
+	l := log.FromContext(ctx)
+
+	total := int(header.dataShards) + int(header.parityShards)
+	present := map[int]string{}
+	for _, m := range matches {
+		h, ok, err := readShardHeader(m)
+		if err != nil {
+			return "", fmt.Errorf("failed to read shard header for [%s]: %w", m, err)
+		}
+		if !ok || h.setID != header.setID {
+			continue
+		}
+		present[int(h.shardIndex)] = m
+	}
+
+	valid := make([]io.Reader, total)
+	var openFiles []*os.File
+	defer func() {
+		for _, f := range openFiles {
+			f.Close()
+		}
+	}()
+
+	var missing []int
+	for i := 0; i < total; i++ {
+		path, ok := present[i]
+		if !ok {
+			missing = append(missing, i)
+			continue
+		}
+		h, _, err := readShardHeader(path)
+		if err != nil {
+			return "", fmt.Errorf("failed to read shard header for [%s]: %w", path, err)
+		}
+		checksumOK, err := verifyShardChecksum(path, h)
+		if err != nil {
+			return "", fmt.Errorf("failed to verify shard [%s]: %w", path, err)
+		}
+		if !checksumOK {
+			l.Warnf("shard [%s] failed checksum verification, treating as damaged", filepath.Base(path))
+			missing = append(missing, i)
+			continue
+		}
+		f, err := shardPayloadReader(path)
+		if err != nil {
+			return "", fmt.Errorf("failed to open shard [%s]: %w", path, err)
+		}
+		openFiles = append(openFiles, f)
+		valid[i] = f
+	}
+
+	enc, err := reedsolomon.NewStream(int(header.dataShards), int(header.parityShards))
+	if err != nil {
+		return "", fmt.Errorf("failed to create redundancy decoder: %w", err)
+	}
+
+	if len(missing) > 0 {
+		if len(missing) > int(header.parityShards) {
+			return "", fmt.Errorf("%d of %d shard(s) are missing or damaged, more than the %d parity shard(s) available to repair with", len(missing), total, header.parityShards)
+		}
+		l.Warnf("repairing %d of %d shard(s) using parity", len(missing), total)
+
+		fill := make([]io.Writer, total)
+		fillFiles := make(map[int]*os.File, len(missing))
+		for _, i := range missing {
+			p := filepath.Join(tempDir, fmt.Sprintf("%s.repaired.%03d.tmp", joinedName, i))
+			f, err := os.Create(p)
+			if err != nil {
+				return "", fmt.Errorf("failed to create repair buffer for shard %d: %w", i, err)
+			}
+			defer f.Close()
+			defer os.Remove(p)
+			fillFiles[i] = f
+			fill[i] = f
+		}
+
+		if err := enc.Reconstruct(valid, fill); err != nil {
+			return "", fmt.Errorf("failed to reconstruct missing shard(s): %w", err)
+		}
+
+		for _, i := range missing {
+			f := fillFiles[i]
+			if _, err := f.Seek(0, io.SeekStart); err != nil {
+				return "", fmt.Errorf("failed to rewind repaired shard %d: %w", i, err)
+			}
+			valid[i] = f
+		}
+
+		// Reconstruct reads every present shard through to EOF, so those readers need rewinding too before Join can read them again.
+		for i, r := range valid {
+			if fillFiles[i] != nil {
+				continue
+			}
+			f, ok := r.(*os.File)
+			if !ok {
+				continue
+			}
+			if _, err := f.Seek(redundancyHeaderSize, io.SeekStart); err != nil {
+				return "", fmt.Errorf("failed to rewind shard %d: %w", i, err)
+			}
+		}
+		l.Infof("successfully repaired %d shard(s) from parity", len(missing))
+	}
+
+	outPath := filepath.Join(tempDir, joinedName)
+	out, err := os.Create(outPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create reassembled archive: %w", err)
+	}
+	defer out.Close()
+
+	if err := enc.Join(out, valid[:header.dataShards], int64(header.originalSize)); err != nil {
+		return "", fmt.Errorf("failed to reassemble archive from shards: %w", err)
+	}
+
+	return outPath, nil
+}

--- a/pkg/archives/redundancy_test.go
+++ b/pkg/archives/redundancy_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -160,6 +161,22 @@ func TestSplitArchiveRedundant_TooManyLosses(t *testing.T) {
 
 	if _, err := JoinChunks(ctx, chunks[tooMany], t.TempDir()); err == nil {
 		t.Fatal("expected an error when losses exceed the parity budget, got nil")
+	}
+}
+
+// TestSplitArchiveRedundant_TotalShardsOverLimit confirms a combined data+parity total over 256 is rejected with a clear error, not the raw reedsolomon one, even when the data shard count alone is within bounds.
+func TestSplitArchiveRedundant_TotalShardsOverLimit(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "haul.tar.zst")
+	newTestArchive(t, archivePath, 200)
+
+	_, err := SplitArchiveRedundant(ctx, archivePath, 1, 50)
+	if err == nil {
+		t.Fatal("expected an error when data+parity shards exceed 256, got nil")
+	}
+	if !strings.Contains(err.Error(), "256 shard limit") {
+		t.Fatalf("expected a clear 256-shard-limit error, got: %v", err)
 	}
 }
 

--- a/pkg/archives/redundancy_test.go
+++ b/pkg/archives/redundancy_test.go
@@ -1,0 +1,185 @@
+package archives
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newTestArchive writes size bytes of pseudo-random content to path and returns that content.
+func newTestArchive(t *testing.T, path string, size int) []byte {
+	t.Helper()
+	data := make([]byte, size)
+	if _, err := rand.Read(data); err != nil {
+		t.Fatalf("failed to generate test data: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("failed to write test archive: %v", err)
+	}
+	return data
+}
+
+func TestSplitArchiveRedundant_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "haul.tar.zst")
+	want := newTestArchive(t, archivePath, 10_000)
+
+	chunks, err := SplitArchiveRedundant(ctx, archivePath, 1_500, 25)
+	if err != nil {
+		t.Fatalf("SplitArchiveRedundant failed: %v", err)
+	}
+	if len(chunks) < 2 {
+		t.Fatalf("expected multiple shards, got %d", len(chunks))
+	}
+
+	joined, err := JoinChunks(ctx, chunks[0], t.TempDir())
+	if err != nil {
+		t.Fatalf("JoinChunks failed: %v", err)
+	}
+	got, err := os.ReadFile(joined)
+	if err != nil {
+		t.Fatalf("failed to read joined archive: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Error("joined archive does not match original content")
+	}
+}
+
+// TestSplitArchiveRedundant_RepairsMissingShards deletes shards up to the parity budget and verifies the archive still reassembles correctly.
+func TestSplitArchiveRedundant_RepairsMissingShards(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "haul.tar.zst")
+	want := newTestArchive(t, archivePath, 10_000)
+
+	chunks, err := SplitArchiveRedundant(ctx, archivePath, 1_500, 25)
+	if err != nil {
+		t.Fatalf("SplitArchiveRedundant failed: %v", err)
+	}
+
+	header, ok, err := isRedundantChunkSet(chunks)
+	if err != nil || !ok {
+		t.Fatalf("expected a redundant chunk set, ok=%v err=%v", ok, err)
+	}
+	parity := int(header.parityShards)
+	if parity < 1 {
+		t.Fatalf("expected at least 1 parity shard, got %d", parity)
+	}
+
+	// delete exactly `parity` shards, the maximum this set can tolerate
+	for i := 0; i < parity; i++ {
+		if err := os.Remove(chunks[i]); err != nil {
+			t.Fatalf("failed to delete shard for test: %v", err)
+		}
+	}
+
+	joined, err := JoinChunks(ctx, chunks[parity], t.TempDir())
+	if err != nil {
+		t.Fatalf("JoinChunks failed to repair from parity: %v", err)
+	}
+	got, err := os.ReadFile(joined)
+	if err != nil {
+		t.Fatalf("failed to read joined archive: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Error("repaired archive does not match original content")
+	}
+}
+
+// TestSplitArchiveRedundant_RepairsCorruptedShards flips bytes in shards (rather than deleting them) and verifies the checksum catches the damage and parity repairs it.
+func TestSplitArchiveRedundant_RepairsCorruptedShards(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "haul.tar.zst")
+	want := newTestArchive(t, archivePath, 10_000)
+
+	chunks, err := SplitArchiveRedundant(ctx, archivePath, 1_500, 25)
+	if err != nil {
+		t.Fatalf("SplitArchiveRedundant failed: %v", err)
+	}
+
+	if _, ok, err := isRedundantChunkSet(chunks); err != nil || !ok {
+		t.Fatalf("expected a redundant chunk set, ok=%v err=%v", ok, err)
+	}
+
+	// corrupt one shard's payload in place, leaving its size and header untouched
+	corrupted := chunks[0]
+	data, err := os.ReadFile(corrupted)
+	if err != nil {
+		t.Fatalf("failed to read shard to corrupt: %v", err)
+	}
+	if len(data) <= redundancyHeaderSize {
+		t.Fatalf("shard [%s] too small to corrupt meaningfully", corrupted)
+	}
+	data[redundancyHeaderSize] ^= 0xFF
+	if err := os.WriteFile(corrupted, data, 0o644); err != nil {
+		t.Fatalf("failed to write corrupted shard: %v", err)
+	}
+
+	joined, err := JoinChunks(ctx, chunks[1], t.TempDir())
+	if err != nil {
+		t.Fatalf("JoinChunks failed to repair corrupted shard: %v", err)
+	}
+	got, err := os.ReadFile(joined)
+	if err != nil {
+		t.Fatalf("failed to read joined archive: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Error("repaired archive does not match original content after corruption")
+	}
+}
+
+// TestSplitArchiveRedundant_TooManyLosses verifies a clear error, not silent corruption, when more shards are missing than parity can cover.
+func TestSplitArchiveRedundant_TooManyLosses(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "haul.tar.zst")
+	newTestArchive(t, archivePath, 10_000)
+
+	chunks, err := SplitArchiveRedundant(ctx, archivePath, 1_500, 25)
+	if err != nil {
+		t.Fatalf("SplitArchiveRedundant failed: %v", err)
+	}
+
+	header, ok, err := isRedundantChunkSet(chunks)
+	if err != nil || !ok {
+		t.Fatalf("expected a redundant chunk set, ok=%v err=%v", ok, err)
+	}
+
+	// delete one more shard than parity can tolerate
+	tooMany := int(header.parityShards) + 1
+	for i := 0; i < tooMany; i++ {
+		if err := os.Remove(chunks[i]); err != nil {
+			t.Fatalf("failed to delete shard for test: %v", err)
+		}
+	}
+
+	if _, err := JoinChunks(ctx, chunks[tooMany], t.TempDir()); err == nil {
+		t.Fatal("expected an error when losses exceed the parity budget, got nil")
+	}
+}
+
+// TestSplitArchiveRedundant_ZeroPercentStillGeneratesOneParityShard confirms a low, non-zero redundancy request still produces at least one parity shard.
+func TestSplitArchiveRedundant_ZeroPercentStillGeneratesOneParityShard(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	archivePath := filepath.Join(dir, "haul.tar.zst")
+	newTestArchive(t, archivePath, 10_000)
+
+	chunks, err := SplitArchiveRedundant(ctx, archivePath, 1_500, 1)
+	if err != nil {
+		t.Fatalf("SplitArchiveRedundant failed: %v", err)
+	}
+
+	header, ok, err := isRedundantChunkSet(chunks)
+	if err != nil || !ok {
+		t.Fatalf("expected a redundant chunk set, ok=%v err=%v", ok, err)
+	}
+	if header.parityShards < 1 {
+		t.Errorf("expected at least 1 parity shard for a non-zero redundancy request, got %d", header.parityShards)
+	}
+}

--- a/pkg/archives/unarchiver.go
+++ b/pkg/archives/unarchiver.go
@@ -249,6 +249,14 @@ func JoinChunks(ctx context.Context, archivePath, tempDir string) (string, error
 			_, idxJ, _ := chunkInfo(matches[j])
 			return idxI < idxJ
 		})
+
+		// A redundant chunk set carries its own header on every shard, so detection and repair happen transparently here regardless of how the caller asked to load the archive.
+		if header, ok, err := isRedundantChunkSet(matches); err != nil {
+			return "", fmt.Errorf("failed to inspect chunk set for redundancy: %w", err)
+		} else if ok {
+			return reconstructAndJoin(ctx, matches, tempDir, filepath.Base(base), header)
+		}
+
 		return joinFiles(ctx, matches, tempDir, filepath.Base(base))
 	}
 


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**
- [X] Commit(s) and code follow the repositories guidelines.
- [X] Test(s) have been added or updated to support these change(s).
- [X] Doc(s) have been added or updated to support these change(s).

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

- N/A

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

- Feature

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

**Why:** `hauler store save --chunk-size ...` splits a haul into sequential byte-range chunks with no redundancy.
- If even one chunk is lost or corrupted during a transfer such as a dropped file, a flaky copy, a network hiccup, the whole haul fails to load, even if every other chunk arrived perfectly fine

**How:** Adds an optional `--redundancy-percent ...` flag to `hauler store save`, which requires `--chunk-size`, and when set chunks are generated using reed solomon parity (https://en.wikipedia.org/wiki/Reed–Solomon_error_correction) via https://github.com/klauspost/reedsolomon
- The `haul` is split into data chunks plus a percentage of additional parity chunks, so any subset of the original data chunk count, mixed data and parity, in any combination, can recover the full `haul`
- Each chunk carries its own small header, with magic bytes, shard indexes, original size, and checksum
- `hauler store load` requires no new flag, it detects a redundant chunk set automatically, verifies each chunk's checksum, and recovers any missing or corrupted chunks from parity before loading the `haul`
- If losses exceed the available parity, `hauler store load` fails with a clear error instead of silently loading it

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- Unit tests covering a clean round trip such as... recovery from deleted chunks, recovery from corrupted chunks, a clear error when losses exceed parity, and a low percentage sanity check
- Live end-to-end test by a `hauler store save --chunk-size 1GB --redundancy-percent 30`, and deleted one chunk and corrupted another, then ran a plain `hauler store load` with no special flags, confirmed automatic recovery, and a byte for byte match against the original `haul`

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- N/A