### PR TITLE
fix: serve registry returns an empty /v2/_catalog list

### DIFF
--- a/cmd/hauler/cli/store/serve.go
+++ b/cmd/hauler/cli/store/serve.go
@@ -18,6 +18,7 @@ import (
 
 	"hauler.dev/go/hauler/v2/internal/flags"
 	"hauler.dev/go/hauler/v2/internal/server"
+	"hauler.dev/go/hauler/v2/pkg/consts"
 	"hauler.dev/go/hauler/v2/pkg/log"
 	"hauler.dev/go/hauler/v2/pkg/store"
 )
@@ -78,6 +79,13 @@ func DefaultRegistryConfig(o *flags.ServeRegistryOpts, rso *flags.StoreRootOpts,
 
 	cfg.Log.Level = configuration.Loglevel(ro.LogLevel)
 	cfg.Validation.Manifests.URLs.Allow = []string{".+"}
+
+	// configuration.Parse applies these defaults when the config comes from
+	// YAML, but they are left as zero-values when the struct is built by
+	// hand, as we do here. A zero Catalog.MaxEntries makes GET /v2/_catalog
+	// always return an empty repository list, so set both explicitly.
+	cfg.Catalog.MaxEntries = consts.DefaultRegistryCatalogMaxEntries
+	cfg.Tags.MaxTags = consts.DefaultRegistryTagsMaxEntries
 
 	return cfg
 }

--- a/cmd/hauler/cli/store/serve_test.go
+++ b/cmd/hauler/cli/store/serve_test.go
@@ -97,6 +97,18 @@ func TestDefaultRegistryConfig(t *testing.T) {
 	if len(cfg.Validation.Manifests.URLs.Allow) == 0 {
 		t.Error("Validation.Manifests.URLs.Allow is empty, want at least one rule")
 	}
+
+	// Catalog/Tags entry caps. configuration.Parse applies these defaults
+	// when a config is loaded from YAML, but a hand-built Configuration (as
+	// produced here) leaves them at the zero value unless set explicitly.
+	// A zero Catalog.MaxEntries makes GET /v2/_catalog always return an
+	// empty repository list, regardless of what's actually stored.
+	if cfg.Catalog.MaxEntries != consts.DefaultRegistryCatalogMaxEntries {
+		t.Errorf("Catalog.MaxEntries = %d, want %d", cfg.Catalog.MaxEntries, consts.DefaultRegistryCatalogMaxEntries)
+	}
+	if cfg.Tags.MaxTags != consts.DefaultRegistryTagsMaxEntries {
+		t.Errorf("Tags.MaxTags = %d, want %d", cfg.Tags.MaxTags, consts.DefaultRegistryTagsMaxEntries)
+	}
 }
 
 func TestDefaultRegistryConfig_WithTLS(t *testing.T) {

--- a/internal/server/registry.go
+++ b/internal/server/registry.go
@@ -14,6 +14,8 @@ import (
 	dockermetrics "github.com/docker/go-metrics"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"hauler.dev/go/hauler/v2/pkg/consts"
 )
 
 func NewRegistry(ctx context.Context, cfg *configuration.Configuration) (*registry.Registry, error) {
@@ -60,6 +62,13 @@ func NewTempRegistry(ctx context.Context, root string) *tmpRegistryServer {
 	}
 
 	cfg.Validation.Manifests.URLs.Allow = []string{".+"}
+
+	// Set these two limits here, not through configuration.Parse. This
+	// Configuration struct is built by hand, so distribution cannot apply
+	// its own default of 1000. Without this line, MaxEntries stays 0, and
+	// GET /v2/_catalog always returns an empty list.
+	cfg.Catalog.MaxEntries = consts.DefaultRegistryCatalogMaxEntries
+	cfg.Tags.MaxTags = consts.DefaultRegistryTagsMaxEntries
 
 	cfg.Log.Level = "error"
 	cfg.HTTP.Headers = http.Header{

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net"
 	"net/http"
@@ -12,6 +13,9 @@ import (
 	"github.com/distribution/distribution/v3/configuration"
 	// Register the filesystem storage driver for the distribution registry.
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/filesystem"
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 
 	"hauler.dev/go/hauler/v2/internal/flags"
 )
@@ -138,5 +142,70 @@ func TestNewFile_DefaultPort(t *testing.T) {
 	}
 	if srv == nil {
 		t.Fatal("expected non-nil server")
+	}
+}
+
+// This test guards against a past bug. NewTempRegistry builds its
+// Configuration struct by hand, so it must set Catalog.MaxEntries itself.
+// Without that line, MaxEntries stays 0. That makes GET /v2/_catalog always
+// return an empty list, no matter how much content the test pushes. It also
+// makes the registry reject any explicit page size (?n=) with
+// PAGINATION_NUMBER_INVALID, because the requested size is always larger
+// than the zero-value limit.
+func TestNewTempRegistry_CatalogListsPushedRepositories(t *testing.T) {
+	ctx := context.Background()
+	srv := NewTempRegistry(ctx, t.TempDir())
+
+	if err := srv.Start(); err != nil {
+		t.Fatalf("failed to start temp registry: %v", err)
+	}
+	t.Cleanup(srv.Stop)
+
+	repo := "library/regression"
+	ref, err := name.NewTag(srv.Registry()+"/"+repo+":latest", name.WithDefaultRegistry(""))
+	if err != nil {
+		t.Fatalf("name.NewTag: %v", err)
+	}
+
+	img, err := random.Image(512, 2)
+	if err != nil {
+		t.Fatalf("random.Image: %v", err)
+	}
+
+	if err := remote.Write(ref, img); err != nil {
+		t.Fatalf("remote.Write: %v", err)
+	}
+
+	for _, path := range []string{"/v2/_catalog", "/v2/_catalog?n=100"} {
+		resp, err := http.Get("http://" + srv.Registry() + path)
+		if err != nil {
+			t.Fatalf("GET %s: %v", path, err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("expected 200 from %s, got %d: %s", path, resp.StatusCode, body)
+		}
+
+		var out struct {
+			Repositories []string `json:"repositories"`
+		}
+		err = json.NewDecoder(resp.Body).Decode(&out)
+		resp.Body.Close()
+		if err != nil {
+			t.Fatalf("decode catalog response from %s: %v", path, err)
+		}
+
+		found := false
+		for _, r := range out.Repositories {
+			if r == repo {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected %q in catalog repositories from %s, got %v", repo, path, out.Repositories)
+		}
 	}
 }

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -138,15 +138,17 @@ const (
 	HaulerIndexFile = "hauler-index.json"
 
 	// other constraints
-	CarbideRegistry           = "rgcrprod.azurecr.us"
-	DefaultNamespace          = "hauler"
-	DefaultTag                = "latest"
-	DefaultRegistry           = ""
-	DefaultStoreName          = "store"
-	DefaultHaulerDirName      = ".hauler"
-	DefaultHaulerTempDirName  = "hauler"
-	DefaultRegistryRootDir    = "registry"
-	DefaultRegistryPort       = 5000
+	CarbideRegistry          = "rgcrprod.azurecr.us"
+	DefaultNamespace         = "hauler"
+	DefaultTag               = "latest"
+	DefaultRegistry          = ""
+	DefaultStoreName         = "store"
+	DefaultHaulerDirName     = ".hauler"
+	DefaultHaulerTempDirName = "hauler"
+	DefaultRegistryRootDir   = "registry"
+	DefaultRegistryPort      = 5000
+	DefaultRegistryCatalogMaxEntries = 1000
+	DefaultRegistryTagsMaxEntries = 1000
 	DefaultFileserverRootDir  = "fileserver"
 	DefaultFileserverPort     = 8080
 	DefaultFileserverTimeout  = 60


### PR DESCRIPTION
**Please check below, if the PR fulfills these requirements:**

- [x] Commit(s) and code follow the repositories guidelines.
- [x] Test(s) have been added or updated to support these change(s).
- [x] Doc(s) have been added or updated to support these change(s).

JFYI, I didn't find any contribution guideline inside of the repo.

<!-- Comments like this will be hidden when you submit, but you can delete them if you wish. -->

**Associated Links:**

<!-- Provide any associated or linked related to these change(s) -->

None

**Types of Changes:**

<!-- What is the type of change? Bugfix, Feature, Breaking Change, etc... -->

Bug: the registry configuration is built by hand, not parsed from YAML. Because of that, distribution does not apply its default of `1000` to `Catalog.MaxEntries`, and the value stays `0`. With a zero limit, `GET /v2/_catalog` always returns an empty list. Any explicit page size (`?n=`) fails with `PAGINATION_NUMBER_INVALID`.

**Proposed Changes:**

<!-- Provide the high level and low level description of your change(s) so we can better understand these change(s) -->

- I've changed the code to set `Catalog.MaxEntries` and `Tags.MaxTags` to the distribution defaults in `DefaultRegistryConfig` and `NewTempRegistry`.

**Verification/Testing of Changes:**

<!-- How can the changes be verified? Provide the steps necessary to reproduce and verify the proposed change(s) -->

- I've add a test that pushes one image and makes sure that both catalog requests list it.

**Additional Context:**

<!-- Provide any additional information, such as if this is a small or large or complex change. Feel free to kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

- The docs haven't been updated since there doesn't seem IMHO the need to do it.
